### PR TITLE
fix(de): cursor jump to the first block unintentionally

### DIFF
--- a/packages/draft-editor/src/buttons/annotation.tsx
+++ b/packages/draft-editor/src/buttons/annotation.tsx
@@ -28,6 +28,8 @@ type AnnotationButtonProps = {
   isActive: boolean
   editorState: EditorState
   onChange: (arg0: EditorState) => void
+  onEditStart: () => void
+  onEditFinish: () => void
 }
 
 export function createAnnotationButton({
@@ -37,12 +39,7 @@ export function createAnnotationButton({
   InnerEditor: React.ComponentType<RichTextEditorProps>
   decorator: DraftDecoratorType
 }): React.FC<AnnotationButtonProps> {
-  return function AnnotationButton(props: {
-    className?: string
-    isActive: boolean
-    editorState: EditorState
-    onChange: (arg0: EditorState) => void
-  }) {
+  return function AnnotationButton(props) {
     const toggleEntity = RichUtils.toggleLink
     const { isActive, editorState: editorStateOfOuterEditor, onChange } = props
     const [toShowInput, setToShowInput] = useState(false)
@@ -52,6 +49,7 @@ export function createAnnotationButton({
 
     const promptForAnnotation = (e: React.MouseEvent<HTMLDivElement>) => {
       e.preventDefault()
+      props.onEditStart()
       const selection = editorStateOfOuterEditor.getSelection()
       if (!selection.isCollapsed()) {
         setToShowInput(true)
@@ -83,6 +81,7 @@ export function createAnnotationButton({
       setInputValue({
         editorStateOfInnerEditor: EditorState.createEmpty(decorator),
       })
+      props.onEditFinish()
     }
 
     const removeAnnotation = () => {
@@ -94,6 +93,7 @@ export function createAnnotationButton({
       setInputValue({
         editorStateOfInnerEditor: EditorState.createEmpty(decorator),
       })
+      props.onEditFinish()
     }
 
     const input = (

--- a/packages/draft-editor/src/buttons/link.tsx
+++ b/packages/draft-editor/src/buttons/link.tsx
@@ -11,14 +11,22 @@ const styles = {
   },
 }
 
-export function LinkButton(props) {
+export function LinkButton(props: {
+  className?: string
+  isActive: boolean
+  editorState: EditorState
+  onChange: (arg0: EditorState) => void
+  onEditStart: () => void
+  onEditFinish: () => void
+}) {
   const { isActive, editorState, onChange } = props
 
   const [toShowUrlInput, setToShowUrlInput] = useState(false)
   const [urlValue, setUrlValue] = useState('')
 
-  const promptForLink = (e) => {
+  const promptForLink = (e: React.MouseEvent<HTMLDivElement>) => {
     e.preventDefault()
+    props.onEditStart()
     const selection = editorState.getSelection()
     if (!selection.isCollapsed()) {
       setToShowUrlInput(true)
@@ -46,6 +54,7 @@ export function LinkButton(props) {
 
     setToShowUrlInput(false)
     setUrlValue('')
+    props.onEditFinish()
   }
 
   const onLinkInputKeyDown = (e) => {
@@ -62,6 +71,7 @@ export function LinkButton(props) {
     }
     setToShowUrlInput(false)
     setUrlValue('')
+    props.onEditFinish()
   }
 
   const urlInput = (

--- a/packages/draft-editor/src/draft-editor.tsx
+++ b/packages/draft-editor/src/draft-editor.tsx
@@ -442,6 +442,12 @@ class RichTextEditor extends React.Component<RichTextEditorProps, State> {
                 editorState={editorState}
                 onChange={this.onChange}
                 readOnly={this.state.readOnly}
+                onEditStart={() => {
+                  this.setState({ readOnly: true })
+                }}
+                onEditFinish={() => {
+                  this.setState({ readOnly: false })
+                }}
               />
               <CustomBlockquoteButton
                 isDisabled={disabledButtons.includes(buttonNames.blockquote)}
@@ -453,8 +459,16 @@ class RichTextEditor extends React.Component<RichTextEditorProps, State> {
                 isDisabled={disabledButtons.includes(buttonNames.annotation)}
                 isActive={entityType === 'ANNOTATION'}
                 editorState={editorState}
-                onChange={this.onChange}
+                onChange={(editorState) => {
+                  this.onChange(editorState)
+                }}
                 readOnly={this.state.readOnly}
+                onEditStart={() => {
+                  this.setState({ readOnly: true })
+                }}
+                onEditFinish={() => {
+                  this.setState({ readOnly: false })
+                }}
               />
               <CustomImageButton
                 isDisabled={disabledButtons.includes(buttonNames.image)}
@@ -494,7 +508,7 @@ class RichTextEditor extends React.Component<RichTextEditorProps, State> {
             onClick={() => {
               if (this.editorRef) {
                 // eslint-disable-next-line prettier/prettier
-                  (this.editorRef as HTMLElement)?.focus()
+                (this.editorRef as HTMLElement)?.focus()
               }
             }}
           >


### PR DESCRIPTION
### Bug Description
This bug happens after clicking Annotation and Link buttons.
After clicking Cancel or Confirm buttons, the cusor will jump to the first block unintentionally.

See demo

https://github.com/kids-reporter/kids-reporter-monorepo/assets/3000343/0d0321ad-5db6-41d3-ae3d-39d02d40a24e
