### PR TITLE
refactor: render `NewsReading` component directly, rather than in draft-renderer

### DIFF
--- a/packages/cms/lists/post.ts
+++ b/packages/cms/lists/post.ts
@@ -77,6 +77,11 @@ const listConfigurations = list({
       label: '首圖圖說',
       validation: { isRequired: false },
     }),
+    newsReadingGroup: relationship({
+      label: '讀報',
+      ref: 'NewsReadingGroup',
+      many: false,
+    }),
     brief: customFields.richTextEditor({
       label: '前言',
       disabledButtons: [
@@ -100,6 +105,7 @@ const listConfigurations = list({
         richTextEditorButtonNames.h2,
         richTextEditorButtonNames.code,
         richTextEditorButtonNames.codeBlock,
+        richTextEditorButtonNames.newsReading,
       ],
     }),
     projects: relationship({

--- a/packages/cms/migrations/20230905072211_add_news_reading_group_field_in_post_list/migration.sql
+++ b/packages/cms/migrations/20230905072211_add_news_reading_group_field_in_post_list/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "newsReadingGroup" INTEGER;
+
+-- CreateIndex
+CREATE INDEX "Post_newsReadingGroup_idx" ON "Post"("newsReadingGroup");
+
+-- AddForeignKey
+ALTER TABLE "Post" ADD CONSTRAINT "Post_newsReadingGroup_fkey" FOREIGN KEY ("newsReadingGroup") REFERENCES "NewsReadingGroup"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/cms/schema.graphql
+++ b/packages/cms/schema.graphql
@@ -151,6 +151,7 @@ type Post {
   authorsJSON: JSON
   heroImage: Photo
   heroCaption: String
+  newsReadingGroup: NewsReadingGroup
   brief: JSON
   content: JSON
   projects(where: ProjectWhereInput! = {}, orderBy: [ProjectOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ProjectWhereUniqueInput): [Project!]
@@ -186,6 +187,7 @@ input PostWhereInput {
   authors: AuthorManyRelationFilter
   heroImage: PhotoWhereInput
   heroCaption: StringFilter
+  newsReadingGroup: NewsReadingGroupWhereInput
   projects: ProjectManyRelationFilter
   tags: TagManyRelationFilter
   relatedPosts: PostManyRelationFilter
@@ -280,6 +282,7 @@ input PostUpdateInput {
   authorsJSON: JSON
   heroImage: PhotoRelateToOneForUpdateInput
   heroCaption: String
+  newsReadingGroup: NewsReadingGroupRelateToOneForUpdateInput
   brief: JSON
   content: JSON
   projects: ProjectRelateToManyForUpdateInput
@@ -309,6 +312,12 @@ input AuthorRelateToManyForUpdateInput {
 input PhotoRelateToOneForUpdateInput {
   create: PhotoCreateInput
   connect: PhotoWhereUniqueInput
+  disconnect: Boolean
+}
+
+input NewsReadingGroupRelateToOneForUpdateInput {
+  create: NewsReadingGroupCreateInput
+  connect: NewsReadingGroupWhereUniqueInput
   disconnect: Boolean
 }
 
@@ -349,6 +358,7 @@ input PostCreateInput {
   authorsJSON: JSON
   heroImage: PhotoRelateToOneForCreateInput
   heroCaption: String
+  newsReadingGroup: NewsReadingGroupRelateToOneForCreateInput
   brief: JSON
   content: JSON
   projects: ProjectRelateToManyForCreateInput
@@ -374,6 +384,11 @@ input AuthorRelateToManyForCreateInput {
 input PhotoRelateToOneForCreateInput {
   create: PhotoCreateInput
   connect: PhotoWhereUniqueInput
+}
+
+input NewsReadingGroupRelateToOneForCreateInput {
+  create: NewsReadingGroupCreateInput
+  connect: NewsReadingGroupWhereUniqueInput
 }
 
 input ProjectRelateToManyForCreateInput {

--- a/packages/cms/schema.prisma
+++ b/packages/cms/schema.prisma
@@ -23,34 +23,37 @@ model User {
 }
 
 model Post {
-  id                     Int              @id @default(autoincrement())
-  slug                   String           @unique @default("")
-  title                  String           @default("")
-  subtitle               String           @default("")
-  status                 String?          @default("draft")
+  id                     Int               @id @default(autoincrement())
+  slug                   String            @unique @default("")
+  title                  String            @default("")
+  subtitle               String            @default("")
+  status                 String?           @default("draft")
   publishedDate          DateTime?
-  subSubcategories       SubSubcategory[] @relation("Post_subSubcategories")
-  authors                Author[]         @relation("Author_posts")
-  authorsJSON            Json?            @default("[]")
-  heroImage              Photo?           @relation("Post_heroImage", fields: [heroImageId], references: [id])
-  heroImageId            Int?             @map("heroImage")
-  heroCaption            String           @default("")
+  subSubcategories       SubSubcategory[]  @relation("Post_subSubcategories")
+  authors                Author[]          @relation("Author_posts")
+  authorsJSON            Json?             @default("[]")
+  heroImage              Photo?            @relation("Post_heroImage", fields: [heroImageId], references: [id])
+  heroImageId            Int?              @map("heroImage")
+  heroCaption            String            @default("")
+  newsReadingGroup       NewsReadingGroup? @relation("Post_newsReadingGroup", fields: [newsReadingGroupId], references: [id])
+  newsReadingGroupId     Int?              @map("newsReadingGroup")
   brief                  Json?
   content                Json?
-  projects               Project[]        @relation("Post_projects")
-  tags                   Tag[]            @relation("Post_tags")
-  relatedPosts           Post[]           @relation("Post_relatedPosts")
-  ogTitle                String           @default("")
-  ogDescription          String           @default("")
-  ogImage                Photo?           @relation("Post_ogImage", fields: [ogImageId], references: [id])
-  ogImageId              Int?             @map("ogImage")
-  createdAt              DateTime?        @default(now())
-  updatedAt              DateTime?        @updatedAt
-  from_Post_relatedPosts Post[]           @relation("Post_relatedPosts")
+  projects               Project[]         @relation("Post_projects")
+  tags                   Tag[]             @relation("Post_tags")
+  relatedPosts           Post[]            @relation("Post_relatedPosts")
+  ogTitle                String            @default("")
+  ogDescription          String            @default("")
+  ogImage                Photo?            @relation("Post_ogImage", fields: [ogImageId], references: [id])
+  ogImageId              Int?              @map("ogImage")
+  createdAt              DateTime?         @default(now())
+  updatedAt              DateTime?         @updatedAt
+  from_Post_relatedPosts Post[]            @relation("Post_relatedPosts")
 
   @@index([status])
   @@index([publishedDate])
   @@index([heroImageId])
+  @@index([newsReadingGroupId])
   @@index([ogImageId])
 }
 
@@ -186,11 +189,12 @@ model Tag {
 }
 
 model NewsReadingGroup {
-  id        Int                    @id @default(autoincrement())
-  name      String                 @default("")
-  items     NewsReadingGroupItem[] @relation("NewsReadingGroup_items")
-  createdAt DateTime?              @default(now())
-  updatedAt DateTime?              @updatedAt
+  id                         Int                    @id @default(autoincrement())
+  name                       String                 @default("")
+  items                      NewsReadingGroupItem[] @relation("NewsReadingGroup_items")
+  createdAt                  DateTime?              @default(now())
+  updatedAt                  DateTime?              @updatedAt
+  from_Post_newsReadingGroup Post[]                 @relation("Post_newsReadingGroup")
 
   @@index([name])
 }

--- a/packages/frontend/next.config.js
+++ b/packages/frontend/next.config.js
@@ -2,6 +2,9 @@
 
 const nextConfig = {
   output: 'standalone',
+  compiler: {
+    styledComponents: true,
+  },
 }
 module.exports = nextConfig
 

--- a/packages/frontend/src/app/(sticky-header)/article/[slug]/dropdown.tsx
+++ b/packages/frontend/src/app/(sticky-header)/article/[slug]/dropdown.tsx
@@ -1,0 +1,151 @@
+import React, { useState } from 'react'
+import styled from 'styled-components'
+
+const DropdownOptionList = styled.ul`
+  margin: 0;
+  position: relative;
+  padding: 4px 0;
+  max-height: 240px;
+  background: #ffffff;
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: 16px;
+    left: 16px;
+    height: 1px;
+    background-color: #e0e0e0;
+  }
+`
+
+const DropdownOption = styled.li`
+  padding: 8px 16px;
+  cursor: pointer;
+  &:hover {
+    color: #fff;
+    background-color: #27b5f7;
+  }
+`
+
+const Container = styled.div`
+  width: 100%;
+  overflow: hidden;
+
+  color: #232323;
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 1.5;
+`
+
+const InputBlock = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 16px;
+  align-items: center;
+`
+
+const Input = styled.input`
+  color: #232323;
+  background: #ffffff;
+  font-size: 18px;
+  padding: 12px 0;
+  outline: none;
+  border: none;
+`
+
+const Label = styled.span`
+  margin-left: 10px;
+  font-size: 14px;
+  cursor: pointer;
+`
+
+const Arrow = styled.span<{ $isListOpen: boolean }>`
+  cursor: pointer;
+  margin-left: auto;
+
+  width: 20px;
+  height: 20px;
+  background-color: #27b5f7;
+  border-radius: 50%;
+  display: flex;
+
+  &::after {
+    content: '';
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: 7px;
+    border-style: solid;
+    border-width: 6px;
+    border-color: #fff transparent transparent transparent;
+    transition: transform 0.1s linear;
+    transform: ${({ $isListOpen }) =>
+      $isListOpen ? 'rotate(180deg)' : 'rotate(0deg)'};
+    transform-origin: center 2.5px;
+  }
+`
+
+type Option = {
+  name: string
+  value: string
+}
+
+type DropdownProps = {
+  className?: string
+  options: Option[]
+  onChange: (option: Option) => void
+  labelForMore?: string
+}
+
+const Dropdown: React.FC<DropdownProps> = function ({
+  className,
+  options,
+  onChange,
+  labelForMore = '',
+}) {
+  const [isListOpen, setIsListOpen] = useState(false)
+  const [selectedOption, setSelectedOption] = useState(options?.[0])
+  const toggleList = () => {
+    if (options.length <= 1) {
+      return
+    }
+    setIsListOpen(!isListOpen)
+  }
+  const selectOption = (option: Option) => {
+    toggleList()
+    onChange(option)
+    setSelectedOption(option)
+  }
+  const optionItem = options.map((option, idx) => (
+    <DropdownOption onClick={() => selectOption(option)} key={`option-${idx}`}>
+      {option.name}
+    </DropdownOption>
+  ))
+
+  return (
+    <Container className={className}>
+      <InputBlock onClick={toggleList}>
+        {
+          // WORKAROUND:
+          // `disabled` attribute is used to prevent `<input>` from hijacking the user's cursors.
+          // If `disabled`  is not provided, and then users will not be able to edit the content
+          // in the DraftEditor.
+        }
+        <Input
+          disabled
+          readOnly
+          placeholder="請選擇"
+          value={selectedOption.name}
+        />
+        {options.length > 1 && (
+          <>
+            <Arrow $isListOpen={isListOpen} />
+            {labelForMore && <Label>{labelForMore}</Label>}
+          </>
+        )}
+      </InputBlock>
+      {isListOpen && <DropdownOptionList>{optionItem}</DropdownOptionList>}
+    </Container>
+  )
+}
+
+export { Dropdown }

--- a/packages/frontend/src/app/(sticky-header)/article/[slug]/dropdown.tsx
+++ b/packages/frontend/src/app/(sticky-header)/article/[slug]/dropdown.tsx
@@ -96,14 +96,19 @@ type DropdownProps = {
   labelForMore?: string
 }
 
-const Dropdown: React.FC<DropdownProps> = function ({
+const Dropdown: React.FC<DropdownProps> = ({
   className,
   options,
   onChange,
   labelForMore = '',
-}) {
+}) => {
   const [isListOpen, setIsListOpen] = useState(false)
   const [selectedOption, setSelectedOption] = useState(options?.[0])
+
+  if (!Array.isArray(options)) {
+    return null
+  }
+
   const toggleList = () => {
     if (options.length <= 1) {
       return
@@ -115,11 +120,19 @@ const Dropdown: React.FC<DropdownProps> = function ({
     onChange(option)
     setSelectedOption(option)
   }
-  const optionItem = options.map((option, idx) => (
-    <DropdownOption onClick={() => selectOption(option)} key={`option-${idx}`}>
-      {option.name}
-    </DropdownOption>
-  ))
+  const optionItem = options.map((option, idx) => {
+    if (option?.name) {
+      return (
+        <DropdownOption
+          onClick={() => selectOption(option)}
+          key={'option-' + idx}
+        >
+          {option.name}
+        </DropdownOption>
+      )
+    }
+    return null
+  })
 
   return (
     <Container className={className}>
@@ -134,7 +147,7 @@ const Dropdown: React.FC<DropdownProps> = function ({
           disabled
           readOnly
           placeholder="請選擇"
-          value={selectedOption.name}
+          value={selectedOption?.name}
         />
         {options.length > 1 && (
           <>

--- a/packages/frontend/src/app/(sticky-header)/article/[slug]/dropdown.tsx
+++ b/packages/frontend/src/app/(sticky-header)/article/[slug]/dropdown.tsx
@@ -162,3 +162,4 @@ const Dropdown: React.FC<DropdownProps> = ({
 }
 
 export { Dropdown }
+export default Dropdown

--- a/packages/frontend/src/app/(sticky-header)/article/[slug]/news-reading.tsx
+++ b/packages/frontend/src/app/(sticky-header)/article/[slug]/news-reading.tsx
@@ -74,3 +74,4 @@ const NewsReading = ({ className, data }: NewsReadingProps) => {
 }
 
 export { NewsReading }
+export default NewsReading

--- a/packages/frontend/src/app/(sticky-header)/article/[slug]/news-reading.tsx
+++ b/packages/frontend/src/app/(sticky-header)/article/[slug]/news-reading.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import React, { useState, useMemo, useEffect } from 'react'
+import styled from 'styled-components'
+import { Dropdown } from './dropdown'
+
+const Container = styled.div`
+  max-width: 600px;
+  width: calc(280 / 320 * 100%);
+  border: 1px solid #eaeaea;
+  border-radius: 20px;
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 70px;
+`
+
+const Divider = styled.div`
+  border: 1px solid #eaeaea;
+  margin-bottom: 20px;
+`
+
+const IframeContainer = styled.div`
+  padding: 20px;
+`
+
+type NewsReadingProps = {
+  className?: string
+  data: {
+    items: {
+      name: string
+      embedCode: string
+    }[]
+  }
+}
+
+const NewsReading = function ({ className, data }: NewsReadingProps) {
+  const [isMounted, setIsMounted] = useState(false)
+  const { items } = data
+
+  const options = useMemo(
+    () =>
+      items.map((r) => {
+        return {
+          name: r.name,
+          value: r.name,
+        }
+      }),
+    [items]
+  )
+  const [selectedOption, setSelectedOption] = useState(options[0])
+  const selectedReading = items.find((r) => r.name === selectedOption.value)
+
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
+
+  if (!isMounted || items.length === 0) {
+    return null
+  }
+
+  return (
+    <Container className={className}>
+      <Dropdown
+        options={options}
+        onChange={(option) => setSelectedOption(option)}
+        labelForMore="更多語言"
+      />
+      <Divider />
+      {selectedReading?.embedCode && (
+        <IframeContainer>
+          <div
+            dangerouslySetInnerHTML={{ __html: selectedReading.embedCode }}
+          />
+        </IframeContainer>
+      )}
+    </Container>
+  )
+}
+
+export { NewsReading }

--- a/packages/frontend/src/app/(sticky-header)/article/[slug]/news-reading.tsx
+++ b/packages/frontend/src/app/(sticky-header)/article/[slug]/news-reading.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useMemo, useEffect } from 'react'
+import React, { useState, useMemo } from 'react'
 import styled from 'styled-components'
 import { Dropdown } from './dropdown'
 
@@ -33,28 +33,24 @@ type NewsReadingProps = {
   }
 }
 
-const NewsReading = function ({ className, data }: NewsReadingProps) {
-  const [isMounted, setIsMounted] = useState(false)
-  const { items } = data
+const NewsReading = ({ className, data }: NewsReadingProps) => {
+  const items = data?.items || []
 
   const options = useMemo(
     () =>
       items.map((r) => {
         return {
-          name: r.name,
-          value: r.name,
+          name: r?.name,
+          value: r?.name,
         }
       }),
     [items]
   )
+
   const [selectedOption, setSelectedOption] = useState(options[0])
-  const selectedReading = items.find((r) => r.name === selectedOption.value)
+  const selectedReading = items?.find((r) => r?.name === selectedOption?.value)
 
-  useEffect(() => {
-    setIsMounted(true)
-  }, [])
-
-  if (!isMounted || items.length === 0) {
+  if (items.length === 0) {
     return null
   }
 

--- a/packages/frontend/src/app/(sticky-header)/article/[slug]/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/article/[slug]/page.tsx
@@ -19,6 +19,7 @@ import {
   GetThemeFromCategory,
 } from '@/app/constants'
 import './page.scss'
+import { NewsReading } from './news-reading'
 
 const heroImageGQL = `
   heroImage {
@@ -49,6 +50,12 @@ const postQueryGQL = `
   query($where: PostWhereUniqueInput!) {
     post(where: $where) {
       title
+      newsReadingGroup {
+        items {
+          name
+          embedCode
+        }
+      }
       brief
       content
       publishedDate
@@ -193,6 +200,9 @@ export default async function PostPage({
               </div>
             </header>
           </div>
+          {post.newsReadingGroup && (
+            <NewsReading data={post.newsReadingGroup} />
+          )}
           <Brief
             content={post.brief}
             authors={orderedAuthorsInBrief}


### PR DESCRIPTION
### Notable Changes
- add `NewsReading` and `Dropdown` components
- render `NewsReading` if `post.newsReadingGroup` is not null


### 實作細節
原本「讀報」（`NewsReading`）是放在 `@kids-reporter/draft-renderer` 透過 `draft-js` 去 render，但因為編輯回報「讀報」是在「標題之下、前言之上」，所以我把「讀報」元件從 `draft-renderer` 搬到 `frontend` 底下實作。

