### PR TITLE
fix(frontend): hydration error and prevent rendering `draft-js` on server side

### DIFF
--- a/packages/frontend/src/app/article/[slug]/brief.tsx
+++ b/packages/frontend/src/app/article/[slug]/brief.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { useEffect, useState } from 'react'
 import { ArticleIntroductionDraftRenderer } from '@kids-reporter/draft-renderer'
 import { RawDraftContentState } from 'draft-js'
 import { Theme } from '@/app/constants'
@@ -66,8 +67,16 @@ type BriefProp = {
 export const Brief = (props: BriefProp) => {
   const content = props?.content
   const authors = props?.authors
+  const [isMounted, setIsMounted] = useState(false)
+
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
+
+  // TODO: render skeleton
   return (
-    content && (
+    content &&
+    isMounted && (
       <div className="post-intro">
         <ArticleIntroductionDraftRenderer
           rawContentState={content}

--- a/packages/frontend/src/app/article/[slug]/post-renderer.tsx
+++ b/packages/frontend/src/app/article/[slug]/post-renderer.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { useEffect, useState } from 'react'
 import { ArticleBodyDraftRenderer } from '@kids-reporter/draft-renderer'
 import { Theme } from '@/app/constants'
 
@@ -8,7 +9,14 @@ type PostProp = {
 }
 
 export const PostRenderer = (props: PostProp) => {
+  const [isMounted, setIsMounted] = useState(false)
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
+
+  // TODO: render skeleton
   return (
+    isMounted &&
     props?.post?.content &&
     props?.theme && (
       <ArticleBodyDraftRenderer


### PR DESCRIPTION
### Bug Description
看[文件](https://nextjs.org/docs/getting-started/react-essentials#client-components)說明，就算我們加了 `'use client'`，next 在 server side 還是會 render `PostRenderer` 和 `Brief`。
所以我改用 `useEffect` 去 skip server side render。


### TODO
因為 server side 不會 render 前言和內文，所以畫面會有跳動的問題。
會需要請設計出一個 skeleton，避免畫面跳來跳去。