### PR TITLE
fix(fe): fix sticky header overlay issue

### DIFF
--- a/packages/frontend/src/app/components/header.tsx
+++ b/packages/frontend/src/app/components/header.tsx
@@ -146,7 +146,14 @@ export const StickyHeader = () => {
           />
         </Link>
         <div className="btn-group">
-          {ContributeBtn}
+          <Link
+            href="/about#post"
+            className="header-left__btn-1 rpjr-btn"
+            style={{ marginRight: '14px' }}
+            onClick={onHamburgerOverlayClose}
+          >
+            投稿
+          </Link>
           {SubscribeBtn}
           {AboutUsBtn}
         </div>

--- a/packages/frontend/src/app/components/header.tsx
+++ b/packages/frontend/src/app/components/header.tsx
@@ -151,7 +151,7 @@ export const StickyHeader = () => {
           {AboutUsBtn}
         </div>
         {searchInput}
-        <Navigation />
+        <Navigation onClick={onHamburgerOverlayClose} />
       </div>
     </div>
   )

--- a/packages/frontend/src/app/components/navigation.tsx
+++ b/packages/frontend/src/app/components/navigation.tsx
@@ -24,7 +24,7 @@ const NavigationItems = [
   },
 ]
 
-export const Navigation = () => {
+export const Navigation = (props: { onClick?: () => void }) => {
   return (
     <nav aria-label="頁首選單">
       <ul className="menu" role="menubar">
@@ -32,7 +32,13 @@ export const Navigation = () => {
           return (
             <li key={`header-nav-item-${index}`}>
               <Link href={item.link} className="ct-menu-link" role="menuitem">
-                {item.title}
+                <button
+                  onClick={() => {
+                    props.onClick?.()
+                  }}
+                >
+                  {item.title}
+                </button>
               </Link>
             </li>
           )

--- a/packages/frontend/src/app/components/navigation.tsx
+++ b/packages/frontend/src/app/components/navigation.tsx
@@ -31,14 +31,15 @@ export const Navigation = (props: { onClick?: () => void }) => {
         {NavigationItems.map((item, index) => {
           return (
             <li key={`header-nav-item-${index}`}>
-              <Link href={item.link} className="ct-menu-link" role="menuitem">
-                <button
-                  onClick={() => {
-                    props.onClick?.()
-                  }}
-                >
-                  {item.title}
-                </button>
+              <Link
+                href={item.link}
+                onClick={() => {
+                  props.onClick?.()
+                }}
+                className="ct-menu-link"
+                role="menuitem"
+              >
+                {item.title}
               </Link>
             </li>
           )

--- a/packages/frontend/src/app/components/navigation.tsx
+++ b/packages/frontend/src/app/components/navigation.tsx
@@ -1,3 +1,4 @@
+'use client'
 import Link from 'next/link'
 import { TOPIC_PAGE_ROUTE } from '@/app/constants'
 


### PR DESCRIPTION
[ticket](https://app.asana.com/0/1205517559975955/1206167731115721/f)

舊的overlay內的link是用`<a>`所以會reload, header state會重置所以沒有這個問題, 但`<a>`換成Next的`<Link>`就不會reload，雖然體驗更好但要額外加上handler來更新header state