### PR TITLE
feat(frontend): search page powered by Google Custom Search JSON API

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -10,6 +10,7 @@
     "analyze": "ANALYZE=true yarn build"
   },
   "dependencies": {
+    "@googleapis/customsearch": "^1.0.4",
     "@kids-reporter/draft-renderer": "^0.4.20",
     "@twreporter/errors": "^1.1.2",
     "@types/draft-js": "^0.11.10",
@@ -19,6 +20,7 @@
     "@types/styled-components": "^5.1.26",
     "axios": "^1.4.0",
     "draft-js": "^0.11.7",
+    "encoding": "^0.1.13",
     "eslint": "8.44.0",
     "eslint-config-next": "13.4.9",
     "next": "13.4.9",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -26,6 +26,7 @@
     "next": "13.4.9",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-transition-group": "^4.4.5",
     "sass": "^1.64.0",
     "styled-components": "5.3.5",
     "swiper": "^10.1.0",

--- a/packages/frontend/src/app/(sticky-header)/search/cards.tsx
+++ b/packages/frontend/src/app/(sticky-header)/search/cards.tsx
@@ -45,7 +45,7 @@ const Cards = ({ items }: { items: PostCardProp[] }) => {
         classNames="item"
       >
         <div ref={nodeRef}>
-          <PostCard post={item.post} showDesc={item?.showDesc} />
+          <PostCard post={item.post} showDesc={item.showDesc} />
         </div>
       </CSSTransition>
     )

--- a/packages/frontend/src/app/(sticky-header)/search/cards.tsx
+++ b/packages/frontend/src/app/(sticky-header)/search/cards.tsx
@@ -1,0 +1,57 @@
+'use client'
+import PostCard, { PostCardProp } from '@/app/components/post-card'
+import styled from 'styled-components'
+import { CSSTransition, TransitionGroup } from 'react-transition-group'
+import { createRef } from 'react'
+import { mediaQuery } from '@/app/utils/media-query'
+
+const FlexContainer = styled(TransitionGroup)`
+  /* flexbox related styles */
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  row-gap: 30px;
+  column-gap: 30px;
+  flex-wrap: wrap;
+  margin: 0 auto 30px auto;
+
+  ${mediaQuery.mediumAbove} {
+    max-width: 1440px;
+  }
+
+  .item-enter {
+    opacity: 0;
+  }
+  .item-enter-done {
+    opacity: 1;
+    transition: opacity 500ms ease-in;
+  }
+`
+
+export type { PostCardProp }
+
+const Cards = ({ items }: { items: PostCardProp[] }) => {
+  const cardsJsx = items.map((item, idx) => {
+    const nodeRef = createRef<HTMLDivElement>()
+    if (!item) {
+      return null
+    }
+    return (
+      <CSSTransition
+        in={true}
+        key={idx}
+        nodeRef={nodeRef}
+        timeout={500}
+        classNames="item"
+      >
+        <div ref={nodeRef}>
+          <PostCard post={item.post} showDesc={item?.showDesc} />
+        </div>
+      </CSSTransition>
+    )
+  })
+  return <FlexContainer>{cardsJsx}</FlexContainer>
+}
+
+export { Cards }
+export default Cards

--- a/packages/frontend/src/app/(sticky-header)/search/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/search/page.tsx
@@ -1,0 +1,66 @@
+import errors from '@twreporter/errors'
+import { LoadMoreResults } from './results'
+import { SearchTitle } from './styled'
+import {
+  getPostOnlySearchResults,
+  transferItemsToPostCards,
+  defaultCount,
+} from '@/app/api/search/route'
+
+const apiKey = process.env.SEARCH_API_KEY || ''
+const cx = process.env.SEARCH_ENGINE_ID || ''
+
+export default async function SearchPage({
+  searchParams,
+}: {
+  searchParams: {
+    q: string
+  }
+}) {
+  if (!searchParams.q) {
+    return <SearchTitle>請輸入要搜尋的字串。</SearchTitle>
+  }
+
+  let data
+  try {
+    data = await getPostOnlySearchResults({
+      q: searchParams.q,
+      apiKey,
+      cx,
+      start: 1,
+      count: defaultCount,
+    })
+  } catch (err) {
+    console.log(
+      JSON.stringify({
+        severity: 'ERROR',
+        message: errors.helpers.printAll(
+          err,
+          { withStack: true, withPayload: true },
+          0,
+          0
+        ),
+      })
+    )
+    return (
+      <SearchTitle>
+        搜尋結果服務異常，請稍候再試。 若持續發生，煩請來信至
+        kidsnews@twreporter.org。
+      </SearchTitle>
+    )
+  }
+
+  const cardItems = Array.isArray(data?.items)
+    ? transferItemsToPostCards(data.items)
+    : []
+
+  return (
+    <div>
+      <SearchTitle>搜尋結果 {searchParams.q}</SearchTitle>
+      <LoadMoreResults
+        currentCardItems={cardItems}
+        nextQuery={data.nextQuery}
+      />
+    </div>
+  )
+}

--- a/packages/frontend/src/app/(sticky-header)/search/results.tsx
+++ b/packages/frontend/src/app/(sticky-header)/search/results.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import axios from 'axios'
+import styled from 'styled-components'
+import errors from '@twreporter/errors'
+import { Cards, PostCardProp } from './cards'
+import { useState } from 'react'
+
+const Container = styled.div`
+  text-align: center;
+`
+
+const LoadMoreBt = styled.div`
+  color: #232323;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 26px;
+
+  border: 2px solid #27b5f7;
+  border-radius: 30px;
+  width: fit-content;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 10px 60px;
+  cursor: pointer;
+`
+
+const LoadingGif = styled.img`
+  display: inline-block;
+  max-width: 100px;
+`
+
+export const LoadMoreResults = ({
+  currentCardItems,
+  nextQuery: nextQueryParam,
+}: {
+  currentCardItems: PostCardProp[]
+  nextQuery?: {
+    q: string
+    startIndex?: number
+    count?: number
+  }
+}) => {
+  const [cardItems, setCardItems] = useState(currentCardItems)
+  const [nextQuery, setNextQuery] = useState(nextQueryParam)
+  const [loadMoreError, setLoadMoreError] = useState(null)
+  const [isLoading, setIsLoading] = useState(false)
+
+  const loadMore = async () => {
+    if (nextQuery) {
+      const start = nextQuery.startIndex
+      const count = nextQuery.count
+      let axiosRes
+      try {
+        setIsLoading(true)
+        axiosRes = await axios.get(
+          `/api/search?q=${nextQuery.q}&start=${start}&count=${count}`
+        )
+      } catch (err) {
+        setIsLoading(false)
+        const annotatedError = errors.helpers.annotateAxiosError(err)
+        setLoadMoreError(annotatedError)
+        return
+      }
+
+      const items = axiosRes.data?.data?.items || []
+      const _nextQuery = axiosRes.data?.data?.nextQuery
+      if (Array.isArray(cardItems)) {
+        setCardItems(cardItems.concat(items))
+      }
+      setNextQuery(_nextQuery)
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <Container>
+      <Cards items={cardItems} />
+      {loadMoreError ? <span>載入發生錯誤，請稍候再試</span> : null}
+      {nextQuery && !isLoading ? (
+        <LoadMoreBt onClick={loadMore}>載入更多</LoadMoreBt>
+      ) : null}
+      {isLoading ? <LoadingGif src="/images/loading.gif" /> : null}
+    </Container>
+  )
+}
+
+export default {
+  LoadMoreResults,
+}

--- a/packages/frontend/src/app/(sticky-header)/search/styled.tsx
+++ b/packages/frontend/src/app/(sticky-header)/search/styled.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import styled from 'styled-components'
+
+export const SearchTitle = styled.h1`
+  font-size: 30px;
+  font-weight: 700;
+  text-align: center;
+  letter-spacing: 1.5px;
+  line-height: 1.5;
+  color: #232323;
+  margin-top: 80px;
+  margin-bottom: 40px;
+`
+
+export default {
+  SearchTitle,
+}

--- a/packages/frontend/src/app/api/search/route.ts
+++ b/packages/frontend/src/app/api/search/route.ts
@@ -1,0 +1,254 @@
+import errors from '@twreporter/errors'
+import { NextResponse } from 'next/server'
+import { PostCardProp } from '@/app/components/post-card'
+import { Theme } from '@/app/constants'
+import { customsearch } from '@googleapis/customsearch'
+import { customsearch_v1 } from '@googleapis/customsearch/v1'
+
+const client = customsearch('v1')
+const apiKey = process.env.SEARCH_API_KEY || ''
+const cx = process.env.SEARCH_ENGINE_ID || ''
+export const defaultCount = 9
+export const defaultStart = 1
+
+type SearchResult = {
+  nextQuery?: {
+    count?: number
+    startIndex?: number
+    q: string
+  }
+  items: customsearch_v1.Schema$Result[]
+}
+
+export function transferItemsToPostCards(
+  items: customsearch_v1.Schema$Result[]
+): PostCardProp[] {
+  const cardItems: PostCardProp[] = []
+  items.forEach((item) => {
+    const metaTag = item?.pagemap?.metatags?.[0]
+    const creativeWork = item?.pagemap?.creativework?.[0]
+    const image = creativeWork?.image || metaTag?.['og:image']
+    const title = creativeWork?.headline || metaTag?.['og:title']
+    const desc = metaTag?.['og:description']
+    const publishedDate = metaTag?.['article:published_time']
+    const url = item.link || metaTag?.['og:url']
+
+    // @TODO: add `subcategory` and `subSubcategory`
+    // Currently, we don't have `subcategory` and `subSubcategory`
+    // data in Google Custom Search Engine
+    // since we don't provide those information in the webpage.
+    // We need to either provide those information by
+    // `PageMap` data (see https://developers.google.com/custom-search/docs/structured_data#addtopage)
+
+    cardItems.push({
+      post: {
+        image,
+        title,
+        desc,
+        publishedDate,
+        url,
+        category: '',
+        subSubcategory: '',
+        theme: Theme.BLUE,
+      },
+      showDesc: true,
+    })
+  })
+
+  return cardItems
+}
+
+async function getSearchResults({
+  cx,
+  apiKey,
+  q,
+  start = defaultStart,
+  count = defaultCount,
+}: {
+  cx: string
+  apiKey: string
+  q: string
+  start?: number
+  count?: number
+}) {
+  let searchRes
+  try {
+    searchRes = await client.cse.list({
+      cx,
+      q,
+      auth: apiKey,
+      start,
+      num: count,
+    })
+  } catch (err) {
+    const annotatedError = errors.helpers.wrap(
+      errors.helpers.annotateAxiosError(err),
+      'SearchAPIError',
+      'Errors occured in quering Google Custom Search JSON API',
+      { q, start, num: count }
+    )
+    throw annotatedError
+  }
+
+  if (!searchRes) {
+    return {
+      nextQuery: undefined,
+      items: [],
+    }
+  }
+
+  const nextPage = searchRes.data.queries?.nextPage?.[0]
+
+  const nextQuery = nextPage
+    ? {
+        startIndex: nextPage.startIndex,
+        count: nextPage.count,
+        q,
+      }
+    : undefined
+
+  const items = searchRes?.data?.items ?? []
+
+  return {
+    // if `data.nextQuery` is `undefined`,
+    // and then it means there is no more items to load.
+    nextQuery,
+    items,
+  }
+}
+
+function filterPostItems(items?: customsearch_v1.Schema$Result[]) {
+  if (Array.isArray(items)) {
+    return items.filter((item) => {
+      const metaTag = item?.pagemap?.metatags?.[0]
+      return metaTag?.['og:type'] === 'article'
+    })
+  }
+  return items
+}
+
+export async function getPostOnlySearchResults({
+  cx,
+  apiKey,
+  q,
+  start = defaultStart,
+  count = defaultCount,
+  accumulatedItems = [],
+}: {
+  cx: string
+  apiKey: string
+  q: string
+  start?: number
+  count?: number
+  accumulatedItems?: customsearch_v1.Schema$Result[]
+}): Promise<SearchResult> {
+  let searchResults
+  try {
+    searchResults = await getSearchResults({
+      cx,
+      apiKey,
+      q,
+      start,
+      count,
+    })
+  } catch (err) {
+    // @TODO print structured logs
+    console.log(
+      JSON.stringify({
+        severity: 'WARNING',
+        message: errors.helpers.printAll(
+          err,
+          { withStack: true, withPayload: true },
+          0,
+          0
+        ),
+      })
+    )
+
+    // Return accumulated items for workaround.
+    // Google Custom Search JSON API sometimes returns different results,
+    // such as `nextPage` information, for the same request API arguments.
+    // Therefore, we might encounter some unexpected errors.
+    // For example, `nexPage` contains `count` and `start` fields, and we take
+    // those fields to query API, but the API returns error response as no further items could be requested.
+    return {
+      items: accumulatedItems,
+    }
+  }
+  let _accItems = accumulatedItems
+  const items = filterPostItems(searchResults?.items)
+  if (Array.isArray(items)) {
+    _accItems = _accItems.concat(items)
+    // repeatedly request API to get enough items
+    if (_accItems.length < count && searchResults?.nextQuery) {
+      const nextCount = searchResults.nextQuery.count
+      const nextStart = searchResults.nextQuery.startIndex
+      return getPostOnlySearchResults({
+        cx,
+        apiKey,
+        q,
+        start: nextStart,
+        count: nextCount,
+        accumulatedItems: _accItems,
+      })
+    }
+  }
+
+  return {
+    nextQuery: searchResults.nextQuery,
+    items: _accItems,
+  }
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const q = searchParams.get('q')
+  const startStr = searchParams.get('start') ?? ''
+  const countStr = searchParams.get('count') ?? ''
+  const postCardFormatStr = searchParams.get('post_card_format')
+
+  const start = parseInt(startStr, 10) || defaultStart
+  const count = parseInt(countStr, 10) || defaultCount
+  const postCardFormat = postCardFormatStr !== 'false'
+
+  if (!q) {
+    return NextResponse.json({
+      items: [],
+    })
+  }
+
+  try {
+    const searchResults = await getPostOnlySearchResults({
+      cx,
+      apiKey,
+      q,
+      start,
+      count,
+    })
+    if (postCardFormat) {
+      const items = transferItemsToPostCards(searchResults.items)
+      return NextResponse.json({
+        status: 'success',
+        data: Object.assign(searchResults, { items }),
+      })
+    }
+
+    return NextResponse.json({
+      status: 'success',
+      data: searchResults,
+    })
+  } catch (err) {
+    console.log(
+      JSON.stringify({
+        severity: 'ERROR',
+        message: errors.helpers.printAll(err, {
+          withPayload: true,
+          withStack: true,
+        }),
+      })
+    )
+    return new Response(errors.helper.printOne(err), {
+      status: 500,
+    })
+  }
+}

--- a/packages/frontend/src/app/api/search/route.ts
+++ b/packages/frontend/src/app/api/search/route.ts
@@ -23,6 +23,10 @@ type SearchResult = {
 export function transferItemsToPostCards(
   items: customsearch_v1.Schema$Result[]
 ): PostCardProp[] {
+  if (!Array.isArray(items)) {
+    return items
+  }
+
   const cardItems: PostCardProp[] = []
   items.forEach((item) => {
     const metaTag = item?.pagemap?.metatags?.[0]
@@ -31,7 +35,7 @@ export function transferItemsToPostCards(
     const title = creativeWork?.headline || metaTag?.['og:title']
     const desc = metaTag?.['og:description']
     const publishedDate = metaTag?.['article:published_time']
-    const url = item.link || metaTag?.['og:url']
+    const url = item?.link || metaTag?.['og:url']
 
     // @TODO: add `subcategory` and `subSubcategory`
     // Currently, we don't have `subcategory` and `subSubcategory`

--- a/packages/frontend/src/app/components/post-card.tsx
+++ b/packages/frontend/src/app/components/post-card.tsx
@@ -39,7 +39,8 @@ export const PostCard = ({
               <span className="subSubcategory">{post.subSubcategory}</span>
             )}
             <span className="published-date">
-              {GetFormattedDate(post.publishedDate) ?? ''}
+              {(post.publishedDate && GetFormattedDate(post.publishedDate)) ??
+                ''}
             </span>
           </div>
         </div>

--- a/packages/frontend/src/app/components/post-card.tsx
+++ b/packages/frontend/src/app/components/post-card.tsx
@@ -21,7 +21,9 @@ export const PostCard = ({
     post && (
       <a
         href={post.url}
-        className={`${className} post-body theme-${post.theme}`}
+        className={`post-body theme-${post.theme} ${
+          className ? className : ''
+        }`}
       >
         <img src={post.image} />
         <div className="card-info">

--- a/yarn.lock
+++ b/yarn.lock
@@ -2385,6 +2385,13 @@
     uuid "^8.0.0"
     xdg-basedir "^4.0.0"
 
+"@googleapis/customsearch@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@googleapis/customsearch/-/customsearch-1.0.4.tgz#f0549e6e07d3fed28233bb7fdd25410cd2f0bac6"
+  integrity sha512-8kn/kFGDFElgz+MBSmGVvja+m5ri8kN8uednMus6ft0MI0GbmwGCQgAPOtj0kZeuMYI63nUk7E+QKY4/VidJ6g==
+  dependencies:
+    googleapis-common "^7.0.0"
+
 "@graphql-tools/merge@^8.4.1":
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.4.2.tgz#95778bbe26b635e8d2f60ce9856b388f11fe8288"
@@ -4465,6 +4472,13 @@ agent-base@6:
   dependencies:
     debug "4"
 
+agent-base@^7.0.2:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.0.tgz#536802b76bc0b34aa50195eb2442276d613e3434"
+  integrity sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==
+  dependencies:
+    debug "^4.3.4"
+
 aggregate-error@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
@@ -5982,6 +5996,13 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
 
+encoding@^0.1.13:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
+  integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
+  dependencies:
+    iconv-lite "^0.6.2"
+
 end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
@@ -6982,12 +7003,30 @@ gaxios@^4.0.0:
     is-stream "^2.0.0"
     node-fetch "^2.6.7"
 
+gaxios@^6.0.0, gaxios@^6.0.3:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-6.1.1.tgz#549629f86a13e756b900f9ff7c94624670102938"
+  integrity sha512-bw8smrX+XlAoo9o1JAksBwX+hi/RG15J+NTSxmNPIclKC3ZVK6C2afwY8OSdRvOK0+ZLecUJYtj2MmjOt3Dm0w==
+  dependencies:
+    extend "^3.0.2"
+    https-proxy-agent "^7.0.1"
+    is-stream "^2.0.0"
+    node-fetch "^2.6.9"
+
 gcp-metadata@^4.2.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-4.3.1.tgz#fb205fe6a90fef2fd9c85e6ba06e5559ee1eefa9"
   integrity sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==
   dependencies:
     gaxios "^4.0.0"
+    json-bigint "^1.0.0"
+
+gcp-metadata@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-6.0.0.tgz#2ae12008bef8caa8726cba31fd0a641ebad5fb56"
+  integrity sha512-Ozxyi23/1Ar51wjUT2RDklK+3HxqDr8TLBNK8rBBFQ7T85iIGnXnVusauj06QyqCXRFZig8LZC+TUddWbndlpQ==
+  dependencies:
+    gaxios "^6.0.0"
     json-bigint "^1.0.0"
 
 gensync@^1.0.0-beta.2:
@@ -7158,12 +7197,37 @@ google-auth-library@^7.14.1:
     jws "^4.0.0"
     lru-cache "^6.0.0"
 
+google-auth-library@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-9.0.0.tgz#b159d22464c679a6a25cb46d48a4ac97f9f426a2"
+  integrity sha512-IQGjgQoVUAfOk6khqTVMLvWx26R+yPw9uLyb1MNyMQpdKiKt0Fd9sp4NWoINjyGHR8S3iw12hMTYK7O8J07c6Q==
+  dependencies:
+    base64-js "^1.3.0"
+    ecdsa-sig-formatter "^1.0.11"
+    gaxios "^6.0.0"
+    gcp-metadata "^6.0.0"
+    gtoken "^7.0.0"
+    jws "^4.0.0"
+    lru-cache "^6.0.0"
+
 google-p12-pem@^3.1.3:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/google-p12-pem/-/google-p12-pem-3.1.4.tgz#123f7b40da204de4ed1fbf2fd5be12c047fc8b3b"
   integrity sha512-HHuHmkLgwjdmVRngf5+gSmpkyaRI6QmOg77J8tkNBHhNEI62sGHyw4/+UkgyZEI7h84NbWprXDJ+sa3xOYFvTg==
   dependencies:
     node-forge "^1.3.1"
+
+googleapis-common@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/googleapis-common/-/googleapis-common-7.0.0.tgz#a7b5262e320c922c25b123edea2a3958f15c3edd"
+  integrity sha512-58iSybJPQZ8XZNMpjrklICefuOuyJ0lMxfKmBqmaC0/xGT4SiOs4BE60LAOOGtBURy1n8fHa2X2YUNFEWWbXyQ==
+  dependencies:
+    extend "^3.0.2"
+    gaxios "^6.0.3"
+    google-auth-library "^9.0.0"
+    qs "^6.7.0"
+    url-template "^2.0.8"
+    uuid "^9.0.0"
 
 gopd@^1.0.1:
   version "1.0.1"
@@ -7214,6 +7278,14 @@ gtoken@^5.0.4:
   dependencies:
     gaxios "^4.0.0"
     google-p12-pem "^3.1.3"
+    jws "^4.0.0"
+
+gtoken@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/gtoken/-/gtoken-7.0.1.tgz#b64bd01d88268ea3a3572c9076a85d1c48f1a455"
+  integrity sha512-KcFVtoP1CVFtQu0aSk3AyAt2og66PFhZAlkUOuWKwzMLoulHXG5W5wE5xAnHb+yl3/wEFoqGW7/cDGMU8igDZQ==
+  dependencies:
+    gaxios "^6.0.0"
     jws "^4.0.0"
 
 gzip-size@^6.0.0:
@@ -7448,6 +7520,14 @@ https-proxy-agent@5.0.1, https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
+https-proxy-agent@^7.0.1:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz#e2645b846b90e96c6e6f347fb5b2e41f1590b09b"
+  integrity sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==
+  dependencies:
+    agent-base "^7.0.2"
+    debug "4"
+
 human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
@@ -7470,7 +7550,7 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.6.3:
+iconv-lite@^0.6.2, iconv-lite@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
@@ -8688,6 +8768,13 @@ node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
+node-fetch@^2.6.9:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-forge@^1, node-forge@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
@@ -9370,6 +9457,13 @@ qs@6.11.0:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
   integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
+  dependencies:
+    side-channel "^1.0.4"
+
+qs@^6.7.0:
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.2.tgz#64bea51f12c1f5da1bc01496f48ffcff7c69d7d9"
+  integrity sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==
   dependencies:
     side-channel "^1.0.4"
 
@@ -11052,6 +11146,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+url-template@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
+  integrity sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==
 
 use-callback-ref@^1.3.0:
   version "1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9649,7 +9649,7 @@ react-style-singleton@^2.2.1:
     invariant "^2.2.4"
     tslib "^2.0.0"
 
-react-transition-group@^4.3.0, react-transition-group@^4.4.2:
+react-transition-group@^4.3.0, react-transition-group@^4.4.2, react-transition-group@^4.4.5:
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
   integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==


### PR DESCRIPTION
### Notable Changes
- add `app/api/search/route.ts`: add `/api/search` endpoint
- add `app/(sticky-header)/search/*`: add search page

### 實作細節
使用 Google Custom Search JSON API 來獲取搜尋結果。
關於 JSON API 的 `apiKey` 和 `cx`（搜尋引擎 ID） 的內容，請到 [Programmable Search console](https://programmablesearchengine.google.com/controlpanel/overview?cx=14e195c89152240ce) 找。 

Custom Search JSON API 回傳的結果，除了包含文章，也會包含作者頁、列表頁、首頁等其他頁面，
但除了文章頁之外的頁面，現有 production（舊的） 網頁提供給搜尋引擎的資料不足，
若我們要在搜尋頁面呈現文章頁以外的結果，會有畫面看起來過於單調的問題（因為資料不足，導致圖片、標題、description 比缺漏）。
所以和編輯、PM 討論過後，決定過濾掉「不是文章」的搜尋結果。
然而，過濾搜尋結果會導致分頁的呈現上搜尋筆數可能不夠多的問題，所以設計上，我們改用「載入更多」的按鈕取代「分頁」。

為了實作「載入更多」，我們會需要有 API endpoint 讓 browser 可以 request，所以在此 PR 中，也加上了 API endpoint（`/api/search`）。
