### PR TITLE
refactor(frontend): update structed log to trigger error reporting

### DIFF
--- a/packages/frontend/src/app/utils/index.ts
+++ b/packages/frontend/src/app/utils/index.ts
@@ -56,9 +56,20 @@ export const log = (level: LogLevel = LogLevel.INFO, msg: string) => {
   })
 
   switch (level) {
-    case LogLevel.ERROR:
-      console.error(structuredMsg)
+    case LogLevel.ERROR: {
+      // Follow https://cloud.google.com/error-reporting/docs/formatting-error-messages doc to print structured error log
+      // and trigger GCP error reporting.
+      const errorLogEntry = {
+        severity: level,
+        jsonPayload: {
+          '@type':
+            'type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent',
+          message: msg,
+        },
+      }
+      console.error(JSON.stringify(errorLogEntry))
       return
+    }
     case LogLevel.WARNING:
       console.warn(structuredMsg)
       return


### PR DESCRIPTION
### Reason to Change
根據 [GCP 文件](https://cloud.google.com/error-reporting/docs/formatting-error-messages)說明，照理來說，我們只要在 message 欄位，印出 error stack trace，GCP 會自動將該 log 分類為 `ReportedErrorEvent`，並且觸發 error reporting。

但是經過測試，當 error stack trace 裡面出現特殊字元時，GCP 無法正確識別出 stack trace。
例如：
```
Error: Errors occured while executing `GetAProject` query
GraphQLError: Errors occured in rendering Project page
at TopicPage (/app/.next/server/app/(sticky-header)/topic/[slug]/page.js:1221:57)
```

在上述 stack trace 中，`(sticky-header)` 字串會讓 GCP 判斷失常。經測試，如果把 `(sticky-header)` 移除，就會正常觸發 error reporting。

但因為 stack trace 是 nodejs 產生的，程式碼無法調整，儘管可以調整，也難保有沒有其他特殊情況會造成 GCP 失常。

所以此 PR 根據文件提供的另外一個方法實作，以便可以觸發 error reporting。