### PR TITLE
feat(cms, frontend): enable authentication layer on api endpoint

### DIFF
--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -19,12 +19,13 @@
     "@keystone-6/auth": "7.0.0",
     "@keystone-6/core": "5.2.0",
     "@kids-reporter/cms-core": "^0.4.30",
+    "@types/react-beautiful-dnd": "^13.1.4",
     "cors": "^2.8.5",
     "express": "^4.17.1",
+    "graphql-tag": "^2.12.6",
     "http-proxy-middleware": "^2.0.3",
     "patch-package": "^6.4.7",
-    "react-beautiful-dnd": "^13.1.1",
-    "@types/react-beautiful-dnd": "^13.1.4"
+    "react-beautiful-dnd": "^13.1.1"
   },
   "resolutions": {
     "**/next": "13.3.4",

--- a/packages/frontend/src/app/api/graphql/route.ts
+++ b/packages/frontend/src/app/api/graphql/route.ts
@@ -1,0 +1,230 @@
+import axios from 'axios'
+import errors from '@twreporter/errors'
+import { NextResponse } from 'next/server'
+import {
+  apiOrigin,
+  apiHeadlessAccountEmail,
+  apiHeadlessAccountPassword,
+} from '@/app/environment-variables'
+
+const accoutEmail = apiHeadlessAccountEmail
+const accountPassword = apiHeadlessAccountPassword
+
+/**
+ *  Since our original GQL server only accepts authenticated requests,
+ *  the client side/browser cannot request GQL server directly due to lacking of session token.
+ *
+ *  Therefore, this route handler is built for accepting client side GQL requests.
+ *  After this handler received the requests from client side,
+ *  it will try to get the session token via account and password authentication first.
+ *
+ *  If the handler has the session token,
+ *  it will request GQL server with that session token and the GQL request body.
+ *
+ *  @TODO:
+ *  The better way for this handler is to proxy the client request to original GQL server,
+ *  rather than parsing request body and compose another request to the GQL server.
+ *  However, the 'http-proxy-middleware' library that we used to use is not ready for NextJS 13 api routes.
+ *  If someday 'http-proxy-middleware' is ready, we could use it to proxy the requests, instead of doing it
+ *  by ourselves.
+ */
+export async function POST(request: Request) {
+  // request body
+  const body = await request.json()
+
+  // session token, used to pass GQL server authentication
+  let token = ''
+  try {
+    // `TokenMananger` is implmented by Singleton pattern.
+    // Therefore, for different requests, they all got the same instance of `TokenManager`,
+    // and use the same session token.
+    // Hence, we could reduce the original GQL server workloads.
+    const tokenManager = new TokenManager(accoutEmail, accountPassword)
+    token = await tokenManager.getToken()
+  } catch (err) {
+    console.log(
+      JSON.stringify({
+        severity: 'ERROR',
+        message: errors.helpers.printAll(
+          err,
+          {
+            withStack: true,
+            withPayload: true,
+          },
+          0,
+          0
+        ),
+      })
+    )
+    return NextResponse.json(
+      {
+        status: 'error',
+        message: errors.helpers.printOne(err, {
+          withStack: false,
+          withPayload: false,
+        }),
+      },
+      {
+        status: 500,
+      }
+    )
+  }
+  try {
+    // original GQL server endpoint
+    const gqlEndpoint = apiOrigin + '/api/graphql'
+    const axiosRes = await axios.post(gqlEndpoint, body, {
+      headers: {
+        'Content-Type': 'application/json',
+        // original GQL server is using Cookie to do the authentication
+        Cookie: `keystonejs-session=${token}`,
+        'x-apollo-operation-name': '',
+      },
+    })
+    return NextResponse.json(axiosRes.data)
+  } catch (err) {
+    const annotatedErr = errors.helpers.annotateAxiosError(err)
+    console.log(
+      JSON.stringify({
+        severity: 'ERROR',
+        message: errors.helpers.printAll(
+          annotatedErr,
+          {
+            withStack: true,
+            withPayload: true,
+          },
+          0,
+          0
+        ),
+      })
+    )
+    return NextResponse.json(
+      {
+        status: 'error',
+        message: errors.helpers.printOne(annotatedErr, {
+          withStack: false,
+          withPayload: false,
+        }),
+      },
+      {
+        status: 500,
+      }
+    )
+  }
+}
+
+const gqlQuery = `
+mutation AuthenticateUserWithPassword($email: String!, $password: String!) {
+  authenticateUserWithPassword(email: $email, password: $password) {
+    ... on UserAuthenticationWithPasswordSuccess {
+      sessionToken
+    }
+    ... on UserAuthenticationWithPasswordFailure {
+      message
+    }
+  }
+}
+`
+
+class TokenManager {
+  // Singleton
+  static instance?: TokenManager
+  private email: string
+  private password: string
+  private token: string
+  private expiredAt?: number // timestamp
+
+  constructor(name: string, password: string) {
+    this.email = name
+    this.password = password
+    this.token = ''
+
+    if (TokenManager.instance) {
+      return TokenManager.instance
+    }
+
+    TokenManager.instance = this
+  }
+
+  /**
+   *  This function will return a cache token if token is existed and not expired.
+   */
+  async getToken() {
+    if (this.token && this.expiredAt && this.expiredAt >= Date.now()) {
+      return this.token
+    }
+
+    // fetch token
+    try {
+      const sessionToken = await this._fetchToken()
+      this.token = sessionToken
+
+      // @TODO expiry time should be returned by API
+      // So far, we set expiry time as one hour later
+      this.expiredAt = Date.now() + 3600 * 1000
+
+      return this.token
+    } catch (err) {
+      const annotatedErr = errors.helpers.wrap(
+        err,
+        'TokenManangerError',
+        'Fail to get session token',
+        {
+          accoutEmail: this.email,
+        }
+      )
+      throw annotatedErr
+    }
+  }
+
+  /**
+   *  This function will return a new token.
+   */
+  async renewToken() {
+    try {
+      const sessionToken = await this._fetchToken()
+      this.token = sessionToken
+
+      // @TODO expiry time should be returned by API
+      // So far, we set expiry time as one hour later
+      this.expiredAt = Date.now() + 3600 * 1000
+      return this.token
+    } catch (err) {
+      const annotatedErr = errors.helpers.wrap(
+        err,
+        'TokenManangerError',
+        'Fail to renew session token',
+        {
+          accoutEmail: this.email,
+        }
+      )
+      throw annotatedErr
+    }
+  }
+
+  async _fetchToken() {
+    let axiosRes
+    // fetch token
+    try {
+      const gqlEndpoint = apiOrigin + '/api/authenticate-user'
+      axiosRes = await axios.post(gqlEndpoint, {
+        query: gqlQuery,
+        variables: {
+          email: this.email,
+          password: this.password,
+        },
+      })
+    } catch (err) {
+      throw errors.helpers.annotateAxiosError(err)
+    }
+
+    const authenticationResult =
+      axiosRes.data?.data?.authenticateUserWithPassword
+    const errorMessage = authenticationResult?.message
+    if (errorMessage) {
+      throw new Error(errorMessage)
+    }
+
+    const sessionToken = authenticationResult?.sessionToken
+    return sessionToken
+  }
+}

--- a/packages/frontend/src/app/api/search/route.ts
+++ b/packages/frontend/src/app/api/search/route.ts
@@ -251,8 +251,15 @@ export async function GET(request: Request) {
         }),
       })
     )
