### PR TITLE
fix(fe): add img lazyload

### DIFF
--- a/packages/frontend/src/app/(sticky-header)/about/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/about/page.tsx
@@ -165,7 +165,7 @@ export default async function About() {
       style={{ width: '95vw', scrollMarginTop: '62px' }}
       className="max-w-2xl flex flex-col justify-center items-center gap-10"
     >
-      <img src={'/assets/images/about_who_we_are.svg'} />
+      <img src={'/assets/images/about_who_we_are.svg'} loading="lazy" />
       <p
         style={{ color: 'var(--paletteColor4)', letterSpacing: '0.9px' }}
         className="text-lg font-normal leading-9"
@@ -193,7 +193,11 @@ export default async function About() {
               key={`tell-you-${index}`}
               className="flex flex-col items-center"
             >
-              <img className="max-w-36 w-full" src={item.image} />
+              <img
+                className="max-w-36 w-full"
+                src={item.image}
+                loading="lazy"
+              />
               <p
                 style={{
                   color: 'var(--paletteColor4)',
@@ -225,22 +229,27 @@ export default async function About() {
         <img
           className="max-w-80 w-full"
           src={'/assets/images/about_news_pic1.svg'}
+          loading="lazy"
         />
         <img
           className="max-w-80 w-full"
           src={'/assets/images/about_news_pic2.svg'}
+          loading="lazy"
         />
         <img
           className="max-w-80 w-full"
           src={'/assets/images/about_news_pic3.svg'}
+          loading="lazy"
         />
         <img
           className="max-w-80 w-full"
           src={'/assets/images/about_news_pic4.svg'}
+          loading="lazy"
         />
         <img
           className="max-w-80 w-full"
           src={'/assets/images/about_news_pic5.svg'}
+          loading="lazy"
         />
       </div>
     </div>
@@ -288,6 +297,7 @@ export default async function About() {
       <img
         className="max-w-44 md:max-w-72 lg:max-w-80 w-full"
         src="/assets/images/about_CTA_subscribe.svg"
+        loading="lazy"
       />
     </div>
   )
@@ -321,7 +331,11 @@ export default async function About() {
       >
         《少年報導者》是一個開放的公共平台，報導仔希望聽見大家的看法和心聲，歡迎10～15歲的同學投稿給報導仔，針對新聞時事、國家政策、校園生活，或是藝術文化、運動體育，都可以寫下你的觀點、評論，讓報導仔協助你成為我們的評論員。
       </p>
-      <img className="max-w-2xl w-full" src={'/assets/images/about_road.svg'} />
+      <img
+        className="max-w-2xl w-full"
+        src={'/assets/images/about_road.svg'}
+        loading="lazy"
+      />
       <div className="flex flex-row justify-around items-start flex-wrap mt-10 mb-10 gap-10">
         <span
           style={{ color: 'var(--paletteColor8)', letterSpacing: '1.08px' }}
@@ -359,6 +373,7 @@ export default async function About() {
       <img
         className="max-w-4xl w-full"
         src={'/assets/images/about_certification_template.jpg'}
+        loading="lazy"
       />
       <p
         style={{ letterSpacing: '.08em', lineHeight: '160%' }}
@@ -417,6 +432,7 @@ export default async function About() {
       <img
         className="max-w-44 md:max-w-72 lg:max-w-80 w-full"
         src="/assets/images/about_CTA_mail.svg"
+        loading="lazy"
       />
     </div>
   )
@@ -433,6 +449,7 @@ export default async function About() {
       <img
         className="max-w-80 w-full mb-10"
         src={'/assets/images/about_go_to_main_site.png'}
+        loading="lazy"
       />
       <h3
         style={{

--- a/packages/frontend/src/app/(sticky-header)/all/[[...page]]/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/all/[[...page]]/page.tsx
@@ -88,7 +88,11 @@ export default async function LatestPosts({
       style={{ width: '95vw' }}
       className="flex flex-col justify-center items-center mb-10 gap-10"
     >
-      <img className="max-w-xl w-full" src={'/assets/images/new_article.svg'} />
+      <img
+        className="max-w-xl w-full"
+        src={'/assets/images/new_article.svg'}
+        loading="lazy"
+      />
       <PostList posts={postSummeries} />
       {totalPages && totalPages > 0 && (
         <Pagination

--- a/packages/frontend/src/app/(sticky-header)/article/[slug]/article.tsx
+++ b/packages/frontend/src/app/(sticky-header)/article/[slug]/article.tsx
@@ -159,7 +159,10 @@ export const Article = ({ post }: { post: any }) => {
           {topicURL && (
             <div className="topic-breadcrumb">
               <Link className="text-sm md:text-base lg:text-lg" href={topicURL}>
-                <img src="/assets/images/topic-breadcrumb-icon.svg" />
+                <img
+                  src="/assets/images/topic-breadcrumb-icon.svg"
+                  loading="lazy"
+                />
                 {mainTopic?.title}
               </Link>
             </div>

--- a/packages/frontend/src/app/(sticky-header)/article/[slug]/hero-image.tsx
+++ b/packages/frontend/src/app/(sticky-header)/article/[slug]/hero-image.tsx
@@ -26,6 +26,7 @@ export const HeroImage = (props: HeroImageProp) => {
               height: 'auto',
               aspectRatio: aspectRatio,
             }}
+            loading="lazy"
           />
         </div>
         <figcaption

--- a/packages/frontend/src/app/(sticky-header)/article/[slug]/hero-image.tsx
+++ b/packages/frontend/src/app/(sticky-header)/article/[slug]/hero-image.tsx
@@ -27,6 +27,7 @@ export const HeroImage = (props: HeroImageProp) => {
               aspectRatio: aspectRatio,
             }}
             loading="eager"
+            fetchPriority="high"
           />
         </div>
         <figcaption

--- a/packages/frontend/src/app/(sticky-header)/article/[slug]/hero-image.tsx
+++ b/packages/frontend/src/app/(sticky-header)/article/[slug]/hero-image.tsx
@@ -26,7 +26,7 @@ export const HeroImage = (props: HeroImageProp) => {
               height: 'auto',
               aspectRatio: aspectRatio,
             }}
-            loading="lazy"
+            loading="eager"
           />
         </div>
         <figcaption

--- a/packages/frontend/src/app/(sticky-header)/article/[slug]/related-posts.tsx
+++ b/packages/frontend/src/app/(sticky-header)/article/[slug]/related-posts.tsx
@@ -11,6 +11,7 @@ export const RelatedPosts = (props: PostSliderProp) => {
           className="w-full h-20 mb-4 "
           src="/assets/images/post-related-post-title.svg"
           alt="相關文章"
+          loading="lazy"
         />
         <PostSlider {...props} />
       </div>

--- a/packages/frontend/src/app/(sticky-header)/article/[slug]/sidebar.tsx
+++ b/packages/frontend/src/app/(sticky-header)/article/[slug]/sidebar.tsx
@@ -178,7 +178,7 @@ export const MobileSidebar = ({ topicURL }: SidebarProp) => {
               onClick={onShareClick}
             >
               <img
-                src={`/assets/images/mobile-sidebar-share.svg`}
+                src="/assets/images/mobile-sidebar-share.svg"
                 loading="lazy"
               />
             </button>

--- a/packages/frontend/src/app/(sticky-header)/article/[slug]/sidebar.tsx
+++ b/packages/frontend/src/app/(sticky-header)/article/[slug]/sidebar.tsx
@@ -63,7 +63,10 @@ export const Sidebar = ({ topicURL }: SidebarProp) => {
         {topicURL && (
           <div>
             <Link href={topicURL}>
-              <img src="/assets/images/topic-breadcrumb-sidebar-icon.svg" />
+              <img
+                src="/assets/images/topic-breadcrumb-sidebar-icon.svg"
+                loading="lazy"
+              />
             </Link>
           </div>
         )}
@@ -82,7 +85,7 @@ export const Sidebar = ({ topicURL }: SidebarProp) => {
                 key={`share-icon-${index}`}
                 onClick={icon.onClick}
               >
-                <img src={`/assets/images/${icon.image}`} />
+                <img src={`/assets/images/${icon.image}`} loading="lazy" />
               </button>
             )
           })}
@@ -93,14 +96,20 @@ export const Sidebar = ({ topicURL }: SidebarProp) => {
             className="w-12 flex flex-col justify-center items-center appearance-none bg-transparent border-none cursor-pointer"
             onClick={onFontSizeChange}
           >
-            <img src={`/assets/images/rpjr-icon-color-text.svg`} />
+            <img
+              src={`/assets/images/rpjr-icon-color-text.svg`}
+              loading="lazy"
+            />
           </button>
           <button
             style={{ aspectRatio: '1/1' }}
             className="w-12 flex flex-col justify-center items-center appearance-none bg-transparent border-none cursor-pointer"
             onClick={() => window.print()}
           >
-            <img src={`/assets/images/rpjr-icon-color-print.svg`} />
+            <img
+              src={`/assets/images/rpjr-icon-color-print.svg`}
+              loading="lazy"
+            />
           </button>
         </div>
       </div>
@@ -132,7 +141,7 @@ export const MobileSidebar = ({ topicURL }: SidebarProp) => {
                   key={`share-icon-${index}`}
                   onClick={icon.onClick}
                 >
-                  <img src={`/assets/images/${icon.image}`} />
+                  <img src={`/assets/images/${icon.image}`} loading="lazy" />
                 </button>
               )
             })}
@@ -149,7 +158,10 @@ export const MobileSidebar = ({ topicURL }: SidebarProp) => {
                 className="flex flex-col justify-center items-center appearance-none bg-transparent w-12 cursor-pointer border-none"
                 href={topicURL}
               >
-                <img src="/assets/images/topic-breadcrumb-sidebar-mobile-icon.svg" />
+                <img
+                  src="/assets/images/topic-breadcrumb-sidebar-mobile-icon.svg"
+                  loading="lazy"
+                />
               </Link>
               <span
                 style={{ lineHeight: '160%', letterSpacing: '0.08em' }}
@@ -165,7 +177,10 @@ export const MobileSidebar = ({ topicURL }: SidebarProp) => {
               className="block appearance-none bg-transparent w-12 cursor-pointer border-none"
               onClick={onShareClick}
             >
-              <img src={`/assets/images/mobile-sidebar-share.svg`} />
+              <img
+                src={`/assets/images/mobile-sidebar-share.svg`}
+                loading="lazy"
+              />
             </button>
             <span
               style={{ lineHeight: '160%', letterSpacing: '0.08em' }}
@@ -180,7 +195,10 @@ export const MobileSidebar = ({ topicURL }: SidebarProp) => {
               className="block appearance-none bg-transparent w-12 cursor-pointer border-none"
               onClick={onFontSizeChange}
             >
-              <img src={`/assets/images/mobile-sidebar-change-font.svg`} />
+              <img
+                src={`/assets/images/mobile-sidebar-change-font.svg`}
+                loading="lazy"
+              />
             </button>
             <span
               style={{ lineHeight: '160%', letterSpacing: '0.08em' }}

--- a/packages/frontend/src/app/(sticky-header)/article/[slug]/sidebar.tsx
+++ b/packages/frontend/src/app/(sticky-header)/article/[slug]/sidebar.tsx
@@ -196,7 +196,7 @@ export const MobileSidebar = ({ topicURL }: SidebarProp) => {
               onClick={onFontSizeChange}
             >
               <img
-                src={`/assets/images/mobile-sidebar-change-font.svg`}
+                src="/assets/images/mobile-sidebar-change-font.svg"
                 loading="lazy"
               />
             </button>

--- a/packages/frontend/src/app/(sticky-header)/author/[[...slug]]/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/author/[[...slug]]/page.tsx
@@ -145,6 +145,7 @@ export default async function Author({ params }: { params: { slug: any } }) {
             className="max-w-44 max-h-44 w-full object-cover"
             src={avatarURL}
             alt={author.name}
+            loading="lazy"
           />
         </div>
         <h1

--- a/packages/frontend/src/app/(sticky-header)/category/[[...path]]/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/category/[[...path]]/page.tsx
@@ -275,7 +275,7 @@ export default async function Category({ params }: { params: { path: any } }) {
       <div
         className={`w-full flex flex-col justify-center items-center gap-10 theme-${theme}`}
       >
-        <img className="max-w-xl w-full" src={imageURL} />
+        <img className="max-w-xl w-full" src={imageURL} loading="lazy" />
         <div className="flex flex-row flex-wrap justify-center gap-2.5">
           {navigationItems?.map(
             (item, index) =>

--- a/packages/frontend/src/app/(sticky-header)/error/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/error/page.tsx
@@ -8,6 +8,7 @@ export default async function Error() {
         className="max-w-72 md:max-w-md lg:max-w-xl w-full mt-20 mb-16"
         src="./assets/images/500_error.png"
         alt="500 Internal Server Error"
+        loading="lazy"
       />
       <div className="flex flex-col justify-center items-center gap-2.5">
         <h1 className="text-3xl md:text-4xl font-bold">伺服器遭遇困難⋯⋯</h1>

--- a/packages/frontend/src/app/(sticky-header)/topic/page/[[...pageNum]]/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/topic/page/[[...pageNum]]/page.tsx
@@ -74,13 +74,18 @@ const TopicCard = (props: { topic: TopicSummary }) => {
           <img
             className="w-full h-full object-cover align-middle"
             src={topic.image}
+            loading="lazy"
           />
         </div>
         <div
           style={{ width: 'fit-content', height: 'fit-content', zIndex: '2' }}
           className="absolute top-5 left-5 bg-white lg:hidden flex flex-row items-center rounded-3xl px-4 py-1 gap-1"
         >
-          <img className="w-10" src={'/assets/images/topic_icon.svg'} />
+          <img
+            className="w-10"
+            src={'/assets/images/topic_icon.svg'}
+            loading="lazy"
+          />
           <span
             style={{ lineHeight: '160%', letterSpacing: '0.08em' }}
             className="font-bold text-xl"
@@ -92,7 +97,11 @@ const TopicCard = (props: { topic: TopicSummary }) => {
           className={`${styles['topic-info']} flex flex-col justify-between items-start bg-white border-solid border-gray-300`}
         >
           <div className="w-full hidden lg:flex flex-row items-center gap-1">
-            <img className="max-w-10" src={'/assets/images/topic_icon.svg'} />
+            <img
+              className="max-w-10"
+              src={'/assets/images/topic_icon.svg'}
+              loading="lazy"
+            />
             <span
               style={{ lineHeight: '160%', letterSpacing: '0.08em' }}
               className="font-bold text-xl"
@@ -213,7 +222,11 @@ export default async function Topic({
       className={`${styles.main} flex flex-col justify-center items-center mb-10`}
     >
       <div className="max-w-7xl w-full flex flex-col justify-center items-center gap-10">
-        <img className="max-w-xl w-full" src={'/assets/images/topic_pic.svg'} />
+        <img
+          className="max-w-xl w-full"
+          src={'/assets/images/topic_pic.svg'}
+          loading="lazy"
+        />
         {featuredTopic && (
           <div className="w-full flex flex-col justify-center bg-white lg:bg-gray-100 p-0 lg:p-5 gap-5 rounded-3xl">
             <TopicCard topic={featuredTopic} />

--- a/packages/frontend/src/app/(sticky-header)/topic/page/[[...pageNum]]/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/topic/page/[[...pageNum]]/page.tsx
@@ -59,6 +59,8 @@ type TopicSummary = {
   relatedPosts?: any[]
 }
 
+const topicIcon = '/assets/images/topic_icon.svg'
+
 const TopicCard = (props: { topic: TopicSummary }) => {
   const moreComponent = (
     <div className={`rpjr-btn rpjr-btn-theme-outline theme-blue`}>
@@ -81,11 +83,7 @@ const TopicCard = (props: { topic: TopicSummary }) => {
           style={{ width: 'fit-content', height: 'fit-content', zIndex: '2' }}
           className="absolute top-5 left-5 bg-white lg:hidden flex flex-row items-center rounded-3xl px-4 py-1 gap-1"
         >
-          <img
-            className="w-10"
-            src={'/assets/images/topic_icon.svg'}
-            loading="lazy"
-          />
+          <img className="w-10" src={topicIcon} loading="lazy" />
           <span
             style={{ lineHeight: '160%', letterSpacing: '0.08em' }}
             className="font-bold text-xl"
@@ -97,11 +95,7 @@ const TopicCard = (props: { topic: TopicSummary }) => {
           className={`${styles['topic-info']} flex flex-col justify-between items-start bg-white border-solid border-gray-300`}
         >
           <div className="w-full hidden lg:flex flex-row items-center gap-1">
-            <img
-              className="max-w-10"
-              src={'/assets/images/topic_icon.svg'}
-              loading="lazy"
-            />
+            <img className="max-w-10" src={topicIcon} loading="lazy" />
             <span
               style={{ lineHeight: '160%', letterSpacing: '0.08em' }}
               className="font-bold text-xl"

--- a/packages/frontend/src/app/components/author-card.tsx
+++ b/packages/frontend/src/app/components/author-card.tsx
@@ -56,6 +56,7 @@ export const AuthorCard = (props: AuthorCardProp) => {
                       className="max-w-full align-middle"
                       src={avatarURL}
                       alt={author.name}
+                      loading="lazy"
                     />
                   </div>
                   <span

--- a/packages/frontend/src/app/components/footer.tsx
+++ b/packages/frontend/src/app/components/footer.tsx
@@ -53,7 +53,7 @@ export const Footer = () => {
         >
           <div className={styles['footer-top__left']}>
             <picture className={styles['footer-top__left-logo']}>
-              <img src="/assets/images/footer-logo.svg" alt="" />
+              <img src="/assets/images/footer-logo.svg" alt="" loading="lazy" />
             </picture>
             <p
               style={{ letterSpacing: 'var(--letterSpacing)' }}
@@ -84,28 +84,44 @@ export const Footer = () => {
                 href="/about"
                 className={styles['footer-top__team-box-item']}
               >
-                <img src="/assets/images/footer_pic1.svg" alt="我們是誰" />
+                <img
+                  src="/assets/images/footer_pic1.svg"
+                  alt="我們是誰"
+                  loading="lazy"
+                />
                 我們是誰
               </Link>
               <Link
                 href="/about#team"
                 className={`${styles['footer-top__team-box-item']} __mPS2id`}
               >
-                <img src="/assets/images/footer_pic2.svg" alt="我們是誰" />
+                <img
+                  src="/assets/images/footer_pic2.svg"
+                  alt="我們是誰"
+                  loading="lazy"
+                />
                 核心團隊
               </Link>
               <Link
                 href="/about#consultants"
                 className={`${styles['footer-top__team-box-item']} __mPS2id`}
               >
-                <img src="/assets/images/footer_pic3.svg" alt="我們是誰" />
+                <img
+                  src="/assets/images/footer_pic3.svg"
+                  alt="我們是誰"
+                  loading="lazy"
+                />
                 顧問群
               </Link>
               <Link
                 href="/about#mail"
                 className={`${styles['footer-top__team-box-item']} __mPS2id`}
               >
-                <img src="/assets/images/footer_pic4.svg" alt="我們是誰" />
+                <img
+                  src="/assets/images/footer_pic4.svg"
+                  alt="我們是誰"
+                  loading="lazy"
+                />
                 聯絡我們
               </Link>
             </div>
@@ -137,6 +153,7 @@ export const Footer = () => {
             <img
               src="/assets/images/footer_pic5.svg"
               className={styles['footer-top__fig']}
+              loading="lazy"
             />
           </div>
         </div>

--- a/packages/frontend/src/app/components/header.tsx
+++ b/packages/frontend/src/app/components/header.tsx
@@ -6,7 +6,9 @@ import { CrossIcon, HamburgerIcon, SearchIcon } from '@/app/icons'
 import { SUBSCRIBE_URL, SEARCH_PLACEHOLDER } from '@/app/constants'
 import styles from './header.module.css'
 
-const slogan = <img src="/assets/images/header-left-slogan.svg" />
+const slogan = (
+  <img src="/assets/images/header-left-slogan.svg" loading="lazy" />
+)
 
 const ContributeBtn = (
   <Link
@@ -73,6 +75,7 @@ export const StickyHeader = () => {
           src="/assets/images/LOGO.svg"
           className="h-8 object-contain"
           alt="少年報導者 The Reporter for Kids"
+          loading="lazy"
         />
       </Link>
     </div>
@@ -167,6 +170,7 @@ export const StickyHeader = () => {
             className="w-auto object-contain"
             src="/assets/images/logo-full.svg"
             alt="少年報導者 The Reporter for Kids"
+            loading="lazy"
           />
         </Link>
         <div className="flex flex-row flex-wrap justify-center sm:mt-10 md:mt-10 mt-16 mb-10">

--- a/packages/frontend/src/app/components/header.tsx
+++ b/packages/frontend/src/app/components/header.tsx
@@ -7,7 +7,7 @@ import { SUBSCRIBE_URL, SEARCH_PLACEHOLDER } from '@/app/constants'
 import styles from './header.module.css'
 
 const slogan = (
-  <img src="/assets/images/header-left-slogan.svg" loading="lazy" />
+  <img src="/assets/images/header-left-slogan.svg" loading="eager" />
 )
 
 const ContributeBtn = (
@@ -75,7 +75,7 @@ export const StickyHeader = () => {
           src="/assets/images/LOGO.svg"
           className="h-8 object-contain"
           alt="少年報導者 The Reporter for Kids"
-          loading="lazy"
+          loading="eager"
         />
       </Link>
     </div>
@@ -170,7 +170,7 @@ export const StickyHeader = () => {
             className="w-auto object-contain"
             src="/assets/images/logo-full.svg"
             alt="少年報導者 The Reporter for Kids"
-            loading="lazy"
+            loading="eager"
           />
         </Link>
         <div className="flex flex-row flex-wrap justify-center sm:mt-10 md:mt-10 mt-16 mb-10">

--- a/packages/frontend/src/app/components/post-card.tsx
+++ b/packages/frontend/src/app/components/post-card.tsx
@@ -4,16 +4,23 @@ import { getFormattedDate } from '@/app/utils'
 
 const fallbackImg = '/assets/images/404.png'
 
+export enum Loading {
+  LAZY = 'lazy',
+  EAGER = 'eager',
+}
+
 export type PostCardProp = {
   className?: string
   post: PostSummary
   isSimple?: boolean
+  loading?: Loading
 }
 
 export const PostCard = ({
   className,
   post,
   isSimple = false,
+  loading = Loading.LAZY,
 }: PostCardProp) => {
   return (
     post && (
@@ -31,7 +38,7 @@ export const PostCard = ({
             style={{ borderRadius: isSimple ? '20px 20px 0 0' : '20px' }}
             className={`w-full h-full object-cover align-middle overflow-hidden rounded-2xl`}
             src={post.image ?? fallbackImg}
-            loading="lazy"
+            loading={loading}
           />
         </div>
         <div

--- a/packages/frontend/src/app/components/post-card.tsx
+++ b/packages/frontend/src/app/components/post-card.tsx
@@ -31,6 +31,7 @@ export const PostCard = ({
             style={{ borderRadius: isSimple ? '20px 20px 0 0' : '20px' }}
             className={`w-full h-full object-cover align-middle overflow-hidden rounded-2xl`}
             src={post.image ?? fallbackImg}
+            loading="lazy"
           />
         </div>
         <div

--- a/packages/frontend/src/app/constants/index.ts
+++ b/packages/frontend/src/app/constants/index.ts
@@ -102,7 +102,7 @@ slug
 ogDescription
 heroImage {
   resized {
-    medium
+    small
   }
 }
 subSubcategoriesOrdered {

--- a/packages/frontend/src/app/home/main-header.tsx
+++ b/packages/frontend/src/app/home/main-header.tsx
@@ -82,7 +82,7 @@ export const MainHeader = () => {
               className="h-auto max-w-full align-middle"
               src="/assets/images/navbar_pic.svg"
               width="291"
-              loading="lazy"
+              loading="eager"
             />
           </div>
           <div className={`${styles.menu} h-72 flex flex-col justify-end`}>
@@ -91,7 +91,7 @@ export const MainHeader = () => {
                 className="max-w-80 mb-10"
                 src="/assets/images/logo-full.svg"
                 alt="少年報導者 The Reporter for Kids"
-                loading="lazy"
+                loading="eager"
               />
             </Link>
             <Navigation />

--- a/packages/frontend/src/app/home/main-header.tsx
+++ b/packages/frontend/src/app/home/main-header.tsx
@@ -82,6 +82,7 @@ export const MainHeader = () => {
               className="h-auto max-w-full align-middle"
               src="/assets/images/navbar_pic.svg"
               width="291"
+              loading="lazy"
             />
           </div>
           <div className={`${styles.menu} h-72 flex flex-col justify-end`}>
@@ -90,6 +91,7 @@ export const MainHeader = () => {
                 className="max-w-80 mb-10"
                 src="/assets/images/logo-full.svg"
                 alt="少年報導者 The Reporter for Kids"
+                loading="lazy"
               />
             </Link>
             <Navigation />

--- a/packages/frontend/src/app/home/main-slider.tsx
+++ b/packages/frontend/src/app/home/main-slider.tsx
@@ -81,6 +81,7 @@ export const MainSlider = (props: SliderProp) => {
                     <img
                       className="w-8 md:w-10"
                       src={'/assets/images/topic_icon.svg'}
+                      loading="lazy"
                     />
                     <span
                       style={{ lineHeight: '160%', letterSpacing: '0.08em' }}
@@ -100,6 +101,7 @@ export const MainSlider = (props: SliderProp) => {
                       <img
                         className="w-full h-full object-cover rounded-none md:rounded-2xl"
                         src={topic.image}
+                        loading="lazy"
                       />
                     </div>
                     <span

--- a/packages/frontend/src/app/home/main-slider.tsx
+++ b/packages/frontend/src/app/home/main-slider.tsx
@@ -81,7 +81,7 @@ export const MainSlider = (props: SliderProp) => {
                     <img
                       className="w-8 md:w-10"
                       src={'/assets/images/topic_icon.svg'}
-                      loading="lazy"
+                      loading="eager"
                     />
                     <span
                       style={{ lineHeight: '160%', letterSpacing: '0.08em' }}
@@ -101,7 +101,7 @@ export const MainSlider = (props: SliderProp) => {
                       <img
                         className="w-full h-full object-cover rounded-none md:rounded-2xl"
                         src={topic.image}
-                        loading="lazy"
+                        loading="eager"
                       />
                     </div>
                     <span

--- a/packages/frontend/src/app/home/main-slider.tsx
+++ b/packages/frontend/src/app/home/main-slider.tsx
@@ -102,6 +102,7 @@ export const MainSlider = (props: SliderProp) => {
                         className="w-full h-full object-cover rounded-none md:rounded-2xl"
                         src={topic.image}
                         loading="eager"
+                        fetchPriority="high"
                       />
                     </div>
                     <span

--- a/packages/frontend/src/app/home/make-friend.tsx
+++ b/packages/frontend/src/app/home/make-friend.tsx
@@ -38,6 +38,7 @@ export const MakeFriends = () => {
         <img
           className="max-w-44 lg:max-w-80 w-full"
           src={'/assets/images/reporter_pic.svg'}
+          loading="lazy"
         />
       </div>
     </div>

--- a/packages/frontend/src/app/home/post-selection.tsx
+++ b/packages/frontend/src/app/home/post-selection.tsx
@@ -55,6 +55,7 @@ export const PostSelection = (props: PostSelectionProp) => {
         className="max-w-52 w-full my-8 mx-auto"
         src={'/assets/images/selected_news.png'}
         alt="精選文章"
+        loading="lazy"
       />
       <div className="max-w-screen-xl flex flex-col lg:flex-row p-6 gap-10">
         <div
@@ -66,7 +67,7 @@ export const PostSelection = (props: PostSelectionProp) => {
               style={{ lineHeight: '160%', letterSpacing: '.08em' }}
               className="flex items-center font-bold text-xl text-gray-900 gap-2.5"
             >
-              <img src={'/assets/images/home-icon-clock.svg'} />
+              <img src={'/assets/images/home-icon-clock.svg'} loading="lazy" />
               最新文章
             </span>
             <Link

--- a/packages/frontend/src/app/home/post-selection.tsx
+++ b/packages/frontend/src/app/home/post-selection.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import PostCard from '@/app/components/post-card'
+import PostCard, { Loading } from '@/app/components/post-card'
 import { PostSummary } from '@/app/components/types'
 import { getFormattedDate } from '@/app/utils'
 import styles from './post-selection.module.css'
@@ -55,7 +55,7 @@ export const PostSelection = (props: PostSelectionProp) => {
         className="max-w-52 w-full my-8 mx-auto"
         src={'/assets/images/selected_news.png'}
         alt="精選文章"
-        loading="lazy"
+        loading="eager"
       />
       <div className="max-w-screen-xl flex flex-col lg:flex-row p-6 gap-10">
         <div
@@ -67,7 +67,7 @@ export const PostSelection = (props: PostSelectionProp) => {
               style={{ lineHeight: '160%', letterSpacing: '.08em' }}
               className="flex items-center font-bold text-xl text-gray-900 gap-2.5"
             >
-              <img src={'/assets/images/home-icon-clock.svg'} loading="lazy" />
+              <img src={'/assets/images/home-icon-clock.svg'} loading="eager" />
               最新文章
             </span>
             <Link
@@ -99,27 +99,47 @@ export const PostSelection = (props: PostSelectionProp) => {
             >
               <div className={`${styles['card-child-1']}`}>
                 {featuredPosts?.[0] && (
-                  <PostCard post={featuredPosts[0]} isSimple={true} />
+                  <PostCard
+                    post={featuredPosts[0]}
+                    isSimple={true}
+                    loading={Loading.EAGER}
+                  />
                 )}
               </div>
               <div className={`${styles['card-child-2']}`}>
                 {featuredPosts?.[1] && (
-                  <PostCard post={featuredPosts[1]} isSimple={true} />
+                  <PostCard
+                    post={featuredPosts[1]}
+                    isSimple={true}
+                    loading={Loading.EAGER}
+                  />
                 )}
               </div>
               <div className={`${styles['card-child-rest']}`}>
                 {featuredPosts?.[2] && (
-                  <PostCard post={featuredPosts[2]} isSimple={true} />
+                  <PostCard
+                    post={featuredPosts[2]}
+                    isSimple={true}
+                    loading={Loading.EAGER}
+                  />
                 )}
               </div>
               <div className={`${styles['card-child-rest']}`}>
                 {featuredPosts?.[3] && (
-                  <PostCard post={featuredPosts[3]} isSimple={true} />
+                  <PostCard
+                    post={featuredPosts[3]}
+                    isSimple={true}
+                    loading={Loading.EAGER}
+                  />
                 )}
               </div>
               <div className={`${styles['card-child-rest']}`}>
                 {featuredPosts?.[4] && (
-                  <PostCard post={featuredPosts[4]} isSimple={true} />
+                  <PostCard
+                    post={featuredPosts[4]}
+                    isSimple={true}
+                    loading={Loading.EAGER}
+                  />
                 )}
               </div>
             </div>

--- a/packages/frontend/src/app/home/search-and-tags.tsx
+++ b/packages/frontend/src/app/home/search-and-tags.tsx
@@ -16,6 +16,7 @@ export const SearchAndTags = (props: SearchAndTagsProp) => {
         className="max-w-64 w-full mb-10"
         decoding="async"
         src="/assets/images/search_title.svg"
+        loading="lazy"
       />
       <form
         style={{ maxWidth: '50%' }}

--- a/packages/frontend/src/app/home/section.tsx
+++ b/packages/frontend/src/app/home/section.tsx
@@ -32,13 +32,18 @@ export const Section = (props: SectionProp) => {
           className="flex flex-row justify-between items-center mb-12 pt-10"
         >
           <div style={{ flex: '1' }} className="hidden lg:flex">
-            <img className="max-w-sm" src={`/assets/images/${config.image}`} />
+            <img
+              className="max-w-sm"
+              src={`/assets/images/${config.image}`}
+              loading="lazy"
+            />
           </div>
           <div style={{ flex: '1' }} className="flex flex-row justify-center">
             <img
               className="w-full flex h-24 items-center justify-center"
               src={`/assets/images/${config.titleImg}`}
               alt={config.title}
+              loading="lazy"
             />
           </div>
           <div

--- a/packages/frontend/src/app/not-found.tsx
+++ b/packages/frontend/src/app/not-found.tsx
@@ -15,6 +15,7 @@ export default function NotFound() {
           className="max-w-72 md:max-w-md lg:max-w-xl w-full"
           src="/assets/images/404.png"
           alt="Not found"
+          loading="lazy"
         />
         <div className="flex flex-col justify-center items-center gap-2.5">
           <h1 className="text-3xl md:text-4xl font-bold">

--- a/packages/frontend/src/app/page.tsx
+++ b/packages/frontend/src/app/page.tsx
@@ -93,7 +93,7 @@ query Query($orderBy: [ProjectOrderByInput!]!, $take: Int) {
     slug
     heroImage {
       resized {
-        medium
+        small
       }
     }
   }
@@ -163,7 +163,7 @@ export default async function Home() {
     topicsRes?.data?.data?.projects?.map((topic: any) => {
       return {
         url: `/topic/${topic.slug}`,
-        image: topic?.heroImage?.resized?.medium ?? '',
+        image: topic?.heroImage?.resized?.small ?? '',
         title: topic.title,
         subtitle: topic.subtitle,
       }

--- a/packages/frontend/src/app/utils/index.ts
+++ b/packages/frontend/src/app/utils/index.ts
@@ -31,7 +31,7 @@ export const getPostSummaries = (posts: any[]): PostSummary[] => {
     const subSubcategory = post?.subSubcategoriesOrdered?.[0]
 
     return {
-      image: post?.heroImage?.resized?.medium ?? '',
+      image: post?.heroImage?.resized?.small ?? '',
       title: post.title,
       url: `/article/${post.slug}`,
       desc: post.ogDescription,


### PR DESCRIPTION
[ticket](https://app.asana.com/0/0/1207228892484345/f)
[ticket](https://app.asana.com/0/0/1207243175963528/f)

1. 一般圖片設為loading="lazy"
2. header/首圖/首頁最上方slider/首頁精選文章 圖片設為loading="eager"
3. 首頁與一般卡片內圖片不需要1200 medium那麼大, 選用800 small降低LCP

lighthouse:
原始:
![Screen Shot 2024-05-09 at 10 27 38 AM](https://github.com/kids-reporter/kids-reporter-monorepo/assets/25971696/1c683f2c-f357-40ed-aba9-5c7a84c5be76)

lazy load
![Screen Shot 2024-05-09 at 10 28 14 AM](https://github.com/kids-reporter/kids-reporter-monorepo/assets/25971696/bb0723d3-fc94-4812-85ef-6730b3cd6db6)

medium -> small
![Screen Shot 2024-05-09 at 10 28 26 AM](https://github.com/kids-reporter/kids-reporter-monorepo/assets/25971696/4c48d3ef-6a83-4a15-809b-ebc7b5825e27)

