### PR TITLE
refactor(cms): change pdf embed code

### DIFF
--- a/packages/cms/lists/pdf.ts
+++ b/packages/cms/lists/pdf.ts
@@ -91,8 +91,8 @@ function createEmbedCode(pdfURL: string, htmlId: string): string {
 </div>
 
 <script type="module">
-  import "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.1.392/build/pdf.mjs";
-  import "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.1.392/web/pdf_viewer.mjs";
+  import "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.1.392/legacy/build/pdf.mjs";
+  import "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.1.392/legacy/web/pdf_viewer.mjs";
 
   function getSafariVersion() {
       const ua = navigator.userAgent;
@@ -108,7 +108,7 @@ function createEmbedCode(pdfURL: string, htmlId: string): string {
   const supportVersion = 15.4;
   const safariVersion = getSafariVersion();
 
-  if (safariVersion > 0 && safariVersion < supportVersion) {
+  if (safariVersion > 0 && safariVersion <= supportVersion) {
     // For older Safari browser
     const container = document.querySelector("#${htmlId} > iframe[data-google-drive]");
     container.style.display = "block";
@@ -117,7 +117,7 @@ function createEmbedCode(pdfURL: string, htmlId: string): string {
 
     // The workerSrc property shall be specified.
     pdfjsLib.GlobalWorkerOptions.workerSrc =
-      "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.1.392/build/pdf.worker.mjs";
+      "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.1.392/legacy/build/pdf.worker.mjs";
 
     const container = document.getElementById("${htmlId}");
 

--- a/packages/cms/lists/pdf.ts
+++ b/packages/cms/lists/pdf.ts
@@ -85,7 +85,9 @@ function createEmbedCode(pdfURL: string, htmlId: string): string {
   <div id="${htmlId}" style="position: absolute; width: 100%; visibility: hidden;">
     <div data-pdfjs class="pdfViewer"></div>
   </div>
-  <iframe data-google-drive src="${pdfURL}" width="100%" height="100%" allow="autoplay" style="display: block; position: absolute;"></iframe>
+  <iframe data-google-docs-viewer src="https://docs.google.com/viewer?url=${encodeURIComponent(
+    pdfURL
+  )}&embedded=true" width="100%" height="100%" allow="autoplay" style="display: block; position: absolute;"></iframe>
 </div>
 
 <script type="module">
@@ -114,7 +116,7 @@ function createEmbedCode(pdfURL: string, htmlId: string): string {
     container.style.visibility = 'visible';
 
     // hide iframe
-    const iframeNode = document.querySelector("#${htmlId} + iframe[data-google-drive]");
+    const iframeNode = document.querySelector("#${htmlId} + iframe[data-google-docs-viewer]");
     if (iframeNode) {
       iframeNode.style.display = 'none';
     }

--- a/packages/cms/lists/pdf.ts
+++ b/packages/cms/lists/pdf.ts
@@ -84,7 +84,6 @@ function createEmbedCode(pdfURL: string, htmlId: string): string {
 <div style="padding-bottom: 60%; position: relative; overflow: scroll; width: 100%;">
   <div id="${htmlId}" style="position: absolute; width: 100%; visibility: hidden;">
     <div data-pdfjs class="pdfViewer"></div>
-    <!-- fallback for older Safari below version 16 -->
   </div>
   <iframe data-google-drive src="${pdfURL}" width="100%" height="100%" allow="autoplay" style="display: block; position: absolute;"></iframe>
 </div>

--- a/packages/cms/lists/pdf.ts
+++ b/packages/cms/lists/pdf.ts
@@ -93,62 +93,61 @@ function createEmbedCode(pdfURL: string, htmlId: string): string {
   import "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.1.392/legacy/build/pdf.mjs";
   import "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.1.392/legacy/web/pdf_viewer.mjs";
 
-    // For modern browsers, use pdfjs library to present pdf.
+  // For modern browsers, use pdfjs library to present pdf.
+  // The workerSrc property shall be specified.
+  pdfjsLib.GlobalWorkerOptions.workerSrc =
+    "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.1.392/legacy/build/pdf.worker.mjs";
 
-    // The workerSrc property shall be specified.
-    pdfjsLib.GlobalWorkerOptions.workerSrc =
-      "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.1.392/legacy/build/pdf.worker.mjs";
+  const container = document.getElementById("${htmlId}");
 
-    const container = document.getElementById("${htmlId}");
+  const eventBus = new pdfjsViewer.EventBus();
 
-    const eventBus = new pdfjsViewer.EventBus();
+  const pdfViewer = new pdfjsViewer.PDFViewer({
+    container,
+    eventBus,
+  });
 
-    const pdfViewer = new pdfjsViewer.PDFViewer({
-      container,
-      eventBus,
-    });
+  eventBus.on("pagesinit", function () {
+    // We can use pdfViewer now, e.g. let's change default scale.
+    pdfViewer.currentScaleValue = "page-fit";
 
-    eventBus.on("pagesinit", function () {
-      // We can use pdfViewer now, e.g. let's change default scale.
-      pdfViewer.currentScaleValue = "page-fit";
+    // show pdfjs container
+    container.style.visibility = 'visible';
 
-      // show pdfjs container
-      container.style.visibility = 'visible';
-
-      // hide iframe
-      const iframeNode = document.querySelector("#${htmlId} + iframe[data-google-drive]");
-      if (iframeNode) {
-        iframeNode.style.display = 'none';
-      }
-    });
-
-    // Loading document.
-    const loadingTask = pdfjsLib.getDocument({
-      url: "${pdfURL}"
-    });
-
-    try {
-      const pdfDocument = await loadingTask.promise;
-      // Document loaded, specifying document for the viewer
-      pdfViewer.setDocument(pdfDocument);
-    } catch(error) {
-      console.error("${pdfURL} can not be fetched.", error)
+    // hide iframe
+    const iframeNode = document.querySelector("#${htmlId} + iframe[data-google-drive]");
+    if (iframeNode) {
+      iframeNode.style.display = 'none';
     }
+  });
 
-    // add pdf custom styles
-    const head = document.head;
-    const fragment = document.createDocumentFragment();
-    const styleEle = document.querySelector("head > style[${attrName}]");
+  // Loading document.
+  const loadingTask = pdfjsLib.getDocument({
+    url: "${pdfURL}"
+  });
 
-    if (styleEle) {
-      head.removeChild(styleEle);
-    }
+  try {
+    const pdfDocument = await loadingTask.promise;
+    // Document loaded, specifying document for the viewer
+    pdfViewer.setDocument(pdfDocument);
+  } catch(error) {
+    console.error("${pdfURL} can not be fetched.", error)
+  }
 
-    const newStyleEle = document.createElement("style");
-    newStyleEle.setAttribute("${attrName}", "");
-    newStyleEle.innerText = "#${htmlId} .pdfViewer .page { margin-left: auto; margin-right: auto; }";
-    fragment.appendChild(newStyleEle);
-    head.appendChild(fragment);
+  // add pdf custom styles
+  const head = document.head;
+  const fragment = document.createDocumentFragment();
+  const styleEle = document.querySelector("head > style[${attrName}]");
+
+  if (styleEle) {
+    head.removeChild(styleEle);
+  }
+
+  const newStyleEle = document.createElement("style");
+  newStyleEle.setAttribute("${attrName}", "");
+  newStyleEle.innerText = "#${htmlId} .pdfViewer .page { margin-left: auto; margin-right: auto; }";
+  fragment.appendChild(newStyleEle);
+  head.appendChild(fragment);
 </script>
   `
   return tmpl

--- a/packages/cms/lists/pdf.ts
+++ b/packages/cms/lists/pdf.ts
@@ -84,7 +84,7 @@ function createEmbedCode(pdfURL: string, htmlId: string): string {
 <div style="padding-bottom: 60%; position: relative; overflow: scroll; width: 100%;">
   <div id="${htmlId}" style="position: absolute; width: 100%;">
     <div data-pdfjs class="pdfViewer"></div>
-    <!-- fallback for older Safari below version 15.4 -->
+    <!-- fallback for older Safari below version 16 -->
   </div>
   <iframe data-google-drive src="${pdfURL}" width="100%" height="100%" allow="autoplay" style="display: none; position: absolute;"></iframe>
 </div>
@@ -104,10 +104,10 @@ function createEmbedCode(pdfURL: string, htmlId: string): string {
       }
   }
 
-  const supportVersion = 15.4;
+  const supportVersion = 16;
   const safariVersion = getSafariVersion();
 
-  if (safariVersion > 0 && safariVersion <= supportVersion) {
+  if (safariVersion > 0 && safariVersion < supportVersion) {
     // For older Safari browser
     const container = document.querySelector("#${htmlId} + iframe[data-google-drive]");
     container.style.display = "block";

--- a/packages/cms/lists/pdf.ts
+++ b/packages/cms/lists/pdf.ts
@@ -156,7 +156,7 @@ function createEmbedCode(pdfURL: string, htmlId: string): string {
 
     const newStyleEle = document.createElement("style");
     newStyleEle.setAttribute("${attrName}", "");
-    newStyleEle.innerText = "#${htmlId} .pdfViewer{ .page { margin-left: auto; margin-right: auto; }}";
+    newStyleEle.innerText = "#${htmlId} .pdfViewer .page { margin-left: auto; margin-right: auto; }";
     fragment.appendChild(newStyleEle);
     head.appendChild(fragment);
   }

--- a/packages/cms/lists/pdf.ts
+++ b/packages/cms/lists/pdf.ts
@@ -82,7 +82,7 @@ function createEmbedCode(pdfURL: string, htmlId: string): string {
   const attrName = 'data-' + htmlId
   const tmpl = `
 <div style="padding-bottom: 60%; position: relative; overflow: scroll; width: 100%;">
-  <div id="${htmlId}" style="position: absolute; width: 100%; height: 100%;">
+  <div id="${htmlId}" style="position: absolute; width: 100%;">
     <div data-pdfjs class="pdfViewer"></div>
     
     <!-- fallback for older Safari below version 15.4 -->

--- a/packages/cms/lists/pdf.ts
+++ b/packages/cms/lists/pdf.ts
@@ -82,36 +82,17 @@ function createEmbedCode(pdfURL: string, htmlId: string): string {
   const attrName = 'data-' + htmlId
   const tmpl = `
 <div style="padding-bottom: 60%; position: relative; overflow: scroll; width: 100%;">
-  <div id="${htmlId}" style="position: absolute; width: 100%;">
+  <div id="${htmlId}" style="position: absolute; width: 100%; visibility: hidden;">
     <div data-pdfjs class="pdfViewer"></div>
     <!-- fallback for older Safari below version 16 -->
   </div>
-  <iframe data-google-drive src="${pdfURL}" width="100%" height="100%" allow="autoplay" style="display: none; position: absolute;"></iframe>
+  <iframe data-google-drive src="${pdfURL}" width="100%" height="100%" allow="autoplay" style="display: block; position: absolute;"></iframe>
 </div>
 
 <script type="module">
   import "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.1.392/legacy/build/pdf.mjs";
   import "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.1.392/legacy/web/pdf_viewer.mjs";
 
-  function getSafariVersion() {
-      const ua = navigator.userAgent;
-      const safariMatch = ua.match(/Version\\/(\\d+\\.\\d+)/);
-
-      if (safariMatch && ua.includes("Safari") && !ua.includes("Chrome")) {
-          return parseFloat(safariMatch[1]);
-      } else {
-          return -1;
-      }
-  }
-
-  const supportVersion = 16;
-  const safariVersion = getSafariVersion();
-
-  if (safariVersion > 0 && safariVersion < supportVersion) {
-    // For older Safari browser
-    const container = document.querySelector("#${htmlId} + iframe[data-google-drive]");
-    container.style.display = "block";
-  } else {
     // For modern browsers, use pdfjs library to present pdf.
 
     // The workerSrc property shall be specified.
@@ -130,6 +111,15 @@ function createEmbedCode(pdfURL: string, htmlId: string): string {
     eventBus.on("pagesinit", function () {
       // We can use pdfViewer now, e.g. let's change default scale.
       pdfViewer.currentScaleValue = "page-fit";
+
+      // show pdfjs container
+      container.style.visibility = 'visible';
+
+      // hide iframe
+      const iframeNode = document.querySelector("#${htmlId} + iframe[data-google-drive]");
+      if (iframeNode) {
+        iframeNode.style.display = 'none';
+      }
     });
 
     // Loading document.
@@ -159,7 +149,6 @@ function createEmbedCode(pdfURL: string, htmlId: string): string {
     newStyleEle.innerText = "#${htmlId} .pdfViewer .page { margin-left: auto; margin-right: auto; }";
     fragment.appendChild(newStyleEle);
     head.appendChild(fragment);
-  }
 </script>
   `
   return tmpl

--- a/packages/cms/lists/pdf.ts
+++ b/packages/cms/lists/pdf.ts
@@ -84,10 +84,9 @@ function createEmbedCode(pdfURL: string, htmlId: string): string {
 <div style="padding-bottom: 60%; position: relative; overflow: scroll; width: 100%;">
   <div id="${htmlId}" style="position: absolute; width: 100%;">
     <div data-pdfjs class="pdfViewer"></div>
-    
     <!-- fallback for older Safari below version 15.4 -->
-    <iframe data-google-drive src="${pdfURL}" width="100%" height="100%" allow="autoplay" style="display: none;"></iframe>
   </div>
+  <iframe data-google-drive src="${pdfURL}" width="100%" height="100%" allow="autoplay" style="display: none; position: absolute;"></iframe>
 </div>
 
 <script type="module">
@@ -110,7 +109,7 @@ function createEmbedCode(pdfURL: string, htmlId: string): string {
 
   if (safariVersion > 0 && safariVersion <= supportVersion) {
     // For older Safari browser
-    const container = document.querySelector("#${htmlId} > iframe[data-google-drive]");
+    const container = document.querySelector("#${htmlId} + iframe[data-google-drive]");
     container.style.display = "block";
   } else {
     // For modern browsers, use pdfjs library to present pdf.

--- a/packages/cms/lists/pdf.ts
+++ b/packages/cms/lists/pdf.ts
@@ -88,12 +88,12 @@ function createEmbedCode(pdfURL: string, htmlId: string): string {
 </div>
 
 <script type="module">
-  import "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/build/pdf.mjs";
-  import "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/web/pdf_viewer.mjs";
+  import "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.1.392/build/pdf.mjs";
+  import "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.1.392/web/pdf_viewer.mjs";
 
   // The workerSrc property shall be specified.
   pdfjsLib.GlobalWorkerOptions.workerSrc =
-    "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.6.82/build/pdf.worker.mjs";
+    "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.1.392/build/pdf.worker.mjs";
 
   const container = document.getElementById("${htmlId}");
 

--- a/packages/cms/lists/pdf.ts
+++ b/packages/cms/lists/pdf.ts
@@ -85,9 +85,7 @@ function createEmbedCode(pdfURL: string, htmlId: string): string {
   <div id="${htmlId}" style="position: absolute; width: 100%; visibility: hidden;">
     <div data-pdfjs class="pdfViewer"></div>
   </div>
-  <iframe data-google-docs-viewer src="https://docs.google.com/viewer?url=${encodeURIComponent(
-    pdfURL
-  )}&embedded=true" width="100%" height="100%" allow="autoplay" style="display: block; position: absolute;"></iframe>
+  <iframe src="${pdfURL}" width="100%" height="100%" allow="autoplay" style="display: block; position: absolute;"></iframe>
 </div>
 
 <script type="module">
@@ -116,7 +114,7 @@ function createEmbedCode(pdfURL: string, htmlId: string): string {
     container.style.visibility = 'visible';
 
     // hide iframe
-    const iframeNode = document.querySelector("#${htmlId} + iframe[data-google-docs-viewer]");
+    const iframeNode = document.querySelector("#${htmlId} + iframe");
     if (iframeNode) {
       iframeNode.style.display = 'none';
     }


### PR DESCRIPTION
Use mozilla/pdf.js lib to render pdf content.
Old way uses <iframe> to render pdf content, but it did not work well on mobile devices.
See [Asana Card](https://app.asana.com/0/1205517559975955/1208337869158726/f) for more info.