### PR TITLE
fix(draft-renderer): image src is a relative path, and it is a wrong url

### DIFF
--- a/packages/draft-renderer/src/block-renderers/image-block.tsx
+++ b/packages/draft-renderer/src/block-renderers/image-block.tsx
@@ -36,6 +36,7 @@ type ImageBlockProps = {
       height: number
     }
     resized?: {
+      original: string
       small: string
       medium: string
       large: string
@@ -63,7 +64,7 @@ export function ImageBlock({ className = '', data }: ImageBlockProps) {
     <Figure className={className}>
       <Img
         alt={desc}
-        src={imageFile?.url}
+        src={resized?.original ?? resized?.medium}
         srcSet={imgSrcSetArr.join(',')}
         sizes="(min-width: 1200px) 1000px, 100vw"
         style={{ aspectRatio: aspectRatio }}


### PR DESCRIPTION
### Bug 說明
`<img>` 的 `src` attribute 取用 `imageFile.src`，但 `imageFile.src` 是一個 relative path，例如： `/images/e0ab00c8-61fe-4d93-b6a7-b10127eeb78b.jpg`。該 relative path 會產生錯誤的網址： `https://kids.twreporter.org/images/e0ab00c8-61fe-4d93-b6a7-b10127eeb78b.jpg`。
正確的網址應該是 `https://kids-storage.twreporter.org/images/e0ab00c8-61fe-4d93-b6a7-b10127eeb78b.jpg` 才對。