### PR TITLE
fix(cms): fix online users defects

### DIFF
--- a/packages/cms/lists/views/online-users.tsx
+++ b/packages/cms/lists/views/online-users.tsx
@@ -163,9 +163,6 @@ export const Field = ({ value }: FieldProps<typeof controller>) => {
           },
         },
       })
-
-      // Set `validCheckTime` state to trigger re-render.
-      setValidCheckTime(new Date(Date.now() - validCheckTimeWindow))
     }
   }, [userData, canonicalPath, createOnlineUser])
 
@@ -203,8 +200,7 @@ export const Field = ({ value }: FieldProps<typeof controller>) => {
       return
     }
 
-    // Polling to tell the server the user is still online
-    const polling = setInterval(() => {
+    const task = () => {
       const id = onlineUser.id
       updateOnlineUser({
         variables: {
@@ -217,7 +213,13 @@ export const Field = ({ value }: FieldProps<typeof controller>) => {
         },
       })
       setValidCheckTime(new Date(Date.now() - validCheckTimeWindow))
-    }, pollInterval)
+    }
+
+    // execute immediately
+    task()
+
+    // Polling to tell the server the user is still online
+    const polling = setInterval(task, pollInterval)
 
     return () => {
       clearInterval(polling)

--- a/packages/cms/lists/views/online-users.tsx
+++ b/packages/cms/lists/views/online-users.tsx
@@ -116,25 +116,27 @@ export const Field = ({ value }: FieldProps<typeof controller>) => {
     new Date(Date.now() - validCheckTimeWindow)
   )
   const [errorMessage, setErrorMessage] = useState('')
+  const [currentUsers, setCurrentUsers] = useState<User[]>([])
   const canonicalPath = value?.canonicalPath
   const userData: User = value?.userData
 
   // Get current online users for a certain webpage
-  const { error: getOnlineUsersError, data: getOnlineUsersData } = useQuery(
-    GET_ONLINE_USERS,
-    {
-      variables: {
-        where: {
-          canonicalPath: {
-            equals: canonicalPath,
-          },
-          lastOnlineAt: {
-            gte: validCheckTime.toISOString(),
-          },
+  const {
+    loading: getOnlineUsersLoading,
+    error: getOnlineUsersError,
+    data: getOnlineUsersData,
+  } = useQuery(GET_ONLINE_USERS, {
+    variables: {
+      where: {
+        canonicalPath: {
+          equals: canonicalPath,
+        },
+        lastOnlineAt: {
+          gte: validCheckTime.toISOString(),
         },
       },
-    }
-  )
+    },
+  })
 
   const [
     createOnlineUser,
@@ -227,6 +229,23 @@ export const Field = ({ value }: FieldProps<typeof controller>) => {
   }, [createOnlineUserData, updateOnlineUser])
 
   useEffect(() => {
+    if (getOnlineUsersLoading === true) {
+      return
+    }
+
+    const users: User[] =
+      getOnlineUsersData?.onlineUsers?.map((onlineUser: OnlineUser) => {
+        return onlineUser?.user
+      }) ?? []
+
+    const deduplcatedUsers = Array.from(
+      new Map(users?.map((user) => [user.id, user])).values()
+    )
+
+    setCurrentUsers(deduplcatedUsers)
+  }, [getOnlineUsersData, getOnlineUsersLoading, setCurrentUsers])
+
+  useEffect(() => {
     if (
       getOnlineUsersError ||
       createOnlineUserError ||
@@ -249,17 +268,7 @@ export const Field = ({ value }: FieldProps<typeof controller>) => {
     return <span style={{ color: 'red' }}>{errorMessage}</span>
   }
 
-  const users: User[] = getOnlineUsersData?.onlineUsers?.map(
-    (onlineUser: OnlineUser) => {
-      return onlineUser?.user
-    }
-  )
-
-  const deduplcatedUsers = Array.from(
-    new Map(users?.map((user) => [user.id, user])).values()
-  )
-
-  const usersJsx = deduplcatedUsers.map((user) => {
+  const usersJsx = currentUsers.map((user) => {
     return (
       <Avatar key={user.id} color={colors[Number(user.id) % colors.length]}>
         <span>{user.name?.[0]}</span>


### PR DESCRIPTION
### Defect 1：使用者加入頁面後，自己的頭像需要等一段時間才出現
原因是 `setInterval` 並不會馬上執行，而是會等 `pollInterval` (程式碼目前設定 5 秒) 到了才執行，所以自己的頭像都會等上 5 秒才會出現。
解決辦法是在執行 polling 之前，就先 trigger re-render，讓元件去拿最新的頭像，此舉可以避免 5 秒鐘的等待時間。

### Defect 2：頭像會有閃爍的問題
原因是之前的程式碼沒有加上 `getOnlineUsersLoading` 的判斷，當 `getOnlineUsersLoading === true` 時，`getOnlineUsersData` 會是 `undefined`，而當 `getOnlineUsersLoading === false` 時，`getOnlineUsersData` 會有資料；所以當 loading 切換時，會讓資料一下有一下沒有，所以元件會一下 render 沒有頭像，一下 render 有頭像，發生閃爍的問題。
解決辦法是用 `currentUsers` state 來儲存現有的頭像資料，避免 `getOnlineUsersData` 時有時無的狀況。
