### PR TITLE
fix(fe): fix build time issue

### DIFF
--- a/packages/frontend/src/app/(sticky-header)/about/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/about/page.tsx
@@ -14,13 +14,14 @@ import {
   AuthorRole,
 } from '@/app/constants'
 import { sendGQLRequest } from '@/app/utils'
+import { isProduction } from '@/environment-variables'
 
 export const metadata: Metadata = {
   title: '關於少年報導者 - 少年報導者 The Reporter for Kids',
   description: GENERAL_DESCRIPTION,
 }
 
-export const revalidate = 86400
+export const revalidate = isProduction ? 86400 : 0 // 1 day
 
 const authorGQL = `
 query($where: AuthorWhereUniqueInput!) {

--- a/packages/frontend/src/app/sitemap.ts
+++ b/packages/frontend/src/app/sitemap.ts
@@ -13,8 +13,9 @@ Therefore, so far we can't upgrade to v13.5.4 due to #56018 & #54057 remains.
 import { MetadataRoute } from 'next'
 import { KIDS_URL_ORIGIN } from '@/app/constants'
 import { sendGQLRequest } from '@/app/utils'
+import { isProduction } from '@/environment-variables'
 
-export const revalidate = 86400 // 1 day
+export const revalidate = isProduction ? 86400 : 0 // 1 day
 
 const postsGQL = `
 query($where: PostWhereInput!) {

--- a/packages/frontend/src/app/utils/index.ts
+++ b/packages/frontend/src/app/utils/index.ts
@@ -3,6 +3,7 @@ import errors from '@twreporter/errors'
 import { Theme, ThemeColor } from '@/app/constants'
 import { PostSummary } from '@/app/components/types'
 import { DEFAULT_THEME_COLOR, API_URL, INTERNAL_API_URL } from '@/app/constants'
+import { isProduction } from '@/environment-variables'
 
 export const getThemeColor = (theme: Theme) => {
   if (theme === Theme.YELLOW) {
@@ -53,7 +54,7 @@ export const sendGQLRequest = async (
 ) => {
   // Define url based on environment
   let url
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' && !isProduction) {
     url = INTERNAL_API_URL
   } else {
     url = API_URL

--- a/packages/frontend/src/app/utils/index.ts
+++ b/packages/frontend/src/app/utils/index.ts
@@ -52,7 +52,7 @@ export const sendGQLRequest = async (
   data?: any,
   config?: AxiosRequestConfig<any> | undefined
 ) => {
-  // Define url based on environment
+  // Define url based on environment, dev/staging needs pure internal api to bypass Identity-Aware Proxy(IAP)
   let url
   if (typeof window === 'undefined' && !isProduction) {
     url = INTERNAL_API_URL


### PR DESCRIPTION
[ticket](https://app.asana.com/0/1205517559975955/1207626776556568/f)

build time產生的靜態頁面(首頁/關於我們/sitemap)在Nextjs build time拿不到`internalGqlEndpoint`這個環境變數, 這個env變數要run time才拿得到, 所以才會造成首頁白頁或關於我們找不到圖像, 而`internalGqlEndpoint`是dev/staging因為開啟IAP後需bypass才會用到的變數, prod環境可直接存取`NEXT_PUBLIC_GQL_ENDPOINT`, 故加額外判斷分離