### PR TITLE
fix(cms): unwanted padding in the post and topic lists

### DIFF
--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@keystone-6/auth": "7.0.0",
     "@keystone-6/core": "5.2.0",
-    "@kids-reporter/cms-core": "1.0.15",
+    "@kids-reporter/cms-core": "1.0.16",
     "@types/react-beautiful-dnd": "^13.1.4",
     "axios": "^1.6.2",
     "cookie-parser": "^1.4.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/cms-core",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "",
   "main": "lib/index.js",
   "types": "src/index.ts",
@@ -33,7 +33,7 @@
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",
     "@twreporter/errors": "^1.1.1",
-    "@kids-reporter/draft-editor": "1.0.15",
+    "@kids-reporter/draft-editor": "1.0.16",
     "axios": "^0.26.0",
     "draft-convert": "^2.1.12",
     "draft-js": "^0.11.7",

--- a/packages/draft-editor/package.json
+++ b/packages/draft-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/draft-editor",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-editor/src/rich-text-editor.tsx
+++ b/packages/draft-editor/src/rich-text-editor.tsx
@@ -50,8 +50,6 @@ import { customStylePrefix as fontColorPrefix } from './buttons/font-color'
 
 const styleSource = [
   'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css',
-  'https://storage.googleapis.com/static-readr-tw-dev/cdn/draft-js/rich-editor.css',
-  'https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css',
 ].map((src, index) => (
   <link
     key={`style-src-${index}`}


### PR DESCRIPTION
### Bug details
因為 `packages/draft-editor` 裡的編輯器有使用 `normalize.css`，而 `normalize.css` 會影響 keystone-ui 的樣式，所以 cms 上有使用到 `draft-editor` 的 lists 會受到影響，例如：post 和 topic lists。
又因為 `draft-editor` 的所見即所得是透過 `draft-render` 和 custom styled components 實作，所以可以移除 normalize.css，單純使用 `draft-renderer` 和 custom styled components 來調整樣式。

### Notion Card
[[CMS]刪除縮排](https://www.notion.so/twreporter/CMS-bc00e085c9434f21ba4e2a2782a311e6)