-    return new Response(errors.helper.printOne(err), {
-      status: 500,
-    })
+
+    return NextResponse.json(
+      {
+        status: 'error',
+        message: errors.helper.printOne(err),
+      },
+      {
+        status: 500,
+      }
+    )
   }
 }

--- a/packages/frontend/src/app/environment-variables.ts
+++ b/packages/frontend/src/app/environment-variables.ts
@@ -1,9 +1,23 @@
 export const cmsOrigin =
   process.env.NEXT_PUBLIC_CMS_ORIGIN || 'http://localhost:3001'
+
 export const gqlEndpoint =
   process.env.NEXT_PUBLIC_GQL_ENDPOINT || 'http://localhost:3001/api/graphql'
 
+export const apiOrigin = process.env.API_ORIGIN || 'http://localhost:3000'
+
+// @TODO: get account and password from GCP Secret Mananger
+export const apiHeadlessAccountEmail =
+  process.env.API_HEADLESS_ACCOUNT_EMAIL ||
+  'change_environment_variable_to_set_up_account'
+export const apiHeadlessAccountPassword =
+  process.env.API_HEADLESS_ACCOUNT_PASSWORD ||
+  'change_environment_variable_to_set_up_password'
+
 export default {
+  apiOrigin,
+  apiHeadlessAccountEmail,
+  apiHeadlessAccountPassword,
   cmsOrigin,
   gqlEndpoint,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9563,13 +9563,13 @@ react-day-picker@^8.0.4:
   resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-8.8.0.tgz#582b9d5e54a84926f159be2b4004801707b3c885"
   integrity sha512-QIC3uOuyGGbtypbd5QEggsCSqVaPNu8kzUWquZ7JjW9fuWB9yv7WyixKmnaFelTLXFdq7h7zU6n/aBleBqe/dA==
 
-react-dom@18.2.0, react-dom@^18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
-  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
+react-dom@18.1.0, react-dom@18.2.0, react-dom@^18.2.0:
+  version "18.1.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.1.0.tgz#7f6dd84b706408adde05e1df575b3a024d7e8a2f"
+  integrity sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==
   dependencies:
     loose-envify "^1.1.0"
-    scheduler "^0.23.0"
+    scheduler "^0.22.0"
 
 react-fast-compare@^3.0.1, react-fast-compare@^3.1.1:
   version "3.2.2"
@@ -9691,14 +9691,7 @@ react-transition-group@^4.3.0, react-transition-group@^4.4.2, react-transition-g
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@18.2.0, react@^18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
-  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
-  dependencies:
-    loose-envify "^1.1.0"
-
-react@^18.1.0:
+react@18.1.0, react@18.2.0, react@^18.1.0, react@^18.2.0:
   version "18.1.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.1.0.tgz#6f8620382decb17fdc5cc223a115e2adbf104890"
   integrity sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==
@@ -10061,10 +10054,10 @@ sass@^1.64.0:
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 
-scheduler@^0.23.0:
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
-  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
+scheduler@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.22.0.tgz#83a5d63594edf074add9a7198b1bae76c3db01b8"
+  integrity sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==
   dependencies:
     loose-envify "^1.1.0"
 


### PR DESCRIPTION
### Notable Changes
For `frontend`:
- add `/api/graphql` endpoint on frontend server to re-compose authenticated requests to original GQL server

For `cms`:
- add authenticate middleware on `/api/graphql` endpoint
- add `/api/authenticate-user` endpoint

### 實作討論與細節
因為 GQL server 要實作 Access Control List (acl) 機制，所以會對進來的 requests 做認證（authentication）。
request 要能夠通過認證檢查，GQL server 才會繼續處理後續邏輯。

但因為 frontend server 在打 GQL server 時，並不會帶上 session token，所以對於 GQL server 來說，
frontend server 所發送的 request 都不會通過認證檢查。

此 PR 在 frontend server 上面增加了一個 `/api/endpoint`，該 api endpoint 接收 frontend server 或是 client side 所發送的「不帶認證資訊」的 requests，在該 api route 中，實作拿取 session token 邏輯，並將 frontend server 和 client side 發進來的 request 重組成「帶有認證資訊」的 request，再將重組後的 request 轉發到 original GQL server。
