### PR TITLE
Add api-gateway service to pass authentication to GraphQL API original server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,7 @@ config.js
 gcskeyfile.json
 .eslintcache
 
+# generated files
 packages/**/lib
+packages/**/dist
 # packages/**/public/*

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "packages/draft-editor",
     "packages/draft-renderer",
     "packages/cms",
-    "packages/frontend"
+    "packages/frontend",
+    "packages/api-gateway"
   ],
   "scripts": {
     "prepare": "husky install"

--- a/packages/api-gateway/Dockerfile
+++ b/packages/api-gateway/Dockerfile
@@ -1,0 +1,26 @@
+ARG NODE_VERSION=18.12.0
+
+FROM node:${NODE_VERSION} AS build
+
+WORKDIR /build
+
+COPY package.json yarn.lock /build/
+
+RUN yarn install
+
+COPY . /build/
+
+RUN yarn build
+
+
+FROM node:${NODE_VERSION}
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# Automatically leverage output traces to reduce image size
+COPY --from=build /build/node_modules ./node_modules
+COPY --from=build /build/dist ./dist
+
+CMD ["node", "dist/server.js"]

--- a/packages/api-gateway/Makefile
+++ b/packages/api-gateway/Makefile
@@ -1,0 +1,31 @@
+P := "\\033[32m[+]\\033[0m"
+
+help:
+	@echo "$(P) make build - Transpile typescript files"
+
+build-dist:
+	@echo "$(P) Transpile typescript files"
+	yarn tsc
+
+dev-server:
+	@echo "$(P) Start dev server"
+	yarn tsc && NODE_ENV=development node dist/server
+
+dev:
+	yarn nodemon -e ts --exec make dev-server
+
+start: build-dist
+	@echo "$(P) Start production server"
+	NODE_ENV=production node dist/server
+
+build: clean build-dist
+
+lint:
+	@echo "$(p) Start linting"
+	yarn eslint src --fix
+
+clean:
+	@echo "$(P) Clean dist/"
+	rm -rf dist/
+
+.PHONY: build clean build-dist

--- a/packages/api-gateway/README.md
+++ b/packages/api-gateway/README.md
@@ -1,0 +1,34 @@
+# API Gateway
+
+### Installation
+```
+$ yarn install
+```
+
+### Development
+```
+$ yarn dev
+// or
+$ make dev
+```
+
+### Build Transpiled Codes
+```
+$ yarn build
+// or
+$ make build
+```
+
+### Start Server on Production
+```
+// build first
+$ make build
+
+// start server
+$ make start
+// or
+$ yarn start
+```
+
+### 環境變數設定
+請見檔案 [`packages/api-gateway/src/environment-variables.ts`](https://github.com/kids-reporter/kids-reporter-monorepo/blob/dev/packages/api-gateway/src/environment-variables.ts)

--- a/packages/api-gateway/package.json
+++ b/packages/api-gateway/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@kids-reporter/api-gateway",
+  "type": "module",
+  "version": "0.4.30",
+  "scripts": {
+    "dev": "make dev",
+    "build": "make build",
+    "start": "make start",
+    "lint": "make lint",
+    "clean": "make clean",
+    "build-lib": "make build-lib"
+  },
+  "dependencies": {
+    "@twreporter/errors": "^1.1.2",
+    "axios": "^1.4.0",
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "http-proxy-middleware": "^2.0.6"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.20"
+  }
+}

--- a/packages/api-gateway/src/app.ts
+++ b/packages/api-gateway/src/app.ts
@@ -1,0 +1,88 @@
+// @ts-ignore `@twreporter/errors` does not have tyepscript definition file yet
+import _errors from '@twreporter/errors'
+import consts from './constants.js'
+import cors from 'cors'
+import express from 'express'
+import middlewareCreator from './middlewares/index.js'
+import { createGraphQLProxy } from './gql-proxy-mini-app.js'
+
+// @twreporter/errors is a cjs module, therefore, we need to use its default property
+const errors = _errors.default
+const statusCodes = consts.statusCodes
+
+/**
+ *  This function creates an express application.
+ *  This application aims to
+ *
+ *  1. create GraphQLProxy mini app. The mini app proxy incoming requests
+ *  to the backed API origin server.
+ */
+export function createApp({
+  gcpProjectId = 'kids-reporter',
+  corsAllowOrigin = [],
+  gql,
+}: {
+  gcpProjectId?: string
+  corsAllowOrigin: string[] | string
+  gql: {
+    headlessAccount: {
+      email: string
+      password: string
+    }
+    apiOrigin: string
+  }
+}) {
+  // create express app
+  const app = express()
+
+  const corsOpts = {
+    origin: corsAllowOrigin,
+  }
+
+  // common middlewares for every request
+  // 1. log requests
+  // 2. handle cors requests
+  app.use(middlewareCreator.createLoggerMw(gcpProjectId), cors(corsOpts))
+
+  // mini app: weekly GraphQL API
+  app.use(createGraphQLProxy(gql))
+
+  /**
+   *  Application level error handler
+   */
+  const errorHandler: express.ErrorRequestHandler = (err, req, res) => {
+    const annotatingError = errors.helpers.wrap(
+      err,
+      'UnknownError',
+      'Express error handler catches an unknown error'
+    )
+
+    const entry = Object.assign(
+      {
+        severity: 'ERROR',
+        // All exceptions that include a stack trace will be
+        // integrated with Error Reporting.
+        // See https://cloud.google.com/run/docs/error-reporting
+        message: errors.helpers.printAll(
+          annotatingError,
+          {
+            withStack: true,
+            withPayload: true,
+          },
+          0,
+          0
+        ),
+      },
+      res.locals.globalLogFields
+    )
+    console.error(JSON.stringify(entry))
+    res.status(statusCodes.internalServerError).send({
+      status: 'error',
+      error: annotatingError.error,
+    })
+  }
+
+  app.use(errorHandler)
+
+  return app
+}

--- a/packages/api-gateway/src/constants.ts
+++ b/packages/api-gateway/src/constants.ts
@@ -1,0 +1,8 @@
+const statusCodes = {
+  ok: 200,
+  unauthorized: 401,
+  internalServerError: 500,
+}
+export default {
+  statusCodes,
+}

--- a/packages/api-gateway/src/environment-variables.ts
+++ b/packages/api-gateway/src/environment-variables.ts
@@ -1,0 +1,45 @@
+const {
+  GCP_PROJECT_ID,
+  CORS_ALLOW_ORIGINS,
+  GQL_ORIGIN,
+  GQL_HEADLESS_ACCOUNT_EMAIL,
+  GQL_HEADLESS_ACCOUNT_PASSWORD,
+} = process.env
+
+/**
+ *
+ * @param {string} [cors]
+ * @returns {'*' | string[]}
+ */
+const getAllowOrigins = (cors: string) => {
+  if (cors === '*') {
+    return '*'
+  } else if (typeof cors === 'string') {
+    return cors.split(',')
+  } else {
+    return [
+      'https://kids.twreporter.org',
+      'https://dev-kids.twreporter.org',
+      'https://staging-kids.twreporter.org',
+    ]
+  }
+}
+const envVar = {
+  gcp: {
+    projectId: GCP_PROJECT_ID || 'kids-reporter',
+  },
+  apis: {
+    gql: {
+      origin: GQL_ORIGIN || 'http://localhost:3000',
+      headlessAccount: {
+        email: GQL_HEADLESS_ACCOUNT_EMAIL || '',
+        password: GQL_HEADLESS_ACCOUNT_PASSWORD || '',
+      },
+    },
+  },
+  cors: {
+    allowOrigins: getAllowOrigins(CORS_ALLOW_ORIGINS || ''),
+  },
+}
+
+export default envVar

--- a/packages/api-gateway/src/gql-proxy-mini-app.ts
+++ b/packages/api-gateway/src/gql-proxy-mini-app.ts
@@ -151,10 +151,10 @@ export function createGraphQLProxy({
   const router = express.Router()
 
   // enable pre-flight request
-  router.options('/graphql')
+  router.options('/api/graphql')
 
   router.post(
-    '/graphql',
+    '/api/graphql',
     async (req, res, next) => {
       console.log(
         JSON.stringify({
@@ -193,9 +193,6 @@ export function createGraphQLProxy({
     createProxyMiddleware({
       target: apiOrigin,
       changeOrigin: true,
-      pathRewrite: {
-        '/graphql': '/api/graphql',
-      },
       onProxyReq: (proxyReq, req, res) => {
         const token = res.locals.sessionToken
         const originalCookie = req.get('Cookie')

--- a/packages/api-gateway/src/gql-proxy-mini-app.ts
+++ b/packages/api-gateway/src/gql-proxy-mini-app.ts
@@ -1,0 +1,318 @@
+import axios from 'axios'
+import consts from './constants.js'
+// @ts-ignore `@twreporter/errors` does not have tyepscript definition file yet
+import _errors from '@twreporter/errors'
+import express from 'express'
+import { createProxyMiddleware } from 'http-proxy-middleware'
+
+// @twreporter/errors is a cjs module, therefore, we need to use its default property
+const errors = _errors.default
+
+const statusCodes = consts.statusCodes
+
+class TokenManager {
+  // Singleton
+  static instance?: TokenManager
+  private email: string
+  private password: string
+  private apiEndpoint: string
+  private token: string
+  private expiredAt?: number // timestamp
+
+  constructor(
+    email: string,
+    password: string,
+    apiEndpoint = 'http://localhost:3000/api/authenticate-user'
+  ) {
+    this.email = email
+    this.password = password
+    this.apiEndpoint = apiEndpoint
+    this.token = ''
+
+    if (TokenManager.instance) {
+      return TokenManager.instance
+    }
+
+    TokenManager.instance = this
+  }
+
+  /**
+   *  This function will return a cache token if token is existed and not expired.
+   */
+  async getToken() {
+    if (this.token && this.expiredAt && this.expiredAt >= Date.now()) {
+      return this.token
+    }
+
+    // fetch token
+    try {
+      const sessionToken = await this._fetchToken()
+      this.token = sessionToken
+
+      // @TODO expiry time should be returned by API
+      // So far, we set expiry time as one hour later
+      this.expiredAt = Date.now() + 3600 * 1000
+
+      return this.token
+    } catch (err) {
+      const annotatedErr = errors.helpers.wrap(
+        err,
+        'TokenManangerError',
+        'Fail to get session token',
+        {
+          accoutEmail: this.email,
+        }
+      )
+      throw annotatedErr
+    }
+  }
+
+  /**
+   *  This function will return a new token.
+   */
+  async renewToken() {
+    try {
+      const sessionToken = await this._fetchToken()
+      this.token = sessionToken
+
+      // @TODO expiry time should be returned by API
+      // So far, we set expiry time as one hour later
+      this.expiredAt = Date.now() + 3600 * 1000
+      return this.token
+    } catch (err) {
+      const annotatedErr = errors.helpers.wrap(
+        err,
+        'TokenManangerError',
+        'Fail to renew session token',
+        {
+          accoutEmail: this.email,
+        }
+      )
+      throw annotatedErr
+    }
+  }
+
+  async _fetchToken() {
+    const gqlQuery = `
+      mutation AuthenticateUserWithPassword($email: String!, $password: String!) {
+        authenticateUserWithPassword(email: $email, password: $password) {
+          ... on UserAuthenticationWithPasswordSuccess {
+            sessionToken
+          }
+          ... on UserAuthenticationWithPasswordFailure {
+            message
+          }
+        }
+      }
+    `
+
+    let axiosRes
+    // fetch token
+    try {
+      axiosRes = await axios.post(this.apiEndpoint, {
+        query: gqlQuery,
+        variables: {
+          email: this.email,
+          password: this.password,
+        },
+      })
+    } catch (err) {
+      throw errors.helpers.annotateAxiosError(err)
+    }
+
+    const authenticationResult =
+      axiosRes.data?.data?.authenticateUserWithPassword
+    const errorMessage = authenticationResult?.message
+    if (errorMessage) {
+      throw new Error(errorMessage)
+    }
+
+    const sessionToken = authenticationResult?.sessionToken
+    return sessionToken
+  }
+}
+
+/**
+ *  This function creates a `GraphQLProxy` mini app.
+ *  This mini app aims to add 'keystonejs-session' cookie on incoming requests' header
+ *  and proxy them to backed GraphQL API original server.
+ */
+export function createGraphQLProxy({
+  headlessAccount,
+  apiOrigin,
+}: {
+  headlessAccount: {
+    email: string
+    password: string
+  }
+  apiOrigin: string
+}) {
+  // create express mini app
+  const router = express.Router()
+
+  // enable pre-flight request
+  router.options('/graphql')
+
+  router.post(
+    '/graphql',
+    async (req, res, next) => {
+      console.log(
+        JSON.stringify({
+          severity: 'DEBUG',
+          message:
+            'Get session token before proxying requests to backed API original server.',
+          ...res?.locals?.globalLogFields,
+        })
+      )
+
+      try {
+        const tokenManager = new TokenManager(
+          headlessAccount.email,
+          headlessAccount.password,
+          apiOrigin + '/api/authenticate-user'
+        )
+        const token = await tokenManager.getToken()
+        res.locals.sessionToken = token
+      } catch (err) {
+        console.log(
+          JSON.stringify({
+            severity: 'ERROR',
+            message: errors.helpers.printAll(
+              err,
+              { withStack: true, withPayload: true },
+              0,
+              0
+            ),
+          })
+        )
+      }
+      next()
+    },
+
+    // proxy request to API GraphQL endpoint
+    createProxyMiddleware({
+      target: apiOrigin,
+      changeOrigin: true,
+      pathRewrite: {
+        '/graphql': '/api/graphql',
+      },
+      onProxyReq: (proxyReq, req, res) => {
+        const token = res.locals.sessionToken
+        const originalCookie = req.get('Cookie')
+        const cookie = originalCookie
+          ? originalCookie + ';keystonejs-session=' + token
+          : 'keystonejs-session=' + token
+
+        console.log(
+          JSON.stringify({
+            severity: 'DEBUG',
+            message:
+              'Proxy to backed API origin server: ' + apiOrigin + proxyReq.path,
+            ...res?.locals?.globalLogFields,
+            debugPayload: {
+              req: {
+                headers: {
+                  cookie: cookie,
+                  'content-type': 'application/json',
+                },
+              },
+            },
+          })
+        )
+        proxyReq.setHeader('Cookie', cookie)
+        proxyReq.setHeader('Content-Type', 'application/json')
+        proxyReq.setHeader('x-apollo-operation-name', '')
+      },
+
+      onProxyRes: async (proxyRes, req, res) => {
+        const statusCode = proxyRes.statusCode
+
+        // renew token if authentication fails
+        if (statusCode == 401) {
+          console.log(
+            JSON.stringify({
+              severity: 'DEBUG',
+              message: 'Renew session token due to 401 (unauthorized) response',
+              ...res?.locals?.globalLogFields,
+            })
+          )
+          try {
+            const tokenManager = new TokenManager(
+              headlessAccount.email,
+              headlessAccount.password,
+              apiOrigin + '/api/authenticate-user'
+            )
+            await tokenManager.renewToken()
+          } catch (err) {
+            const annotatedErr = errors.helpers.wrap(
+              err,
+              'GraphQLProxyError',
+              'Error to renew session token'
+            )
+            console.log(
+              JSON.stringify({
+                severity: 'ERROR',
+                message: errors.helpers.printAll(
+                  annotatedErr,
+                  { withStack: true, withPayload: true },
+                  0,
+                  0
+                ),
+              })
+            )
+          }
+        }
+      },
+
+      onError: (err, req, res, target) => { // eslint-disable-line
+        const annotatedErr = errors.helpers.wrap(
+          err,
+          'GraphQLProxyError',
+          `Error occurs while proxying request to API origin server: ${apiOrigin}` +
+            err.message
+        )
+
+        console.log(
+          JSON.stringify({
+            severity: 'ERROR',
+            message: errors.helpers.printAll(annotatedErr, {
+              withStack: true,
+              withPayload: true,
+            }),
+            ...res?.locals?.globalLogFields,
+          })
+        )
+
+        res.status(statusCodes.internalServerError).send({
+          status: 'error',
+          error: annotatedErr.message,
+        })
+      },
+    })
+  )
+
+  const errorHandler: express.ErrorRequestHandler = (err, req, res, next) => {
+    const annotatedErr = errors.helpers.wrap(
+      err,
+      'GraphQLProxyError',
+      'Unknow error happens when `GraphQLProxy` mini app deals with proxied requests and responses'
+    )
+    console.log(
+      JSON.stringify({
+        severity: 'ERROR',
+        message: errors.helpers.printAll(err, {
+          withStack: true,
+          withPayload: true,
+        }),
+        ...res?.locals?.globalLogFields,
+      })
+    )
+
+    // Let main application level error handle to deal with the error
+    next(annotatedErr)
+  }
+
+  router.use(errorHandler)
+
+  return router
+}

--- a/packages/api-gateway/src/middlewares/index.ts
+++ b/packages/api-gateway/src/middlewares/index.ts
@@ -1,0 +1,6 @@
+import { createLoggerMw } from './logger.js'
+const mws = {
+  createLoggerMw,
+}
+
+export default mws

--- a/packages/api-gateway/src/middlewares/logger.ts
+++ b/packages/api-gateway/src/middlewares/logger.ts
@@ -1,0 +1,54 @@
+import express from 'express' // eslint-disable-line
+
+/**
+ *  Follow [Writing structured logs](https://cloud.google.com/run/docs/logging#writing_structured_logs)
+ *  doc to do logging.
+ *
+ *  @param {Object} req
+ *  @param {Function} req
+ *  @param {string} projectId
+ *  @return {Object} globalLogFields
+ */
+function getGlobalLogFields(req: express.Request, projectId: string) {
+  const globalLogFields: { 'logging.googleapis.com/trace'?: string } = {}
+
+  // Add log correlation to nest all log messages beneath request log in Log Viewer.
+  const traceHeader = req.header('X-Cloud-Trace-Context')
+  if (traceHeader && projectId) {
+    const [trace] = traceHeader.split('/')
+    globalLogFields[
+      'logging.googleapis.com/trace'
+    ] = `projects/${projectId}/traces/${trace}`
+  }
+  return globalLogFields
+}
+
+/**
+ *  Create an express middleware to log request.
+ */
+export function createLoggerMw(projectId: string): express.RequestHandler {
+  const handler: express.RequestHandler = (req, res, next) => {
+    const globalLogFields = getGlobalLogFields(req, projectId)
+
+    console.log(
+      JSON.stringify({
+        severity: 'INFO',
+        message: `Request: ${req.method} ${req.originalUrl}`,
+        debugPayload: {
+          'req.headers': {
+            'Content-Length': req.get('Content-Length'),
+            'Content-Type': req.get('Content-Type'),
+            Authorization: req.get('Authorization'),
+          },
+          'req.body': req.body,
+        },
+        ...globalLogFields,
+      })
+    )
+
+    res.locals.globalLogFields = globalLogFields
+
+    next()
+  }
+  return handler
+}

--- a/packages/api-gateway/src/server.ts
+++ b/packages/api-gateway/src/server.ts
@@ -1,0 +1,62 @@
+import http from 'http'
+import { createApp } from './app.js'
+import envVar from './environment-variables.js'
+
+const port = process.env.PORT || '8080'
+
+async function start() {
+  let server: http.Server
+  try {
+    const app = createApp({
+      gcpProjectId: envVar.gcp.projectId,
+      corsAllowOrigin: envVar.cors.allowOrigins,
+      gql: {
+        headlessAccount: envVar.apis.gql.headlessAccount,
+        apiOrigin: envVar.apis.gql.origin,
+      },
+    })
+    server = http.createServer(app).listen(port, () => {
+      console.log(
+        JSON.stringify({
+          severity: 'NOTICE',
+          message: `server starts at port ${port}`,
+        })
+      )
+    })
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        severity: 'ALERT',
+        // All exceptions that include a stack trace will be
+        // integrated with Error Reporting.
+        // See https://cloud.google.com/run/docs/error-reporting
+        message:
+          err instanceof Error && err.stack
+            ? 'Error to start server: ' + err.stack
+            : new Error('Error to start server').stack,
+      })
+    )
+  }
+
+  process.on('SIGTERM', () => {
+    console.log('SIGTERM signal received')
+    if (server) {
+      console.log('Close HTTP server')
+      server.close(() => {
+        console.log('HTTP server closed')
+      })
+    }
+  })
+
+  process.on('SIGINT', () => {
+    console.log('SIGINT signal received')
+    if (server) {
+      console.log('Close HTTP server')
+      server.close(() => {
+        console.log('HTTP server closed')
+      })
+    }
+  })
+}
+
+start()

--- a/packages/api-gateway/tsconfig.json
+++ b/packages/api-gateway/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -19,12 +19,13 @@
     "@keystone-6/auth": "7.0.0",
     "@keystone-6/core": "5.2.0",
     "@kids-reporter/cms-core": "^0.4.31",
+    "@types/react-beautiful-dnd": "^13.1.4",
     "cors": "^2.8.5",
     "express": "^4.17.1",
+    "graphql-tag": "^2.12.6",
     "http-proxy-middleware": "^2.0.3",
     "patch-package": "^6.4.7",
-    "react-beautiful-dnd": "^13.1.1",
-    "@types/react-beautiful-dnd": "^13.1.4"
+    "react-beautiful-dnd": "^13.1.1"
   },
   "resolutions": {
     "**/next": "13.3.4",

--- a/packages/frontend/src/app/api/search/route.ts
+++ b/packages/frontend/src/app/api/search/route.ts
@@ -251,8 +251,15 @@ export async function GET(request: Request) {
         }),
       })
     )
-    return new Response(errors.helper.printOne(err), {
-      status: 500,
-    })
+
+    return NextResponse.json(
+      {
+        status: 'error',
+        message: errors.helper.printOne(err),
+      },
+      {
+        status: 500,
+      }
+    )
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4432,6 +4432,11 @@
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
+abbrev@1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
+  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
 abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
@@ -5207,7 +5212,7 @@ checkpoint-client@1.1.23:
     node-fetch "2.6.7"
     uuid "8.3.2"
 
-"chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.0, chokidar@^3.5.3:
+"chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.0, chokidar@^3.5.2, chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -6610,7 +6615,7 @@ execa@^7.1.1:
     signal-exit "^3.0.7"
     strip-final-newline "^3.0.0"
 
-express@^4.17.1, express@^4.17.3:
+express@^4.17.1, express@^4.17.3, express@^4.18.2:
   version "4.18.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz#3fabe08296e930c796c19e3c516979386ba9fd59"
   integrity sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==
@@ -7504,7 +7509,7 @@ http-proxy-agent@5.0.0, http-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
-http-proxy-middleware@^2.0.3:
+http-proxy-middleware@^2.0.3, http-proxy-middleware@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz#e1a4dd6979572c7ab5a4e4b55095d1f32a74963f"
   integrity sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==
@@ -7573,6 +7578,11 @@ ieee754@^1.1.13, ieee754@^1.1.4, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
+ignore-by-default@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
+  integrity sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==
 
 ignore-walk@^5.0.1:
   version "5.0.1"
@@ -8805,6 +8815,29 @@ node-releases@^2.0.13:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.13.tgz#d5ed1627c23e3461e819b02e57b75e4899b1c81d"
   integrity sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==
 
+nodemon@^2.0.20:
+  version "2.0.22"
+  resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-2.0.22.tgz#182c45c3a78da486f673d6c1702e00728daf5258"
+  integrity sha512-B8YqaKMmyuCO7BowF1Z1/mkPqLk6cs/l63Ojtd6otKjMx47Dq1utxfRxcavH1I7VSaL8n5BUaoutadnsX3AAVQ==
+  dependencies:
+    chokidar "^3.5.2"
+    debug "^3.2.7"
+    ignore-by-default "^1.0.1"
+    minimatch "^3.1.2"
+    pstree.remy "^1.1.8"
+    semver "^5.7.1"
+    simple-update-notifier "^1.0.7"
+    supports-color "^5.5.0"
+    touch "^3.1.0"
+    undefsafe "^2.0.5"
+
+nopt@~1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
+  integrity sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==
+  dependencies:
+    abbrev "1"
+
 normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -9442,6 +9475,11 @@ proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
+pstree.remy@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.8.tgz#c242224f4a67c21f686839bbdb4ac282b8373d3a"
+  integrity sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==
 
 pump@^3.0.0:
   version "3.0.0"
@@ -10101,7 +10139,7 @@ selfsigned@^2.1.1:
   dependencies:
     node-forge "^1"
 
-"semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.6.0, semver@^5.7.1:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
@@ -10117,6 +10155,11 @@ semver@^7.2.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@~7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
+  integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
 send@0.18.0:
   version "0.18.0"
@@ -10256,6 +10299,13 @@ signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+
+simple-update-notifier@^1.0.7:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz#67694c121de354af592b347cdba798463ed49c82"
+  integrity sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==
+  dependencies:
+    semver "~7.0.0"
 
 sirv@^1.0.7:
   version "1.0.19"
@@ -10911,6 +10961,13 @@ totalist@^1.0.0:
   resolved "https://registry.yarnpkg.com/totalist/-/totalist-1.1.0.tgz#a4d65a3e546517701e3e5c37a47a70ac97fe56df"
   integrity sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==
 
+touch@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/touch/-/touch-3.1.0.tgz#fe365f5f75ec9ed4e56825e0bb76d24ab74af83b"
+  integrity sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==
+  dependencies:
+    nopt "~1.0.10"
+
 tr46@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-3.0.0.tgz#555c4e297a950617e8eeddef633c87d4d9d6cbf9"
@@ -11106,6 +11163,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+undefsafe@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.5.tgz#38733b9327bdcd226db889fb723a6efd162e6e2c"
+  integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
 
 undici@5.21.0:
   version "5.21.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9563,13 +9563,13 @@ react-day-picker@^8.0.4:
   resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-8.8.0.tgz#582b9d5e54a84926f159be2b4004801707b3c885"
   integrity sha512-QIC3uOuyGGbtypbd5QEggsCSqVaPNu8kzUWquZ7JjW9fuWB9yv7WyixKmnaFelTLXFdq7h7zU6n/aBleBqe/dA==
 
-react-dom@18.2.0, react-dom@^18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
-  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
+react-dom@18.1.0, react-dom@18.2.0, react-dom@^18.2.0:
+  version "18.1.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.1.0.tgz#7f6dd84b706408adde05e1df575b3a024d7e8a2f"
+  integrity sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==
   dependencies:
     loose-envify "^1.1.0"
-    scheduler "^0.23.0"
+    scheduler "^0.22.0"
 
 react-fast-compare@^3.0.1, react-fast-compare@^3.1.1:
   version "3.2.2"
@@ -9691,14 +9691,7 @@ react-transition-group@^4.3.0, react-transition-group@^4.4.2, react-transition-g
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@18.2.0, react@^18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
-  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
-  dependencies:
-    loose-envify "^1.1.0"
-
-react@^18.1.0:
+react@18.1.0, react@18.2.0, react@^18.1.0, react@^18.2.0:
   version "18.1.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.1.0.tgz#6f8620382decb17fdc5cc223a115e2adbf104890"
   integrity sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==
@@ -10061,10 +10054,10 @@ sass@^1.64.0:
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 
-scheduler@^0.23.0:
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
-  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
+scheduler@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.22.0.tgz#83a5d63594edf074add9a7198b1bae76c3db01b8"
+  integrity sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==
   dependencies:
     loose-envify "^1.1.0"
 


### PR DESCRIPTION
### 前情提要
關於此 PR，可以先參考之前的討論 https://github.com/kids-reporter/kids-reporter-monorepo/pull/241 。
根據 PR 241 的討論結論，我們要將放在 `frontend` 上的 `/api/graphql` endpoint 移到此 PR 中的 `api-gateway` 服務上。


### Notable Changes
#### Add `packages/api-gateway` subpkg
For `api-gateway`:
- add `/api/graphql` endpoint: proxy incoming requests to original GQL server with session token

For `cms`:
- add authenticate middleware on `/api/graphql` endpoint
- add `/api/authenticate-user` endpoint

### 實作討論與細節
因為 GQL server 要實作 Access Control List (acl) 機制，所以會對進來的 requests 做認證（authentication）。
request 要能夠通過認證檢查，GQL server 才會繼續處理後續邏輯。

但因為 frontend server 在打 GQL server 時，並不會帶上 session token，所以對於 GQL server 來說，
frontend server 所發送的 request 都不會通過認證檢查。

此 PR 新增 `api-gateway` 服務，該服務有一個 `/api/graphql` endpoint，該 api endpoint 接收 frontend server 或是 client side 所發送的「不帶認證資訊」的 requests，在該 api route 中，實作拿取 session token 邏輯，並將 frontend server 和 client side 發進來的 request 附加上「帶有認證資訊」的 `Cookie` header，最後將 request proxy 到 original GQL server。
