### PR TITLE
fix(fe): remove themeColor field in post

### DIFF
--- a/packages/frontend/src/app/(sticky-header)/article/[slug]/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/article/[slug]/page.tsx
@@ -74,7 +74,6 @@ const postGQL = `
       }
       relatedPosts {
         title
-        themeColor
         slug
         publishedDate
         ${heroImageGQL}


### PR DESCRIPTION
由於https://github.com/kids-reporter/kids-reporter-monorepo/pull/356 post schema去除`themeColor`, fe query對應去除`themeColor`(article頁render不出來)