### PR TITLE
feat(cms): Add SVG upload support

### DIFF
--- a/packages/cms/keystone.ts
+++ b/packages/cms/keystone.ts
@@ -59,6 +59,15 @@ export default withAuth(
         },
         generateUrl: (path) => `/images${path}`,
       },
+      svgImages: {
+        kind: 'local',
+        type: 'file',
+        storagePath: appConfig.images.storagePath,
+        serverRoute: {
+          path: '/images',
+        },
+        generateUrl: (path) => `/images${path}`,
+      },
     },
     graphql: {
       apolloConfig: {

--- a/packages/cms/keystone.ts
+++ b/packages/cms/keystone.ts
@@ -59,15 +59,6 @@ export default withAuth(
         },
         generateUrl: (path) => `/images${path}`,
       },
-      svgImages: {
-        kind: 'local',
-        type: 'file',
-        storagePath: appConfig.images.storagePath,
-        serverRoute: {
-          path: '/images',
-        },
-        generateUrl: (path) => `/images${path}`,
-      },
     },
     graphql: {
       apolloConfig: {

--- a/packages/cms/lists/index.ts
+++ b/packages/cms/lists/index.ts
@@ -8,6 +8,7 @@ import Project from './project'
 import ProjectCategory from './project-category'
 import SubSubcategory from './sub-subcategory'
 import Subcategory from './subcatgory'
+import SVG from './svg'
 import Tag from './tag'
 import User from './user'
 import { NewsReadingGroup, NewsReadingGroupItem } from './news-reading'
@@ -39,6 +40,7 @@ export const listDefinition = {
   NewsReadingGroupItem,
   EditorPicksSetting,
   PDF,
+  SVG,
   //EditorChoice,
   //Video,
   //AudioFile: Audio,

--- a/packages/cms/lists/pdf.ts
+++ b/packages/cms/lists/pdf.ts
@@ -51,6 +51,9 @@ const listConfigurations = list({
           return code
         },
       }),
+      ui: {
+        views: './lists/views/embedded-code',
+      },
     }),
     createdAt: timestamp({
       defaultValue: { kind: 'now' },

--- a/packages/cms/lists/svg.ts
+++ b/packages/cms/lists/svg.ts
@@ -1,0 +1,80 @@
+import config from '../config'
+import { graphql, list } from '@keystone-6/core'
+import {
+  file,
+  text,
+  timestamp,
+  relationship,
+  virtual,
+} from '@keystone-6/core/fields'
+import {
+  allowAllRoles,
+  allowRoles,
+  RoleEnum,
+} from './utils/access-control-list'
+
+const listConfigurations = list({
+  fields: {
+    name: text({
+      label: '標題',
+      validation: { isRequired: true },
+    }),
+    svgFile: file({
+      storage: 'svgImages',
+    }),
+    authors: relationship({
+      label: '作者',
+      ref: 'Author',
+      many: true,
+    }),
+    embeddedCode: virtual({
+      field: graphql.field({
+        type: graphql.String,
+        async resolve(item: Record<string, any>, args, context) {
+          const itemId = item?.id
+          const { svgFile } = await context.query.SVG.findOne({
+            where: { id: itemId },
+            query: 'svgFile { url }',
+          })
+
+          return `<img src="${config.googleCloudStorage.origin}${svgFile.url}" alt="${item.name}">`
+        },
+      }),
+      ui: {
+        views: './lists/views/embedded-code',
+      },
+    }),
+    createdAt: timestamp({
+      defaultValue: { kind: 'now' },
+    }),
+    updatedAt: timestamp({
+      db: {
+        updatedAt: true,
+      },
+    }),
+  },
+  ui: {
+    label: 'SVG',
+    listView: {
+      initialColumns: ['name'],
+      initialSort: { field: 'updatedAt', direction: 'ASC' },
+      pageSize: 50,
+    },
+  },
+
+  access: {
+    operation: {
+      query: allowAllRoles(),
+      create: allowRoles([
+        RoleEnum.Owner,
+        RoleEnum.Admin,
+        RoleEnum.Editor,
+        RoleEnum.Contributor,
+      ]),
+      update: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+      delete: allowRoles([RoleEnum.Owner, RoleEnum.Admin, RoleEnum.Editor]),
+    },
+  },
+})
+
+export default listConfigurations

--- a/packages/cms/lists/svg.ts
+++ b/packages/cms/lists/svg.ts
@@ -20,7 +20,8 @@ const listConfigurations = list({
       validation: { isRequired: true },
     }),
     svgFile: file({
-      storage: 'svgImages',
+      label: '上傳 SVG 檔案',
+      storage: 'files',
     }),
     authors: relationship({
       label: '作者',

--- a/packages/cms/lists/views/authorsJSON-editor.tsx
+++ b/packages/cms/lists/views/authorsJSON-editor.tsx
@@ -6,7 +6,7 @@ import { Button } from '@keystone-ui/button'
 import { FieldContainer, FieldLabel, TextInput } from '@keystone-ui/fields'
 import { PlusCircleIcon, TrashIcon } from '@keystone-ui/icons'
 import { Divider } from '@keystone-ui/core'
-import { controller } from '@keystone-6/core/fields/types/json/views'
+import { controller } from '@keystone-6/core/fields/types/virtual/views'
 
 type Author = {
   id: string | undefined

--- a/packages/cms/lists/views/embedded-code.tsx
+++ b/packages/cms/lists/views/embedded-code.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react'
+import { FieldProps } from '@keystone-6/core/types'
+import { Button } from '@keystone-ui/button'
+import { FieldLabel, FieldContainer } from '@keystone-ui/fields'
+import { controller } from '@keystone-6/core/fields/types/json/views'
+
+export const Field = ({ value }: FieldProps<typeof controller>) => {
+  const DEFAULT_BUTTON_TEXT = 'Copy to Clipboard'
+  const COPIED_BUTTON_TEXT = 'Copied!'
+
+  const [buttonText, setButtonText] = useState(DEFAULT_BUTTON_TEXT)
+
+  const copyToClipboard = async () => {
+    await navigator.clipboard.writeText(value)
+    setButtonText(COPIED_BUTTON_TEXT)
+    setTimeout(() => setButtonText(DEFAULT_BUTTON_TEXT), 2000)
+  }
+
+  return (
+    <FieldContainer>
+      <FieldLabel>Embedded Code</FieldLabel>
+      <textarea
+        readOnly
+        value={value}
+        style={{
+          resize: 'vertical',
+          width: '100%',
+          minHeight: '80px',
+          maxHeight: '160px',
+          padding: '20px 30px',
+          borderRadius: '6px',
+          backgroundColor: '#fafbfc',
+        }}
+      />
+      <br />
+      <Button onClick={copyToClipboard}>{buttonText}</Button>
+    </FieldContainer>
+  )
+}

--- a/packages/cms/lists/views/embedded-code.tsx
+++ b/packages/cms/lists/views/embedded-code.tsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react'
 import { FieldProps } from '@keystone-6/core/types'
 import { Button } from '@keystone-ui/button'
 import { FieldLabel, FieldContainer } from '@keystone-ui/fields'
-import { controller } from '@keystone-6/core/fields/types/json/views'
+import { controller } from '@keystone-6/core/fields/types/virtual/views'
+import { TextArea } from '@keystone-ui/fields'
 
 export const Field = ({ value }: FieldProps<typeof controller>) => {
   const DEFAULT_BUTTON_TEXT = 'Copy to Clipboard'
@@ -19,20 +20,7 @@ export const Field = ({ value }: FieldProps<typeof controller>) => {
   return (
     <FieldContainer>
       <FieldLabel>Embedded Code</FieldLabel>
-      <textarea
-        readOnly
-        value={value}
-        style={{
-          resize: 'vertical',
-          width: '100%',
-          minHeight: '80px',
-          maxHeight: '160px',
-          padding: '20px 30px',
-          borderRadius: '6px',
-          backgroundColor: '#fafbfc',
-        }}
-      />
-      <br />
+      <TextArea readOnly value={value} />
       <Button onClick={copyToClipboard}>{buttonText}</Button>
     </FieldContainer>
   )

--- a/packages/cms/lists/views/link-button.tsx
+++ b/packages/cms/lists/views/link-button.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { FieldProps } from '@keystone-6/core/types'
 import { Button } from '@keystone-ui/button'
 import { FieldLabel, FieldContainer } from '@keystone-ui/fields'
-import { controller } from '@keystone-6/core/fields/types/json/views'
+import { controller } from '@keystone-6/core/fields/types/virtual/views'
 
 export const Field = ({ value }: FieldProps<typeof controller>) => {
   let href = ''

--- a/packages/cms/schema.graphql
+++ b/packages/cms/schema.graphql
@@ -1375,6 +1375,60 @@ input PDFCreateInput {
   updatedAt: DateTime
 }
 
+type SVG {
+  id: ID!
+  name: String
+  svgFile: FileFieldOutput
+  authors(where: AuthorWhereInput! = {}, orderBy: [AuthorOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AuthorWhereUniqueInput): [Author!]
+  authorsCount(where: AuthorWhereInput! = {}): Int
+  embeddedCode: String
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
+input SVGWhereUniqueInput {
+  id: ID
+}
+
+input SVGWhereInput {
+  AND: [SVGWhereInput!]
+  OR: [SVGWhereInput!]
+  NOT: [SVGWhereInput!]
+  id: IDFilter
+  name: StringFilter
+  authors: AuthorManyRelationFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+}
+
+input SVGOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+}
+
+input SVGUpdateInput {
+  name: String
+  svgFile: FileFieldInput
+  authors: AuthorRelateToManyForUpdateInput
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
+input SVGUpdateArgs {
+  where: SVGWhereUniqueInput!
+  data: SVGUpdateInput!
+}
+
+input SVGCreateInput {
+  name: String
+  svgFile: FileFieldInput
+  authors: AuthorRelateToManyForCreateInput
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
 """
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
@@ -1465,6 +1519,12 @@ type Mutation {
   updatePDFS(data: [PDFUpdateArgs!]!): [PDF]
   deletePDF(where: PDFWhereUniqueInput!): PDF
   deletePDFS(where: [PDFWhereUniqueInput!]!): [PDF]
+  createSVG(data: SVGCreateInput!): SVG
+  createSVGS(data: [SVGCreateInput!]!): [SVG]
+  updateSVG(where: SVGWhereUniqueInput!, data: SVGUpdateInput!): SVG
+  updateSVGS(data: [SVGUpdateArgs!]!): [SVG]
+  deleteSVG(where: SVGWhereUniqueInput!): SVG
+  deleteSVGS(where: [SVGWhereUniqueInput!]!): [SVG]
   endSession: Boolean!
   authenticateUserWithPassword(email: String!, password: String!): UserAuthenticationWithPasswordResult
   createInitialUser(data: CreateInitialUserInput!): UserAuthenticationWithPasswordSuccess!
@@ -1531,6 +1591,9 @@ type Query {
   pDFS(where: PDFWhereInput! = {}, orderBy: [PDFOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PDFWhereUniqueInput): [PDF!]
   pDF(where: PDFWhereUniqueInput!): PDF
   pDFSCount(where: PDFWhereInput! = {}): Int
+  sVGS(where: SVGWhereInput! = {}, orderBy: [SVGOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: SVGWhereUniqueInput): [SVG!]
+  sVG(where: SVGWhereUniqueInput!): SVG
+  sVGSCount(where: SVGWhereInput! = {}): Int
   keystone: KeystoneMeta!
   authenticatedItem: AuthenticatedItem
 }

--- a/packages/cms/schema.prisma
+++ b/packages/cms/schema.prisma
@@ -97,6 +97,7 @@ model Author {
   createdAt          DateTime? @default(now())
   updatedAt          DateTime? @updatedAt
   from_Photo_authors Photo[]   @relation("Photo_authors")
+  from_SVG_authors   SVG[]     @relation("SVG_authors")
 
   @@index([name])
   @@index([avatarId])
@@ -261,4 +262,14 @@ model PDF {
   updatedAt              DateTime? @updatedAt
 
   @@index([name])
+}
+
+model SVG {
+  id               Int       @id @default(autoincrement())
+  name             String    @default("")
+  svgFile_filesize Int?
+  svgFile_filename String?
+  authors          Author[]  @relation("SVG_authors")
+  createdAt        DateTime? @default(now())
+  updatedAt        DateTime? @updatedAt
 }


### PR DESCRIPTION
Add SVG upload support by:

- Add a new svgImages storage
- Add a new SVG list
- Add a new Embedded Code view

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205857712183793