### PR TITLE
fix(cms): abnormal online user count

### DIFF
--- a/packages/cms/keystone.ts
+++ b/packages/cms/keystone.ts
@@ -14,7 +14,7 @@ import { twoFactorAuth } from './express-mini-apps/two-factor-auth'
 const { withAuth } = createAuth({
   listKey: 'User',
   identityField: 'email',
-  sessionData: 'name role email twoFactorAuth',
+  sessionData: 'id name role email twoFactorAuth',
   secretField: 'password',
   initFirstItem: {
     // If there are no items in the database, keystone will ask you to create

--- a/packages/cms/lists/index.ts
+++ b/packages/cms/lists/index.ts
@@ -1,6 +1,8 @@
 import Author from './author'
+import CallBaodaozai from './call-baodaozai'
 import Category from './category'
 import EditorPicksSetting from './editor-picks-setting'
+import OnlineUser from './online-user'
 import PDF from './pdf'
 import Photo from './photo'
 import Post from './post'
@@ -12,7 +14,6 @@ import SVG from './svg'
 import Tag from './tag'
 import User from './user'
 import { NewsReadingGroup, NewsReadingGroupItem } from './news-reading'
-import CallBaodaozai from './call-baodaozai'
 
 export const listDefinition = {
   User,
@@ -31,4 +32,5 @@ export const listDefinition = {
   PDF,
   SVG,
   CallBaodaozai,
+  OnlineUser,
 }

--- a/packages/cms/lists/online-user.ts
+++ b/packages/cms/lists/online-user.ts
@@ -1,0 +1,59 @@
+import { list } from '@keystone-6/core'
+import { relationship, text, timestamp } from '@keystone-6/core/fields'
+import { allowAllRoles } from './utils/access-control-list'
+
+const listConfigurations = list({
+  fields: {
+    user: relationship({
+      ref: 'User',
+      many: false,
+    }),
+    canonicalPath: text({
+      isIndexed: true,
+    }),
+    lastOnlineAt: timestamp({
+      isIndexed: true,
+    }),
+    createdAt: timestamp({
+      defaultValue: { kind: 'now' },
+    }),
+    updatedAt: timestamp({
+      db: {
+        updatedAt: true,
+      },
+    }),
+  },
+  access: {
+    operation: {
+      query: allowAllRoles(),
+      create: allowAllRoles(),
+      update: allowAllRoles(),
+      delete: allowAllRoles(),
+    },
+  },
+  ui: {
+    label: 'Online Users',
+    isHidden: true,
+    hideCreate: true,
+    createView: {
+      defaultFieldMode: 'hidden',
+    },
+    itemView: {
+      defaultFieldMode: 'read',
+    },
+    listView: {
+      defaultFieldMode: 'read',
+      initialColumns: [],
+      initialSort: {
+        field: 'id',
+        direction: 'DESC',
+      },
+    },
+  },
+  db: {
+    idField: {
+      kind: 'cuid',
+    },
+  },
+})
+export default listConfigurations

--- a/packages/cms/lists/post.ts
+++ b/packages/cms/lists/post.ts
@@ -1,4 +1,5 @@
 import envVars from '../environment-variables'
+import { KeystoneContext } from '@keystone-6/core/types'
 import {
   customFields,
   richTextEditorButtonNames,
@@ -537,10 +538,27 @@ const listConfigurations = list({
         },
       },
     }),
-    onlineUsers: relationship({
+    onlineUsers: virtual({
       label: 'online user',
-      ref: 'User',
-      many: true,
+      field: graphql.field({
+        type: graphql.JSON,
+        async resolve(
+          item: Record<string, unknown>,
+          args,
+          context: KeystoneContext
+        ) {
+          const authenticatedUser = context.session.data
+          const userData = {
+            id: authenticatedUser.id,
+            email: authenticatedUser.email,
+            name: authenticatedUser.name,
+          }
+          return {
+            canonicalPath: `/posts/${item.id}`,
+            userData: userData,
+          }
+        },
+      }),
       ui: {
         views: './lists/views/online-users',
         createView: { fieldMode: 'hidden' },

--- a/packages/cms/lists/project.ts
+++ b/packages/cms/lists/project.ts
@@ -1,4 +1,5 @@
 import envVars from '../environment-variables'
+import { KeystoneContext } from '@keystone-6/core/types'
 import {
   customFields,
   richTextEditorButtonNames,
@@ -174,6 +175,36 @@ const listConfigurations = list({
         listView: {
           fieldMode: 'hidden',
         },
+      },
+    }),
+    onlineUsers: virtual({
+      label: 'online user',
+      field: graphql.field({
+        type: graphql.JSON,
+        async resolve(
+          item: Record<string, unknown>,
+          args,
+          context: KeystoneContext
+        ) {
+          const authenticatedUser = context.session.data
+          const userData = {
+            id: authenticatedUser.id,
+            email: authenticatedUser.email,
+            name: authenticatedUser.name,
+          }
+          return {
+            canonicalPath: `/projects/${item.id}`,
+            userData: userData,
+          }
+        },
+      }),
+      ui: {
+        views: './lists/views/online-users',
+        createView: { fieldMode: 'hidden' },
+        itemView: {
+          fieldPosition: 'sidebar',
+        },
+        listView: { fieldMode: 'hidden' },
       },
     }),
   },

--- a/packages/cms/lists/views/online-users.tsx
+++ b/packages/cms/lists/views/online-users.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState, useRef } from 'react'
-import axios from 'axios'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { FieldProps } from '@keystone-6/core/types'
 import { FieldContainer } from '@keystone-ui/fields'
-import { controller } from '@keystone-6/core/fields/types/json/views'
+import { controller } from '@keystone-6/core/fields/types/virtual/views'
+import { useMutation, useQuery, gql } from '@keystone-6/core/admin-ui/apollo'
 
 const colors = [
   '#EEE8AA',
@@ -18,42 +18,51 @@ const colors = [
   '#FFE4B5',
 ]
 
-const upateUserGql = `
-mutation Mutation($where: PostWhereUniqueInput!, $data: PostUpdateInput!) {
-  updatePost(where: $where, data: $data) {
-    onlineUsers {
-      email
+const DELETE_ONLINE_USER = gql`
+  mutation DeleteOnlineUser($where: OnlineUserWhereUniqueInput!) {
+    deleteOnlineUser(where: $where) {
+      id
     }
   }
-}
 `
 
-const currentUserGql = `
-query User {
-  authenticatedItem {
-    ... on User {
+const CREATE_ONLINE_USER = gql`
+  mutation CreateOnlineUser($data: OnlineUserCreateInput!) {
+    createOnlineUser(data: $data) {
       id
-      name
-      email
+      canonicalPath
+      lastOnlineAt
     }
   }
-}`
+`
 
-const onlineUsersGql = `
-query($where: PostWhereUniqueInput!) {
-  post(where: $where) {
-    onlineUsers {
-      id
-      name
-      email
+const UPDATE_ONLINE_USER = gql`
+  mutation UpdateOnlineUser(
+    $where: OnlineUserWhereUniqueInput!
+    $data: OnlineUserUpdateInput!
+  ) {
+    updateOnlineUser(where: $where, data: $data) {
+      lastOnlineAt
     }
   }
-}
+`
+
+const GET_ONLINE_USERS = gql`
+  query GetOnlineUsers($where: OnlineUserWhereInput!) {
+    onlineUsers(where: $where) {
+      user {
+        id
+        name
+        email
+      }
+    }
+  }
 `
 
 const Container = styled(FieldContainer)`
   display: flex;
   flex-direction: row;
+  min-height: 40px;
 `
 
 const Tooltip = styled.span`
@@ -75,7 +84,6 @@ const Avatar = styled.div`
   width: 40px;
   height: 40px;
   display: flex;
-  flex-direction: column;
   justify-content: center;
   align-items: center;
   border-radius: 20px;
@@ -88,151 +96,177 @@ const Avatar = styled.div`
   }
 `
 
+type OnlineUser = {
+  user: User
+  canonicalPath: string
+  lastOnlineAt: Date
+}
+
 type User = {
   id: string
   name: string
   email: string
 }
 
-export const Field = ({ value }: FieldProps<typeof controller>) => {
-  const postID = value?.id
-  const isCurrentUserWritable = useRef(true)
-  const currentUserEmail = useRef('')
-  const [users, setUsers] = useState<User[]>([])
+const pollInterval = 5000 // 5 seconds
+const validCheckTimeWindow = 60000 // 60 seconds
 
-  const handleQueryUsers = async (): Promise<User[]> => {
-    const users: User[] = []
-    try {
-      const usersRes = await axios.post('/api/graphql', {
-        query: onlineUsersGql,
+export const Field = ({ value }: FieldProps<typeof controller>) => {
+  const [validCheckTime, setValidCheckTime] = useState(
+    new Date(Date.now() - validCheckTimeWindow)
+  )
+  const [errorMessage, setErrorMessage] = useState('')
+  const canonicalPath = value?.canonicalPath
+  const userData: User = value?.userData
+
+  // Get current online users for a certain webpage
+  const { error: getOnlineUsersError, data: getOnlineUsersData } = useQuery(
+    GET_ONLINE_USERS,
+    {
+      variables: {
+        where: {
+          canonicalPath: {
+            equals: canonicalPath,
+          },
+          lastOnlineAt: {
+            gte: validCheckTime.toISOString(),
+          },
+        },
+      },
+    }
+  )
+
+  const [
+    createOnlineUser,
+    { data: createOnlineUserData, error: createOnlineUserError },
+  ] = useMutation(CREATE_ONLINE_USER)
+  const [deleteOnlineUser, { error: deleteOnlineUserError }] =
+    useMutation(DELETE_ONLINE_USER)
+  const [updateOnlineUser, { error: updateOnlineUserError }] =
+    useMutation(UPDATE_ONLINE_USER)
+
+  useEffect(() => {
+    if (userData) {
+      const userId = userData.id
+
+      // tell the server that the user is online for a certain webpage
+      createOnlineUser({
         variables: {
-          where: {
-            id: postID,
+          data: {
+            user: {
+              connect: {
+                id: userId,
+              },
+            },
+            canonicalPath,
+            lastOnlineAt: new Date().toISOString(),
           },
         },
       })
-      return usersRes?.data?.data?.post?.onlineUsers
-    } catch (err) {
-      console.log(err)
-    }
-    return users
-  }
 
-  const handleRemoveUser = async () => {
-    if (isCurrentUserWritable.current && currentUserEmail.current) {
-      try {
-        await axios.post('/api/graphql', {
-          query: upateUserGql,
-          variables: {
-            where: {
-              id: postID,
-            },
-            data: {
-              onlineUsers: {
-                disconnect: [
-                  {
-                    email: currentUserEmail.current,
-                  },
-                ],
-              },
-            },
+      // Set `validCheckTime` state to trigger re-render.
+      setValidCheckTime(new Date(Date.now() - validCheckTimeWindow))
+    }
+  }, [userData, canonicalPath, createOnlineUser])
+
+  useEffect(() => {
+    const onlineUser = createOnlineUserData?.createOnlineUser
+
+    if (!onlineUser) {
+      return
+    }
+
+    // tell the server the user is offline right now
+    const handleBeforeUnload = () => {
+      const id = onlineUser.id
+      deleteOnlineUser({
+        variables: {
+          where: {
+            id,
           },
-        })
-      } catch (err) {
-        console.log(err)
-      }
+        },
+      })
     }
-  }
 
-  // Update onlineUsers after join
-  useEffect(() => {
-    const updateUser = async () => {
-      try {
-        const users = await handleQueryUsers()
-        const currentUserRes = await axios.post('/api/graphql', {
-          query: currentUserGql,
-        })
-        const authenticatedItem = currentUserRes?.data?.data?.authenticatedItem
-        if (authenticatedItem?.email && authenticatedItem?.name) {
-          currentUserEmail.current = authenticatedItem.email
-          const isCurrentUserExisting = users?.find(
-            (user) => user?.email === currentUserEmail.current
-          )
-          if (!isCurrentUserExisting) {
-            const updateResults = await axios.post('/api/graphql', {
-              query: upateUserGql,
-              variables: {
-                where: {
-                  id: postID,
-                },
-                data: {
-                  onlineUsers: {
-                    connect: [
-                      {
-                        email: currentUserEmail.current,
-                      },
-                    ],
-                  },
-                },
-              },
-            })
-            if (updateResults?.data?.errors) {
-              isCurrentUserWritable.current = false
-            }
-          }
+    window.addEventListener('beforeunload', handleBeforeUnload)
 
-          setUsers(
-            isCurrentUserWritable.current && !isCurrentUserExisting
-              ? [
-                  ...users,
-                  {
-                    email: currentUserEmail.current,
-                    name: authenticatedItem.name,
-                    id: authenticatedItem.id,
-                  },
-                ]
-              : [...users]
-          )
-        }
-      } catch (err) {
-        console.log(err)
-      }
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+      handleBeforeUnload()
     }
-    updateUser()
-    window.addEventListener('beforeunload', handleRemoveUser)
-  }, [])
+  }, [createOnlineUserData, deleteOnlineUser])
 
-  // Polling & clear polling/current user field when leaving
   useEffect(() => {
-    const polling = setInterval(async () => {
-      const users = await handleQueryUsers()
-      setUsers(users ?? [])
-    }, 5000)
+    const onlineUser = createOnlineUserData?.createOnlineUser
+
+    if (!onlineUser) {
+      return
+    }
+
+    // Polling to tell the server the user is still online
+    const polling = setInterval(() => {
+      const id = onlineUser.id
+      updateOnlineUser({
+        variables: {
+          where: {
+            id,
+          },
+          data: {
+            lastOnlineAt: new Date().toISOString(),
+          },
+        },
+      })
+      setValidCheckTime(new Date(Date.now() - validCheckTimeWindow))
+    }, pollInterval)
 
     return () => {
       clearInterval(polling)
-      handleRemoveUser()
-      window.removeEventListener('beforeunload', handleRemoveUser)
     }
-  }, [])
+  }, [createOnlineUserData, updateOnlineUser])
 
-  return (
-    <Container>
-      {users?.map((user, index) => {
-        return (
-          user && (
-            <Avatar
-              key={`online-user-${index}`}
-              color={colors[Number(user.id) % colors.length]}
-            >
-              <span>{user.name?.[0]}</span>
-              <Tooltip>
-                {user.name}: {user.email}
-              </Tooltip>
-            </Avatar>
-          )
-        )
-      })}
-    </Container>
+  useEffect(() => {
+    if (
+      getOnlineUsersError ||
+      createOnlineUserError ||
+      updateOnlineUserError ||
+      deleteOnlineUserError
+    ) {
+      setErrorMessage('線上人數功能異常，請回報技術人員')
+      return
+    }
+
+    setErrorMessage('')
+  }, [
+    getOnlineUsersError,
+    createOnlineUserError,
+    updateOnlineUserError,
+    deleteOnlineUserError,
+  ])
+
+  if (errorMessage) {
+    return <span style={{ color: 'red' }}>{errorMessage}</span>
+  }
+
+  const users: User[] = getOnlineUsersData?.onlineUsers?.map(
+    (onlineUser: OnlineUser) => {
+      return onlineUser?.user
+    }
   )
+
+  const deduplcatedUsers = Array.from(
+    new Map(users?.map((user) => [user.id, user])).values()
+  )
+
+  const usersJsx = deduplcatedUsers.map((user) => {
+    return (
+      <Avatar key={user.id} color={colors[Number(user.id) % colors.length]}>
+        <span>{user.name?.[0]}</span>
+        <Tooltip>
+          {user.name}: {user.email}
+        </Tooltip>
+      </Avatar>
+    )
+  })
+
+  return <Container>{usersJsx}</Container>
 }

--- a/packages/cms/migrations/20250122040016_add_online_user_list/migration.sql
+++ b/packages/cms/migrations/20250122040016_add_online_user_list/migration.sql
@@ -1,0 +1,38 @@
+/*
+  Warnings:
+
+  - You are about to drop the `_Post_onlineUsers` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "_Post_onlineUsers" DROP CONSTRAINT "_Post_onlineUsers_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_Post_onlineUsers" DROP CONSTRAINT "_Post_onlineUsers_B_fkey";
+
+-- DropTable
+DROP TABLE "_Post_onlineUsers";
+
+-- CreateTable
+CREATE TABLE "OnlineUser" (
+    "id" TEXT NOT NULL,
+    "user" INTEGER,
+    "canonicalPath" TEXT NOT NULL DEFAULT '',
+    "lastOnlineAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3),
+
+    CONSTRAINT "OnlineUser_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "OnlineUser_user_idx" ON "OnlineUser"("user");
+
+-- CreateIndex
+CREATE INDEX "OnlineUser_canonicalPath_idx" ON "OnlineUser"("canonicalPath");
+
+-- CreateIndex
+CREATE INDEX "OnlineUser_lastOnlineAt_idx" ON "OnlineUser"("lastOnlineAt");
+
+-- AddForeignKey
+ALTER TABLE "OnlineUser" ADD CONSTRAINT "OnlineUser_user_fkey" FOREIGN KEY ("user") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/cms/schema.graphql
+++ b/packages/cms/schema.graphql
@@ -224,8 +224,7 @@ type Post {
   updatedLog: JSON
   preview: JSON
   listPreview: String
-  onlineUsers(where: UserWhereInput! = {}, orderBy: [UserOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: UserWhereUniqueInput): [User!]
-  onlineUsersCount(where: UserWhereInput! = {}): Int
+  onlineUsers: JSON
   summary: JSON
 }
 
@@ -260,7 +259,6 @@ input PostWhereInput {
   updatedAt: DateTimeNullableFilter
   createdBy: UserWhereInput
   updatedBy: UserWhereInput
-  onlineUsers: UserManyRelationFilter
 }
 
 input SubSubcategoryManyRelationFilter {
@@ -291,12 +289,6 @@ input PostManyRelationFilter {
   every: PostWhereInput
   some: PostWhereInput
   none: PostWhereInput
-}
-
-input UserManyRelationFilter {
-  every: UserWhereInput
-  some: UserWhereInput
-  none: UserWhereInput
 }
 
 input PostOrderByInput {
@@ -344,7 +336,6 @@ input PostUpdateInput {
   updatedAt: DateTime
   createdBy: UserRelateToOneForUpdateInput
   updatedBy: UserRelateToOneForUpdateInput
-  onlineUsers: UserRelateToManyForUpdateInput
 }
 
 input ProjectRelateToOneForUpdateInput {
@@ -406,13 +397,6 @@ input UserRelateToOneForUpdateInput {
   disconnect: Boolean
 }
 
-input UserRelateToManyForUpdateInput {
-  disconnect: [UserWhereUniqueInput!]
-  set: [UserWhereUniqueInput!]
-  create: [UserCreateInput!]
-  connect: [UserWhereUniqueInput!]
-}
-
 input PostUpdateArgs {
   where: PostWhereUniqueInput!
   data: PostUpdateInput!
@@ -449,7 +433,6 @@ input PostCreateInput {
   updatedAt: DateTime
   createdBy: UserRelateToOneForCreateInput
   updatedBy: UserRelateToOneForCreateInput
-  onlineUsers: UserRelateToManyForCreateInput
 }
 
 input ProjectRelateToOneForCreateInput {
@@ -495,11 +478,6 @@ input PostRelateToManyForCreateInput {
 input UserRelateToOneForCreateInput {
   create: UserCreateInput
   connect: UserWhereUniqueInput
-}
-
-input UserRelateToManyForCreateInput {
-  create: [UserCreateInput!]
-  connect: [UserWhereUniqueInput!]
 }
 
 type Photo {
@@ -687,6 +665,7 @@ type Project {
   createdAt: DateTime
   updatedAt: DateTime
   preview: JSON
+  onlineUsers: JSON
 }
 
 input ProjectWhereUniqueInput {
@@ -1596,6 +1575,60 @@ input CallBaodaozaiCreateInput {
   updatedAt: DateTime
 }
 
+type OnlineUser {
+  id: ID!
+  user: User
+  canonicalPath: String
+  lastOnlineAt: DateTime
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
+input OnlineUserWhereUniqueInput {
+  id: ID
+}
+
+input OnlineUserWhereInput {
+  AND: [OnlineUserWhereInput!]
+  OR: [OnlineUserWhereInput!]
+  NOT: [OnlineUserWhereInput!]
+  id: IDFilter
+  user: UserWhereInput
+  canonicalPath: StringFilter
+  lastOnlineAt: DateTimeNullableFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+}
+
+input OnlineUserOrderByInput {
+  id: OrderDirection
+  canonicalPath: OrderDirection
+  lastOnlineAt: OrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+}
+
+input OnlineUserUpdateInput {
+  user: UserRelateToOneForUpdateInput
+  canonicalPath: String
+  lastOnlineAt: DateTime
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
+input OnlineUserUpdateArgs {
+  where: OnlineUserWhereUniqueInput!
+  data: OnlineUserUpdateInput!
+}
+
+input OnlineUserCreateInput {
+  user: UserRelateToOneForCreateInput
+  canonicalPath: String
+  lastOnlineAt: DateTime
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
 """
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
@@ -1698,6 +1731,12 @@ type Mutation {
   updateCallBaodaozais(data: [CallBaodaozaiUpdateArgs!]!): [CallBaodaozai]
   deleteCallBaodaozai(where: CallBaodaozaiWhereUniqueInput!): CallBaodaozai
   deleteCallBaodaozais(where: [CallBaodaozaiWhereUniqueInput!]!): [CallBaodaozai]
+  createOnlineUser(data: OnlineUserCreateInput!): OnlineUser
+  createOnlineUsers(data: [OnlineUserCreateInput!]!): [OnlineUser]
+  updateOnlineUser(where: OnlineUserWhereUniqueInput!, data: OnlineUserUpdateInput!): OnlineUser
+  updateOnlineUsers(data: [OnlineUserUpdateArgs!]!): [OnlineUser]
+  deleteOnlineUser(where: OnlineUserWhereUniqueInput!): OnlineUser
+  deleteOnlineUsers(where: [OnlineUserWhereUniqueInput!]!): [OnlineUser]
   endSession: Boolean!
   authenticateUserWithPassword(email: String!, password: String!): UserAuthenticationWithPasswordResult
   createInitialUser(data: CreateInitialUserInput!): UserAuthenticationWithPasswordSuccess!
@@ -1770,6 +1809,9 @@ type Query {
   callBaodaozais(where: CallBaodaozaiWhereInput! = {}, orderBy: [CallBaodaozaiOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: CallBaodaozaiWhereUniqueInput): [CallBaodaozai!]
   callBaodaozai(where: CallBaodaozaiWhereUniqueInput!): CallBaodaozai
   callBaodaozaisCount(where: CallBaodaozaiWhereInput! = {}): Int
+  onlineUsers(where: OnlineUserWhereInput! = {}, orderBy: [OnlineUserOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: OnlineUserWhereUniqueInput): [OnlineUser!]
+  onlineUser(where: OnlineUserWhereUniqueInput!): OnlineUser
+  onlineUsersCount(where: OnlineUserWhereInput! = {}): Int
   keystone: KeystoneMeta!
   authenticatedItem: AuthenticatedItem
 }

--- a/packages/cms/schema.prisma
+++ b/packages/cms/schema.prisma
@@ -12,19 +12,19 @@ generator client {
 }
 
 model User {
-  id                    Int       @id @default(autoincrement())
-  name                  String    @default("")
-  email                 String    @unique @default("")
-  password              String
-  role                  String
-  createdAt             DateTime? @default(now())
-  updatedAt             DateTime? @updatedAt
-  twoFactorAuthBypass   Boolean   @default(false)
-  twoFactorAuthSecret   String?
-  twoFactorAuthTemp     String?
-  from_Post_createdBy   Post[]    @relation("Post_createdBy")
-  from_Post_updatedBy   Post[]    @relation("Post_updatedBy")
-  from_Post_onlineUsers Post[]    @relation("Post_onlineUsers")
+  id                   Int          @id @default(autoincrement())
+  name                 String       @default("")
+  email                String       @unique @default("")
+  password             String
+  role                 String
+  createdAt            DateTime?    @default(now())
+  updatedAt            DateTime?    @updatedAt
+  twoFactorAuthBypass  Boolean      @default(false)
+  twoFactorAuthSecret  String?
+  twoFactorAuthTemp    String?
+  from_Post_createdBy  Post[]       @relation("Post_createdBy")
+  from_Post_updatedBy  Post[]       @relation("Post_updatedBy")
+  from_OnlineUser_user OnlineUser[] @relation("OnlineUser_user")
 }
 
 model Post {
@@ -65,7 +65,6 @@ model Post {
   createdById                                Int?                 @map("createdBy")
   updatedBy                                  User?                @relation("Post_updatedBy", fields: [updatedById], references: [id])
   updatedById                                Int?                 @map("updatedBy")
-  onlineUsers                                User[]               @relation("Post_onlineUsers")
   from_Post_relatedPosts                     Post[]               @relation("Post_relatedPosts")
   from_EditorPicksSetting_editorPicksOfPosts EditorPicksSetting[] @relation("EditorPicksSetting_editorPicksOfPosts")
 
@@ -311,4 +310,18 @@ model CallBaodaozai {
   aboutUs   Json?
   createdAt DateTime? @default(now())
   updatedAt DateTime? @updatedAt
+}
+
+model OnlineUser {
+  id            String    @id @default(cuid())
+  user          User?     @relation("OnlineUser_user", fields: [userId], references: [id])
+  userId        Int?      @map("user")
+  canonicalPath String    @default("")
+  lastOnlineAt  DateTime?
+  createdAt     DateTime? @default(now())
+  updatedAt     DateTime? @updatedAt
+
+  @@index([userId])
+  @@index([canonicalPath])
+  @@index([lastOnlineAt])
 }


### PR DESCRIPTION
### Bug 說明
原本的實作方式是在 `post` list 中，透過 `online_users` field 去紀錄在線的使用者，`lists/views/online-users.tsx` 裡面會將在某一篇文章編輯的使用者加到 `online_users`，同時 query `online_users` 目前所有的使用者，來呈現目上在線的使用者。
但因為有些使用者開了頁面後，一直放著，直到使用者 cookie 失效，再離開頁面時，會因為 cookie 失效，而無法更新 `online_users` field，將自己移除。因此，無法順利移除的使用者會變成幽靈人口，導致在線使用者的功能異常，無法正確反應「目前在線的使用者有誰」。

### 修改細節
新增 `OnlineUsers` list，並且擁有 `user`, `canonicalPath` 和 `lastOnlineAt` 等 fields，用來記錄使用者最近掛在哪一個頁面上。改寫 `lists/views/online-users.tsx`，讓使用者上線時，在 `OnlineUsers` table 中新增一筆上線的紀錄，並且在下線時，將上線紀錄從 table 中移除；並且透過 polling 的方式，透過 `canonicalPath`， query 目前在線的使用者。
因為有 `lastOnlineAt` 欄位紀錄最近上線時間，所以有使用者掛網太久，導致 cookie 失效，新到頁面的使用者會因為 `lastOnlineAt` 的條件而忽視幽靈人口，使在線使用者功能恢復正常。

### Bonus
因為新的作法不綁定在 `post` list 中，所以我也順便將「在線使用者功能」套在 `project`（專題） list 中。
專題頁面有文字編輯區塊，編輯會需要知道還有誰在線上，避免互相覆蓋對方的修改。