### PR TITLE
fix(cms): update authorsJSON-editor.tsx. Rerender if `value` prop changed

### DIFF
--- a/packages/cms/lists/views/authorsJSON-editor.tsx
+++ b/packages/cms/lists/views/authorsJSON-editor.tsx
@@ -108,6 +108,13 @@ export const Field = ({
   )
   const [newAuthor, setNewAuthor] = useState<Author>({ ...authorTemplate })
 
+  const [prevValue, setPrevValue] = useState(value)
+
+  if (value !== prevValue) {
+    setPrevValue(value)
+    setAuthors(value ? JSON.parse(value) : [])
+  }
+
   const onAddNewAuthor = () => {
     if (onChange) {
       const newAuthors = [...authors, newAuthor]


### PR DESCRIPTION
### 問題描述
當編輯在文章頁修改 `authors` relationship 的值且儲存修改後，`authorsJSON` 欄位的值隨即更新，需要編輯重新整理頁面後，才能看到更新。

### 實作細節
當編輯儲存文章的修改後，文章頁會拿到最新的資料，並將資料透過 `value` prop 傳入 `Field` component，但因為 `authorsJSON-editor.tsx` 裡面的 `Field` 不是 pure functional component（因為有使用 `setState`），所以並不會因為 prop change 而 rerender；因此，此 PR 根據 [react 文件說明](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes) 要求 `Field` component rerender。