### PR TITLE
Several list updates and bug fix

### DIFF
--- a/packages/cms/lists/author.ts
+++ b/packages/cms/lists/author.ts
@@ -18,7 +18,7 @@ const listConfigurations = list({
       label: '大頭照',
     }),
     posts: relationship({
-      ref: 'Post.writers',
+      ref: 'Post.authors',
       many: true,
       label: '文章',
     }),

--- a/packages/cms/lists/photo.ts
+++ b/packages/cms/lists/photo.ts
@@ -1,6 +1,12 @@
 import config from '../config'
 import { list, graphql } from '@keystone-6/core'
-import { image, text, virtual, timestamp } from '@keystone-6/core/fields'
+import {
+  image,
+  text,
+  virtual,
+  timestamp,
+  relationship,
+} from '@keystone-6/core/fields'
 
 const listConfigurations = list({
   fields: {
@@ -10,6 +16,11 @@ const listConfigurations = list({
     }),
     imageFile: image({
       storage: 'images',
+    }),
+    authors: relationship({
+      label: '作者',
+      ref: 'Author',
+      many: true,
     }),
     createdAt: timestamp({
       defaultValue: { kind: 'now' },

--- a/packages/cms/lists/post.ts
+++ b/packages/cms/lists/post.ts
@@ -1,12 +1,10 @@
 import {
   customFields,
-  utils,
   richTextEditorButtonNames,
 } from '@kids-reporter/cms-core'
 import { graphql, list } from '@keystone-6/core'
 import {
   virtual,
-  integer,
   relationship,
   timestamp,
   text,
@@ -52,7 +50,7 @@ const listConfigurations = list({
         hideCreate: true,
       },
     }),
-    writers: relationship({
+    authors: relationship({
       ref: 'Author.posts',
       many: true,
       label: '作者',
@@ -60,54 +58,6 @@ const listConfigurations = list({
         hideCreate: true,
       },
     }),
-    photographers: relationship({
-      many: true,
-      label: '攝影',
-      ref: 'Author',
-      ui: {
-        hideCreate: true,
-      },
-    }),
-    editors: relationship({
-      label: '責任編輯',
-      many: true,
-      ref: 'Author',
-      ui: {
-        hideCreate: true,
-      },
-    }),
-    designers: relationship({
-      label: '設計',
-      many: true,
-      ref: 'Author',
-      ui: {
-        hideCreate: true,
-      },
-    }),
-    engineers: relationship({
-      many: true,
-      label: '工程',
-      ref: 'Author',
-      ui: {
-        hideCreate: true,
-      },
-    }),
-    reviewers: relationship({
-      many: true,
-      label: '核稿',
-      ref: 'Author',
-      ui: {
-        hideCreate: true,
-      },
-    }),
-    otherByline: text({
-      validation: { isRequired: false },
-      label: '作者（其他）',
-    }),
-    //heroVideo: relationship({
-    //  label: 'Leading Video',
-    //  ref: 'Video',
-    //}),
     heroImage: relationship({
       label: '首圖',
       ref: 'Photo',
@@ -115,15 +65,6 @@ const listConfigurations = list({
     heroCaption: text({
       label: '首圖圖說',
       validation: { isRequired: false },
-    }),
-    heroImageSize: select({
-      label: '首圖尺寸',
-      options: [
-        { label: 'extend', value: 'extend' },
-        { label: 'normal', value: 'normal' },
-        { label: 'small', value: 'small' },
-      ],
-      defaultValue: 'normal',
     }),
     brief: customFields.richTextEditor({
       label: '前言',
@@ -161,9 +102,6 @@ const listConfigurations = list({
       ref: 'Tag.posts',
       many: true,
       label: '標籤',
-    }),
-    readingTime: integer({
-      label: '閱讀時間',
     }),
     relatedPosts: relationship({
       ref: 'Post',
@@ -231,50 +169,4 @@ const listConfigurations = list({
   },
   hooks: {},
 })
-export default utils.addManualOrderRelationshipFields(
-  [
-    {
-      fieldName: 'manualOrderOfWriters',
-      targetFieldName: 'writers',
-      targetListName: 'Author',
-      targetListLabelField: 'name',
-    },
-    {
-      fieldName: 'manualOrderOfPhotographers',
-      targetFieldName: 'photographers',
-      targetListName: 'Author',
-      targetListLabelField: 'name',
-    },
-    {
-      fieldName: 'manualOrderOfDesigners',
-      targetFieldName: 'designers',
-      targetListName: 'Author',
-      targetListLabelField: 'name',
-    },
-    {
-      fieldName: 'manualOrderOfEngineers',
-      targetFieldName: 'engineers',
-      targetListName: 'Author',
-      targetListLabelField: 'name',
-    },
-    {
-      fieldName: 'manualOrderOfReviewers',
-      targetFieldName: 'reviewers',
-      targetListName: 'Author',
-      targetListLabelField: 'name',
-    },
-    {
-      fieldName: 'manualOrderOfEditors',
-      targetFieldName: 'editors',
-      targetListName: 'Author',
-      targetListLabelField: 'name',
-    },
-    {
-      fieldName: 'manualOrderOfRelatedPosts',
-      targetFieldName: 'relatedPosts',
-      targetListName: 'Post',
-      targetListLabelField: 'name',
-    },
-  ],
-  listConfigurations
-)
+export default listConfigurations

--- a/packages/cms/lists/post.ts
+++ b/packages/cms/lists/post.ts
@@ -4,6 +4,7 @@ import {
 } from '@kids-reporter/cms-core'
 import { graphql, list } from '@keystone-6/core'
 import {
+  json,
   virtual,
   relationship,
   timestamp,
@@ -57,6 +58,10 @@ const listConfigurations = list({
       ui: {
         hideCreate: true,
       },
+    }),
+    authorsJSON: json({
+      label: '作者列',
+      defaultValue: [],
     }),
     heroImage: relationship({
       label: '首圖',
@@ -167,6 +172,111 @@ const listConfigurations = list({
       delete: () => true,
     },
   },
-  hooks: {},
+  hooks: {
+    resolveInput: async ({ inputData, item, resolvedData, context }) => {
+      let authorsJSON: AuthorsJSON =
+        inputData?.authorsJSON || item?.authorsJSON || []
+      authorsJSON = resolveAuthorsJSON(authorsJSON)
+
+      // `authors` is a relationship field.
+      // Therefore, `authors` only store author id
+      const relationshipAuthors: RelationshipInput = inputData?.authors
+      if (relationshipAuthors) {
+        const disconnect = relationshipAuthors?.disconnect
+        // delete disconnected authors from `authorsJSON`
+        if (Array.isArray(disconnect) && disconnect.length > 0) {
+          disconnect.forEach(({ id }) => {
+            authorsJSON = authorsJSON.filter((item) => {
+              // if `item.id` is not existed,
+              // which means it is manually added by users,
+              // and then we don't filter this item out.
+              if (!item.id) {
+                return true
+              }
+              // filter out disconnected item
+              return item.id !== id
+            })
+          })
+        }
+
+        // add new connected authors into `authorsJSON`
+        const connect = relationshipAuthors?.connect
+        if (Array.isArray(connect) && connect.length > 0) {
+          const ids = connect.map(({ id }) => id)
+          // find author items via gql query
+          const items = await context.query.Author.findMany({
+            where: { id: { in: ids } },
+            query: 'id name',
+          })
+          items.forEach((item) => {
+            authorsJSON.push({
+              id: item.id,
+              name: item.name,
+              type: 'link',
+              role: heuristicallyPickRole(item.name),
+            })
+          })
+        }
+      }
+
+      resolvedData.authorsJSON = authorsJSON
+      return resolvedData
+    },
+  },
 })
+
+/**
+ * This function is used to resolve field `authorsJSON`.
+ * It filters out invalid data and
+ * adds missing properties, such as `type`.
+ */
+function resolveAuthorsJSON(authorsJSON: AuthorsJSON): AuthorsJSON {
+  return authorsJSON
+    .filter(
+      (item) =>
+        typeof item === 'object' &&
+        typeof item.name === 'string' &&
+        typeof item.role === 'string'
+    )
+    .map((item) => {
+      if (item.id) {
+        item.type = 'link'
+      } else {
+        item.type = 'string'
+      }
+      return item
+    })
+}
+
+function heuristicallyPickRole(authorName: string): string {
+  switch (authorName) {
+    case '陳韻如': {
+      return '責任編輯'
+    }
+    case '楊惠君': {
+      return '核稿'
+    }
+    case '黃禹禛':
+    case '鄭涵文': {
+      return '設計'
+    }
+    default:
+      return '文字'
+  }
+}
+
+type AuthorsJSON = {
+  id?: string
+  name: string
+  type?: 'link' | 'string'
+  role: string
+}[]
+
+type RelationshipInput =
+  | {
+      disconnect?: { id: string }[]
+      connect?: { id: string }[]
+    }
+  | undefined
+
 export default listConfigurations

--- a/packages/cms/migrations/20230815083019_update_authors_of_post_and_photo_list/migration.sql
+++ b/packages/cms/migrations/20230815083019_update_authors_of_post_and_photo_list/migration.sql
@@ -1,0 +1,95 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `heroImageSize` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `manualOrderOfDesigners` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `manualOrderOfEditors` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `manualOrderOfEngineers` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `manualOrderOfPhotographers` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `manualOrderOfRelatedPosts` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `manualOrderOfReviewers` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `manualOrderOfWriters` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `otherByline` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `readingTime` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the `_Post_designers` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `_Post_editors` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `_Post_engineers` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `_Post_photographers` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `_Post_reviewers` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "_Post_designers" DROP CONSTRAINT "_Post_designers_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_Post_designers" DROP CONSTRAINT "_Post_designers_B_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_Post_editors" DROP CONSTRAINT "_Post_editors_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_Post_editors" DROP CONSTRAINT "_Post_editors_B_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_Post_engineers" DROP CONSTRAINT "_Post_engineers_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_Post_engineers" DROP CONSTRAINT "_Post_engineers_B_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_Post_photographers" DROP CONSTRAINT "_Post_photographers_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_Post_photographers" DROP CONSTRAINT "_Post_photographers_B_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_Post_reviewers" DROP CONSTRAINT "_Post_reviewers_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_Post_reviewers" DROP CONSTRAINT "_Post_reviewers_B_fkey";
+
+-- AlterTable
+ALTER TABLE "Post" DROP COLUMN "heroImageSize",
+DROP COLUMN "manualOrderOfDesigners",
+DROP COLUMN "manualOrderOfEditors",
+DROP COLUMN "manualOrderOfEngineers",
+DROP COLUMN "manualOrderOfPhotographers",
+DROP COLUMN "manualOrderOfRelatedPosts",
+DROP COLUMN "manualOrderOfReviewers",
+DROP COLUMN "manualOrderOfWriters",
+DROP COLUMN "otherByline",
+DROP COLUMN "readingTime",
+ADD COLUMN     "authorsJSON" JSONB DEFAULT '[]';
+
+-- DropTable
+DROP TABLE "_Post_designers";
+
+-- DropTable
+DROP TABLE "_Post_editors";
+
+-- DropTable
+DROP TABLE "_Post_engineers";
+
+-- DropTable
+DROP TABLE "_Post_photographers";
+
+-- DropTable
+DROP TABLE "_Post_reviewers";
+
+-- CreateTable
+CREATE TABLE "_Photo_authors" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_Photo_authors_AB_unique" ON "_Photo_authors"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_Photo_authors_B_index" ON "_Photo_authors"("B");
+
+-- AddForeignKey
+ALTER TABLE "_Photo_authors" ADD CONSTRAINT "_Photo_authors_A_fkey" FOREIGN KEY ("A") REFERENCES "Author"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_Photo_authors" ADD CONSTRAINT "_Photo_authors_B_fkey" FOREIGN KEY ("B") REFERENCES "Photo"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/cms/schema.graphql
+++ b/packages/cms/schema.graphql
@@ -146,29 +146,17 @@ type Post {
   publishedDate: DateTime
   subSubcategories(where: SubSubcategoryWhereInput! = {}, orderBy: [SubSubcategoryOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: SubSubcategoryWhereUniqueInput): [SubSubcategory!]
   subSubcategoriesCount(where: SubSubcategoryWhereInput! = {}): Int
-  writers(where: AuthorWhereInput! = {}, orderBy: [AuthorOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AuthorWhereUniqueInput): [Author!]
-  writersCount(where: AuthorWhereInput! = {}): Int
-  photographers(where: AuthorWhereInput! = {}, orderBy: [AuthorOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AuthorWhereUniqueInput): [Author!]
-  photographersCount(where: AuthorWhereInput! = {}): Int
-  editors(where: AuthorWhereInput! = {}, orderBy: [AuthorOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AuthorWhereUniqueInput): [Author!]
-  editorsCount(where: AuthorWhereInput! = {}): Int
-  designers(where: AuthorWhereInput! = {}, orderBy: [AuthorOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AuthorWhereUniqueInput): [Author!]
-  designersCount(where: AuthorWhereInput! = {}): Int
-  engineers(where: AuthorWhereInput! = {}, orderBy: [AuthorOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AuthorWhereUniqueInput): [Author!]
-  engineersCount(where: AuthorWhereInput! = {}): Int
-  reviewers(where: AuthorWhereInput! = {}, orderBy: [AuthorOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AuthorWhereUniqueInput): [Author!]
-  reviewersCount(where: AuthorWhereInput! = {}): Int
-  otherByline: String
+  authors(where: AuthorWhereInput! = {}, orderBy: [AuthorOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AuthorWhereUniqueInput): [Author!]
+  authorsCount(where: AuthorWhereInput! = {}): Int
+  authorsJSON: JSON
   heroImage: Photo
   heroCaption: String
-  heroImageSize: String
   brief: JSON
   content: JSON
   projects(where: ProjectWhereInput! = {}, orderBy: [ProjectOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ProjectWhereUniqueInput): [Project!]
   projectsCount(where: ProjectWhereInput! = {}): Int
   tags(where: TagWhereInput! = {}, orderBy: [TagOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TagWhereUniqueInput): [Tag!]
   tagsCount(where: TagWhereInput! = {}): Int
-  readingTime: Int
   relatedPosts(where: PostWhereInput! = {}, orderBy: [PostOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PostWhereUniqueInput): [Post!]
   relatedPostsCount(where: PostWhereInput! = {}): Int
   ogTitle: String
@@ -177,20 +165,6 @@ type Post {
   createdAt: DateTime
   updatedAt: DateTime
   preview: JSON
-  manualOrderOfWriters: JSON
-  writersInInputOrder: [Author]
-  manualOrderOfPhotographers: JSON
-  photographersInInputOrder: [Author]
-  manualOrderOfDesigners: JSON
-  designersInInputOrder: [Author]
-  manualOrderOfEngineers: JSON
-  engineersInInputOrder: [Author]
-  manualOrderOfReviewers: JSON
-  reviewersInInputOrder: [Author]
-  manualOrderOfEditors: JSON
-  editorsInInputOrder: [Author]
-  manualOrderOfRelatedPosts: JSON
-  relatedPostsInInputOrder: [Post]
 }
 
 input PostWhereUniqueInput {
@@ -209,19 +183,11 @@ input PostWhereInput {
   status: StringNullableFilter
   publishedDate: DateTimeNullableFilter
   subSubcategories: SubSubcategoryManyRelationFilter
-  writers: AuthorManyRelationFilter
-  photographers: AuthorManyRelationFilter
-  editors: AuthorManyRelationFilter
-  designers: AuthorManyRelationFilter
-  engineers: AuthorManyRelationFilter
-  reviewers: AuthorManyRelationFilter
-  otherByline: StringFilter
+  authors: AuthorManyRelationFilter
   heroImage: PhotoWhereInput
   heroCaption: StringFilter
-  heroImageSize: StringNullableFilter
   projects: ProjectManyRelationFilter
   tags: TagManyRelationFilter
-  readingTime: IntNullableFilter
   relatedPosts: PostManyRelationFilter
   ogTitle: StringFilter
   ogDescription: StringFilter
@@ -283,17 +249,6 @@ input TagManyRelationFilter {
   none: TagWhereInput
 }
 
-input IntNullableFilter {
-  equals: Int
-  in: [Int!]
-  notIn: [Int!]
-  lt: Int
-  lte: Int
-  gt: Int
-  gte: Int
-  not: IntNullableFilter
-}
-
 input PostManyRelationFilter {
   every: PostWhereInput
   some: PostWhereInput
@@ -307,10 +262,7 @@ input PostOrderByInput {
   subtitle: OrderDirection
   status: OrderDirection
   publishedDate: OrderDirection
-  otherByline: OrderDirection
   heroCaption: OrderDirection
-  heroImageSize: OrderDirection
-  readingTime: OrderDirection
   ogTitle: OrderDirection
   ogDescription: OrderDirection
   createdAt: OrderDirection
@@ -324,34 +276,20 @@ input PostUpdateInput {
   status: String
   publishedDate: DateTime
   subSubcategories: SubSubcategoryRelateToManyForUpdateInput
-  writers: AuthorRelateToManyForUpdateInput
-  photographers: AuthorRelateToManyForUpdateInput
-  editors: AuthorRelateToManyForUpdateInput
-  designers: AuthorRelateToManyForUpdateInput
-  engineers: AuthorRelateToManyForUpdateInput
-  reviewers: AuthorRelateToManyForUpdateInput
-  otherByline: String
+  authors: AuthorRelateToManyForUpdateInput
+  authorsJSON: JSON
   heroImage: PhotoRelateToOneForUpdateInput
   heroCaption: String
-  heroImageSize: String
   brief: JSON
   content: JSON
   projects: ProjectRelateToManyForUpdateInput
   tags: TagRelateToManyForUpdateInput
-  readingTime: Int
   relatedPosts: PostRelateToManyForUpdateInput
   ogTitle: String
   ogDescription: String
   ogImage: PhotoRelateToOneForUpdateInput
   createdAt: DateTime
   updatedAt: DateTime
-  manualOrderOfWriters: JSON
-  manualOrderOfPhotographers: JSON
-  manualOrderOfDesigners: JSON
-  manualOrderOfEngineers: JSON
-  manualOrderOfReviewers: JSON
-  manualOrderOfEditors: JSON
-  manualOrderOfRelatedPosts: JSON
 }
 
 input SubSubcategoryRelateToManyForUpdateInput {
@@ -407,34 +345,20 @@ input PostCreateInput {
   status: String
   publishedDate: DateTime
   subSubcategories: SubSubcategoryRelateToManyForCreateInput
-  writers: AuthorRelateToManyForCreateInput
-  photographers: AuthorRelateToManyForCreateInput
-  editors: AuthorRelateToManyForCreateInput
-  designers: AuthorRelateToManyForCreateInput
-  engineers: AuthorRelateToManyForCreateInput
-  reviewers: AuthorRelateToManyForCreateInput
-  otherByline: String
+  authors: AuthorRelateToManyForCreateInput
+  authorsJSON: JSON
   heroImage: PhotoRelateToOneForCreateInput
   heroCaption: String
-  heroImageSize: String
   brief: JSON
   content: JSON
   projects: ProjectRelateToManyForCreateInput
   tags: TagRelateToManyForCreateInput
-  readingTime: Int
   relatedPosts: PostRelateToManyForCreateInput
   ogTitle: String
   ogDescription: String
   ogImage: PhotoRelateToOneForCreateInput
   createdAt: DateTime
   updatedAt: DateTime
-  manualOrderOfWriters: JSON
-  manualOrderOfPhotographers: JSON
-  manualOrderOfDesigners: JSON
-  manualOrderOfEngineers: JSON
-  manualOrderOfReviewers: JSON
-  manualOrderOfEditors: JSON
-  manualOrderOfRelatedPosts: JSON
 }
 
 input SubSubcategoryRelateToManyForCreateInput {
@@ -471,6 +395,8 @@ type Photo {
   id: ID!
   name: String
   imageFile: ImageFieldOutput
+  authors(where: AuthorWhereInput! = {}, orderBy: [AuthorOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AuthorWhereUniqueInput): [Author!]
+  authorsCount(where: AuthorWhereInput! = {}): Int
   createdAt: DateTime
   updatedAt: DateTime
   resized: ResizedImages
@@ -510,6 +436,7 @@ input PhotoWhereInput {
   NOT: [PhotoWhereInput!]
   id: IDFilter
   name: StringFilter
+  authors: AuthorManyRelationFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
 }
@@ -524,6 +451,7 @@ input PhotoOrderByInput {
 input PhotoUpdateInput {
   name: String
   imageFile: ImageFieldInput
+  authors: AuthorRelateToManyForUpdateInput
   createdAt: DateTime
   updatedAt: DateTime
 }
@@ -543,6 +471,7 @@ input PhotoUpdateArgs {
 input PhotoCreateInput {
   name: String
   imageFile: ImageFieldInput
+  authors: AuthorRelateToManyForCreateInput
   createdAt: DateTime
   updatedAt: DateTime
 }

--- a/packages/cms/schema.prisma
+++ b/packages/cms/schema.prisma
@@ -23,44 +23,30 @@ model User {
 }
 
 model Post {
-  id                         Int              @id @default(autoincrement())
-  slug                       String           @unique @default("")
-  name                       String           @default("")
-  subtitle                   String           @default("")
-  status                     String?          @default("draft")
-  publishedDate              DateTime?
-  subSubcategories           SubSubcategory[] @relation("Post_subSubcategories")
-  writers                    Author[]         @relation("Author_posts")
-  photographers              Author[]         @relation("Post_photographers")
-  editors                    Author[]         @relation("Post_editors")
-  designers                  Author[]         @relation("Post_designers")
-  engineers                  Author[]         @relation("Post_engineers")
-  reviewers                  Author[]         @relation("Post_reviewers")
-  otherByline                String           @default("")
-  heroImage                  Photo?           @relation("Post_heroImage", fields: [heroImageId], references: [id])
-  heroImageId                Int?             @map("heroImage")
-  heroCaption                String           @default("")
-  heroImageSize              String?          @default("normal")
-  brief                      Json?
-  content                    Json?
-  projects                   Project[]        @relation("Post_projects")
-  tags                       Tag[]            @relation("Post_tags")
-  readingTime                Int?
-  relatedPosts               Post[]           @relation("Post_relatedPosts")
-  ogTitle                    String           @default("")
-  ogDescription              String           @default("")
-  ogImage                    Photo?           @relation("Post_ogImage", fields: [ogImageId], references: [id])
-  ogImageId                  Int?             @map("ogImage")
-  createdAt                  DateTime?        @default(now())
-  updatedAt                  DateTime?        @updatedAt
-  manualOrderOfWriters       Json?
-  manualOrderOfPhotographers Json?
-  manualOrderOfDesigners     Json?
-  manualOrderOfEngineers     Json?
-  manualOrderOfReviewers     Json?
-  manualOrderOfEditors       Json?
-  manualOrderOfRelatedPosts  Json?
-  from_Post_relatedPosts     Post[]           @relation("Post_relatedPosts")
+  id                     Int              @id @default(autoincrement())
+  slug                   String           @unique @default("")
+  name                   String           @default("")
+  subtitle               String           @default("")
+  status                 String?          @default("draft")
+  publishedDate          DateTime?
+  subSubcategories       SubSubcategory[] @relation("Post_subSubcategories")
+  authors                Author[]         @relation("Author_posts")
+  authorsJSON            Json?            @default("[]")
+  heroImage              Photo?           @relation("Post_heroImage", fields: [heroImageId], references: [id])
+  heroImageId            Int?             @map("heroImage")
+  heroCaption            String           @default("")
+  brief                  Json?
+  content                Json?
+  projects               Project[]        @relation("Post_projects")
+  tags                   Tag[]            @relation("Post_tags")
+  relatedPosts           Post[]           @relation("Post_relatedPosts")
+  ogTitle                String           @default("")
+  ogDescription          String           @default("")
+  ogImage                Photo?           @relation("Post_ogImage", fields: [ogImageId], references: [id])
+  ogImageId              Int?             @map("ogImage")
+  createdAt              DateTime?        @default(now())
+  updatedAt              DateTime?        @updatedAt
+  from_Post_relatedPosts Post[]           @relation("Post_relatedPosts")
 
   @@index([status])
   @@index([publishedDate])
@@ -76,6 +62,7 @@ model Photo {
   imageFile_width         Int?
   imageFile_height        Int?
   imageFile_id            String?
+  authors                 Author[]   @relation("Photo_authors")
   createdAt               DateTime?  @default(now())
   updatedAt               DateTime?  @updatedAt
   from_Post_heroImage     Post[]     @relation("Post_heroImage")
@@ -89,20 +76,16 @@ model Photo {
 }
 
 model Author {
-  id                      Int       @id @default(autoincrement())
-  name                    String    @default("")
-  email                   String    @default("")
-  bio                     String    @default("")
-  avatar                  Photo?    @relation("Author_avatar", fields: [avatarId], references: [id])
-  avatarId                Int?      @map("avatar")
-  posts                   Post[]    @relation("Author_posts")
-  createdAt               DateTime? @default(now())
-  updatedAt               DateTime? @updatedAt
-  from_Post_photographers Post[]    @relation("Post_photographers")
-  from_Post_editors       Post[]    @relation("Post_editors")
-  from_Post_designers     Post[]    @relation("Post_designers")
-  from_Post_engineers     Post[]    @relation("Post_engineers")
-  from_Post_reviewers     Post[]    @relation("Post_reviewers")
+  id                 Int       @id @default(autoincrement())
+  name               String    @default("")
+  email              String    @default("")
+  bio                String    @default("")
+  avatar             Photo?    @relation("Author_avatar", fields: [avatarId], references: [id])
+  avatarId           Int?      @map("avatar")
+  posts              Post[]    @relation("Author_posts")
+  createdAt          DateTime? @default(now())
+  updatedAt          DateTime? @updatedAt
+  from_Photo_authors Photo[]   @relation("Photo_authors")
 
   @@index([name])
   @@index([avatarId])

--- a/packages/draft-editor/src/buttons/image.tsx
+++ b/packages/draft-editor/src/buttons/image.tsx
@@ -56,7 +56,7 @@ export function ImageButton(props: {
         <ImageSelector
           onChange={onImageSelectorChange}
           enableCaption={true}
-          enableUrl={true}
+          enableUrl={false}
           enableAlignment={true}
         />
       )}

--- a/packages/draft-editor/src/buttons/slideshow.tsx
+++ b/packages/draft-editor/src/buttons/slideshow.tsx
@@ -67,7 +67,7 @@ export function SlideshowButton(props: {
         <ImageSelector
           onChange={onImageSelectorChange}
           enableCaption={true}
-          enableDelay={true}
+          enableDelay={false}
           enableMultiSelect={true}
         />
       )}

--- a/packages/draft-renderer/src/block-renderers/embedded-code-block.tsx
+++ b/packages/draft-renderer/src/block-renderers/embedded-code-block.tsx
@@ -17,9 +17,9 @@ export const Block = styled.div`
 `
 
 export const Caption = styled.div`
+  font-size: 14px;
   line-height: 1.43;
   letter-spacing: 0.4px;
-  ${({ theme }) => theme.fontSize.xs};
   color: #808080;
   padding: 15px 15px 0 15px;
 `


### PR DESCRIPTION
### Notable Changes
#### 更新 Post list：
1. 將`writers`、`reviewers`、`editors` 等等欄位合併成 `authors` 欄位。
2. 新增 `authorsJSON` 欄位。
3. 更新 Post list：新增 `resolveInput` hook，透過此 hook 調整 `authorsJSON` 的內容。

#### 更新 Photo list：
1. 新增 `authors` 欄位。

#### 實作細節
因為合併 `writers`、`reviewers`、`editors` 等多個欄位成為 `authors` 欄位後，編輯會無法知道每個 author 在當篇文章中的角色，所以新增 `authorsJSON` 欄位（`json` type），讓編輯能夠更新該欄位，儲存每個 author 在該篇文章的角色。

`authorsJSON` 範例：
```
[
  {
    "id": "1", // id 代表該作者在 Author list 裡 item 的編號
    "name": "陳韻如",
    "role": "責任編輯",
    "type": "link" // `link` 表示該筆在前端(@kids-reporter/frontend) 要用連結的方式呈現
  },
  {
    "name": "陳韻如",
    "role": "責任編輯",
    "type": "string" // 當 `id` 不存在時，`type` 會是 `string`。代表在前端用純文字呈現
  }
]
```