### PR TITLE
refactor(frontend): collect styled-components styles on server side

### DIFF
--- a/packages/frontend/src/app/layout.tsx
+++ b/packages/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next'
 import BackToTop from '@/app/components/back-to-top'
 import Footer from '@/app/components/footer'
+import StyledComponentsRegistry from './registry'
 import './globals.scss'
 
 export const metadata: Metadata = {
@@ -16,11 +17,13 @@ export default function RootLayout({
 }) {
   return (
     <html>
-      <body>
-        {children}
-        <BackToTop />
-        <Footer />
-      </body>
+      <StyledComponentsRegistry>
+        <body>
+          {children}
+          <BackToTop />
+          <Footer />
+        </body>
+      </StyledComponentsRegistry>
     </html>
   )
 }

--- a/packages/frontend/src/app/registry.tsx
+++ b/packages/frontend/src/app/registry.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import React, { useState } from 'react'
+import { useServerInsertedHTML } from 'next/navigation'
+import { ServerStyleSheet, StyleSheetManager } from 'styled-components'
+
+export default function StyledComponentsRegistry({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  // Only create stylesheet once with lazy initial state
+  // x-ref: https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
+  const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet())
+
+  useServerInsertedHTML(() => {
+    const styles = styledComponentsStyleSheet.getStyleElement()
+    styledComponentsStyleSheet.instance.clearTag()
+    return <>{styles}</>
+  })
+
+  if (typeof window !== 'undefined') return <>{children}</>
+
+  return (
+    <StyleSheetManager sheet={styledComponentsStyleSheet.instance}>
+      {children}
+    </StyleSheetManager>
+  )
+}


### PR DESCRIPTION
### Notable Changes
- collect styled-components styles on server side

### 實作細節
根據 [nextjs 官方文件 ](https://nextjs.org/docs/app/building-your-application/styling/css-in-js#styled-components) 實作 server side rendering。
此修正可以解決 https://github.com/kids-reporter/kids-reporter-monorepo/pull/123#issuecomment-1706254009 問題。