### PR TITLE
fix(dr): update block-render-map for Atomic block

### DIFF
--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@keystone-6/auth": "7.0.0",
     "@keystone-6/core": "5.2.0",
-    "@kids-reporter/cms-core": "^0.4.19",
+    "@kids-reporter/cms-core": "^0.4.20",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "http-proxy-middleware": "^2.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/cms-core",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "",
   "main": "lib/index.js",
   "types": "src/index.ts",
@@ -33,7 +33,7 @@
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",
     "@twreporter/errors": "^1.1.1",
-    "@kids-reporter/draft-editor": "^0.4.19",
+    "@kids-reporter/draft-editor": "^0.4.20",
     "axios": "^0.26.0",
     "draft-convert": "^2.1.12",
     "draft-js": "^0.11.7",

--- a/packages/draft-editor/package.json
+++ b/packages/draft-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/draft-editor",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -23,7 +23,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@kids-reporter/draft-renderer": "^0.4.19",
+    "@kids-reporter/draft-renderer": "^0.4.20",
     "@twreporter/errors": "^1.1.2",
     "draft-js": "^0.11.7"
   },

--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/draft-renderer",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/src/block-render-maps/annotation.tsx
+++ b/packages/draft-renderer/src/block-render-maps/annotation.tsx
@@ -2,7 +2,7 @@ import Immutable from 'immutable'
 import React from 'react'
 import styled from 'styled-components'
 import { DefaultDraftBlockRenderMap } from 'draft-js'
-import { Paragraph, Heading, List } from './article-content'
+import { Atomic, Paragraph, Heading, List } from './article-content'
 
 const HeadingForAnnotation = styled(Heading)`
   margin: 0 auto 27px auto;
@@ -23,7 +23,8 @@ const ParagraphForAnnotation = styled(Paragraph)`
 
 const _blockRenderMapForAnnotation = Immutable.Map({
   atomic: {
-    element: 'div',
+    element: 'figure',
+    wrapper: <Atomic />,
   },
   'header-four': {
     element: 'h4',

--- a/packages/draft-renderer/src/block-render-maps/article-content.tsx
+++ b/packages/draft-renderer/src/block-render-maps/article-content.tsx
@@ -75,9 +75,17 @@ export const List = styled.ol`
   }
 `
 
+export const Atomic = styled.div`
+  /* reset browser default styles */
+  > figure {
+    margin: 0;
+  }
+`
+
 const _blockRenderMap = Immutable.Map({
   atomic: {
-    element: 'div',
+    element: 'figure',
+    wrapper: <Atomic />,
   },
   'header-two': {
     element: 'h2',

--- a/packages/draft-renderer/src/block-render-maps/info-box.tsx
+++ b/packages/draft-renderer/src/block-render-maps/info-box.tsx
@@ -23,6 +23,11 @@ const ParagraphForInfoBox = styled(Paragraph)`
 `
 
 const Atomic = styled.div`
+  /* reset figure default styles */
+  figure {
+    margin: 0;
+  }
+
   /* hide last empty block which immediately follows an atomic block */
   & + ${Paragraph}:last-of-type {
     line-height: 0;

--- a/packages/draft-renderer/src/block-render-maps/project-content.tsx
+++ b/packages/draft-renderer/src/block-render-maps/project-content.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { DefaultDraftBlockRenderMap } from 'draft-js'
 import {
+  Atomic,
   Paragraph as _Paragraph,
   List,
   Heading as _Heading,
@@ -19,7 +20,8 @@ export const Heading = styled(_Heading)`
 
 const _blockRenderMap = Immutable.Map({
   atomic: {
-    element: 'div',
+    element: 'figure',
+    wrapper: <Atomic />,
   },
   'header-two': {
     element: 'h2',

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -10,7 +10,7 @@
     "analyze": "ANALYZE=true yarn build"
   },
   "dependencies": {
-    "@kids-reporter/draft-renderer": "^0.4.19",
+    "@kids-reporter/draft-renderer": "^0.4.20",
     "@twreporter/errors": "^1.1.2",
     "@types/draft-js": "^0.11.10",
     "@types/node": "20.4.1",


### PR DESCRIPTION
This patch fixes a copy-and-paste bug.
Error happens when user copy and paste multiple paragraphs onto Draft Editor.
The reason is we use `<div>` to render `atomic` blocks. Therefore, when user copies and pastes the multiple paragraphs (`<div>s`), and then Draft Editor will treat those paragraphs as `atomic` blocks. But those paragraphs won't have Draft Entity at all, and that causes errors.