### PR TITLE
feat(cms): integrate with Algolia for article search

### DIFF
--- a/packages/cms/environment-variables.ts
+++ b/packages/cms/environment-variables.ts
@@ -23,6 +23,10 @@ const {
   OPEN_AI_KEY,
   TWREPORTER_ID,
   SEARCH_API_KEY,
+  ALGOLIA_APP_ID,
+  ALGOLIA_API_KEY,
+  KIDS_WEBSITE_URL_ORIGIN,
+  ENABLE_ALGOLIA_FEATURE_TOGGLE,
 } = process.env
 
 enum DatabaseProvider {
@@ -94,6 +98,13 @@ const environmentVariables = {
   searchAPIKey: SEARCH_API_KEY || 'search-api-key',
   nodeEnv: NODE_ENV || 'development', // value could be 'development', 'production' or 'test'
   openAIKey: OPEN_AI_KEY || 'open-ai-key',
+  algolia: {
+    appID: ALGOLIA_APP_ID || '',
+    apiKey: ALGOLIA_API_KEY || '',
+  },
+  kidsWebsiteUrlOrigin:
+    KIDS_WEBSITE_URL_ORIGIN || 'https://kids.twreporter.org',
+  enableAlgoliaFeatureToggle: ENABLE_ALGOLIA_FEATURE_TOGGLE === 'true',
 }
 
 export default environmentVariables

--- a/packages/cms/lists/author.ts
+++ b/packages/cms/lists/author.ts
@@ -1,3 +1,4 @@
+import envVars from '../environment-variables'
 import { list } from '@keystone-6/core'
 import { relationship, text, timestamp } from '@keystone-6/core/fields'
 import {
@@ -6,6 +7,9 @@ import {
   RoleEnum,
 } from './utils/access-control-list'
 import { slugConfig } from './config'
+import { algoliasearch } from 'algoliasearch'
+import { authorIndexName, getAuthorObjectID } from './utils/algolia'
+import errors from '@twreporter/errors'
 
 const listConfigurations = list({
   fields: {
@@ -58,5 +62,86 @@ const listConfigurations = list({
   ui: {
     label: 'Authors',
   },
+  hooks: {
+    afterOperation: async ({ operation, item, originalItem, context }) => {
+      if (!envVars.enableAlgoliaFeatureToggle) {
+        return
+      }
+
+      try {
+        const indexName = authorIndexName
+        const client = algoliasearch(
+          envVars.algolia.appID,
+          envVars.algolia.apiKey
+        )
+
+        const objectID = getAuthorObjectID((item || originalItem).id.toString())
+
+        if (operation === 'delete') {
+          try {
+            await client.deleteObject({
+              indexName,
+              objectID,
+            })
+
+            return
+          } catch (_error) {
+            const error = errors.helpers.wrap(
+              _error,
+              'Author.hooks.afterOperation error',
+              'Error to delete Algolia object.',
+              { objectID, indexName }
+            )
+            throw error
+          }
+        }
+
+        const { avatar, image: ogImage } = await context.query.Author.findOne({
+          where: {
+            id: item?.id.toString(),
+          },
+          query: 'avatar { resized { medium } }, image { resized { medium } } ',
+        })
+
+        const record = {
+          url: `${envVars.kidsWebsiteUrlOrigin}/author/${item?.slug}`,
+          name: item?.name,
+          email: item?.email,
+          bio: item?.bio,
+          avatarSrc: avatar?.resized?.medium,
+          ogImgSrc: ogImage?.resized?.medium,
+        }
+
+        try {
+          await client.partialUpdateObject({
+            indexName,
+            objectID,
+            attributesToUpdate: record,
+            createIfNotExists: true,
+          })
+        } catch (_error) {
+          const error = errors.helpers.wrap(
+            _error,
+            'Author.hooks.afterOperation error',
+            'Error to partial update an object in Algolia.',
+            { indexName, objectID, AttributeToUpdate: record }
+          )
+          throw error
+        }
+      } catch (error) {
+        console.log(
+          JSON.stringify({
+            severity: 'ERROR',
+            message: errors.helpers.printAll(error, {
+              withStack: true,
+              withPayload: true,
+            }),
+          })
+        )
+        throw error
+      }
+    },
+  },
 })
+
 export default listConfigurations

--- a/packages/cms/lists/post.ts
+++ b/packages/cms/lists/post.ts
@@ -28,6 +28,8 @@ import {
   articleIndexName,
   getArticleObjectID,
   getAuthorObjectID,
+  convertDraftToText,
+  splitText,
 } from './utils/algolia'
 import errors from '@twreporter/errors'
 
@@ -854,10 +856,9 @@ const listConfigurations = list({
             return {
               objectID: getArticleObjectID(
                 item.id.toString(),
-                index.toString().padStart(3, '0')
+                (index + 1).toString().padStart(3, '0')
               ),
               articleID: `article-${item.id.toString()}`,
-              type: 'article',
               content: chunk,
               ...restAttributes,
             }
@@ -1017,115 +1018,6 @@ async function getHeroImage(
   })
 
   return heroImage?.resized?.medium || ''
-}
-
-// Extract texts from draftjs object.
-function convertDraftToText(draftRawData?: RawDraftContentState) {
-  const blocks = draftRawData?.blocks || []
-  const entityMap = draftRawData?.entityMap || {}
-
-  const contentText: string[] = []
-
-  blocks.forEach((block) => {
-    let text = block.text || ''
-
-    // convert inline entity, such as ANNOTATION entity
-    if (block.entityRanges && block.entityRanges.length > 0) {
-      //  + entity
-      let resultText = ''
-      let lastOffset = 0
-
-      block.entityRanges.forEach(({ offset, length, key }) => {
-        const entity = entityMap[key]
-        if (!entity) {
-          return
-        }
-
-        // Append plain text before the entity
-        resultText += text.slice(lastOffset, offset)
-
-        // Get the text covered by the entity
-        const entityText = text.slice(offset, offset + length)
-
-        if (entity.type === 'ANNOTATION') {
-          const rawContentState = entity.data?.rawContentState
-          const _text = convertDraftToText(rawContentState)
-          resultText += `${entityText} (${_text})`
-        } else {
-          // If it's an unknown entity type, keep the text as is
-          resultText += entityText
-        }
-
-        lastOffset = offset + length
-      })
-
-      // Move the cursor forward
-      resultText += text.slice(lastOffset)
-
-      text = resultText
-    }
-
-    // ----- Handle Atomic Blocks -----
-    if (block.type === 'atomic') {
-      const entityKey =
-        block.entityRanges.length > 0 ? block.entityRanges[0].key : null
-      const entity = entityKey !== null ? entityMap[entityKey] : null
-
-      if (entity) {
-        const entityType = entity.type.toUpperCase()
-
-        // Convert atomic blocks into plain text descriptions
-        switch (entityType) {
-          case 'INFOBOX': {
-            const rawContentState = entity.data?.rawContentState
-            text = convertDraftToText(rawContentState)
-            break
-          }
-          case 'BLOCKQUOTE': {
-            text = entity.data?.text
-            break
-          }
-        }
-      }
-    }
-
-    contentText.push(text)
-  })
-
-  return contentText.join('\n')
-}
-
-// split long text into different chunks
-function splitText(text: string, maxChars = 1500) {
-  // separate long text into paragraphs
-  const paragraphs = text
-    .split(/\n/)
-    .map((p) => p.trim())
-    .filter((p) => p.length > 0)
-
-  const chunks: string[] = []
-  let currentChunk = ''
-
-  paragraphs.forEach((paragraph) => {
-    // if the length of currentChunk + paragraph is less than maxChars,
-    // and then concat currentChunk and paragraph
-    if ((currentChunk + paragraph).length <= maxChars) {
-      currentChunk = currentChunk + paragraph
-    } else {
-      // otherwise, push currentChunk into chunks
-      if (currentChunk) {
-        chunks.push(currentChunk)
-      }
-      currentChunk = paragraph
-    }
-  })
-
-  // push the last one currentChunk
-  if (currentChunk) {
-    chunks.push(currentChunk)
-  }
-
-  return chunks
 }
 
 /**

--- a/packages/cms/lists/post.ts
+++ b/packages/cms/lists/post.ts
@@ -22,6 +22,14 @@ import relationshipUtil, {
   OrderedRelationshipConfig,
 } from './utils/manual-order-relationship'
 import { slugConfig } from './config'
+import { RawDraftContentState } from 'draft-js'
+import { algoliasearch } from 'algoliasearch'
+import {
+  articleIndexName,
+  getArticleObjectID,
+  getAuthorObjectID,
+} from './utils/algolia'
+import errors from '@twreporter/errors'
 
 const subSubcategories: OrderedRelationshipConfig = {
   fieldName: 'subSubcategories',
@@ -712,8 +720,407 @@ const listConfigurations = list({
 
       return resolvedData
     },
+    afterOperation: async ({
+      operation,
+      item,
+      inputData,
+      originalItem,
+      context,
+    }) => {
+      if (!envVars.enableAlgoliaFeatureToggle) {
+        return
+      }
+
+      try {
+        const indexName = articleIndexName
+        const client = algoliasearch(
+          envVars.algolia.appID,
+          envVars.algolia.apiKey
+        )
+
+        const articleID = item
+          ? `article-${item.id.toString()}`
+          : `article-${originalItem.id.toString()}`
+
+        // Article is deleted or not published any more.
+        // Delete indexes on Algolia.
+        if (
+          operation === 'delete' ||
+          (item?.status !== 'published' && originalItem?.status === 'published')
+        ) {
+          try {
+            await client.deleteBy({
+              indexName,
+              deleteByParams: {
+                filters: `articleID:${articleID}`,
+              },
+            })
+          } catch (_error) {
+            const error = errors.helpers.wrap(
+              _error,
+              'Post.hooks.afterOperation error',
+              'Error to delete Algolia indexes.',
+              { articleID, indexName }
+            )
+            throw error
+          }
+
+          return
+        }
+
+        // There is no need to index the article.
+        if (item.status !== 'published') {
+          // `afterOperation` is done.
+          return
+        }
+
+        const _fieldNames = [
+          'slug',
+          'title',
+          'subtitle',
+          'publishedDate',
+          'ogDescription',
+          'status',
+          'authors',
+          'heroImage',
+        ]
+
+        const shouldPartialUpdate = _fieldNames.find((fieldName) => {
+          return Object.prototype.hasOwnProperty.call(inputData, fieldName)
+        })
+
+        if (!shouldPartialUpdate && !inputData?.brief && !inputData?.content) {
+          // Data is unchanged; skip updating the index.
+          // `afterOperation` is done
+          return
+        }
+
+        let res
+
+        try {
+          res = await client.search({
+            requests: [
+              {
+                indexName,
+                query: '',
+                // @TODO we need to handle pagination if needed
+                hitsPerPage: 1000,
+                filters: `articleID:${articleID}`,
+              },
+            ],
+          })
+        } catch (_error) {
+          const error = errors.helpers.wrap(
+            _error,
+            'Post.hooks.afterOperation error',
+            'Error to search records in Algolia.',
+            { indexName, articleID }
+          )
+          throw error
+        }
+
+        // @ts-ignore Not sure why `res.results` is `SearchForFacetValuesResponse` type, rather than `SearchResponse` type
+        const hits = res.results?.[0]?.hits
+
+        const shouldReindexOrBuildIndexFromScratch =
+          hits?.length === 0 || inputData.brief || inputData.content
+
+        const authors = await getAuthors(item.id.toString(), context)
+        const heroImageSrc = await getHeroImage(item.id.toString(), context)
+
+        if (shouldReindexOrBuildIndexFromScratch) {
+          if (hits?.length > 0) {
+            // Delete old indexes
+            await client.deleteBy({
+              indexName,
+              deleteByParams: {
+                filters: `articleID:${articleID}`,
+              },
+            })
+          }
+
+          // Create records from `item`.
+          const newRecord = prepareArticleRecord(item)
+          newRecord.authorIDs = authors?.map((author) =>
+            getAuthorObjectID(author.id)
+          )
+          newRecord.authorNames = authors?.map((author) => author.name)
+          newRecord.imgSrc = heroImageSrc
+          const { contentChunks, ...restAttributes } = newRecord
+
+          // Algolia enforces a 10KB limit per record.
+          // Split content into smaller chunks to prevent exceeding this limit.
+          const objects = contentChunks?.map((chunk, index) => {
+            return {
+              objectID: getArticleObjectID(
+                item.id.toString(),
+                index.toString().padStart(3, '0')
+              ),
+              articleID: `article-${item.id.toString()}`,
+              type: 'article',
+              content: chunk,
+              ...restAttributes,
+            }
+          })
+
+          try {
+            if (objects) {
+              await client.saveObjects({
+                indexName,
+                objects,
+              })
+            }
+          } catch (_error) {
+            const error = errors.helpers.wrap(
+              _error,
+              'Post.hooks.afterOperation error',
+              'Error to save objects into Algolia.',
+              { articleID, indexName, objects }
+            )
+            throw error
+          }
+        }
+
+        // Update only the modified fields of previously indexed records.
+        const partialUpdate = prepareArticleRecord(inputData)
+        if (inputData.authors) {
+          partialUpdate.authorIDs = authors?.map((author) =>
+            getAuthorObjectID(author.id)
+          )
+          partialUpdate.authorNames = authors?.map((author) => author.name)
+        }
+        if (inputData.heroImage) {
+          partialUpdate.imgSrc = heroImageSrc
+        }
+        const { contentChunks, ...restUpdates } = partialUpdate // eslint-disable-line
+        const objects = hits?.map((hit: { objectID: string }) => {
+          return {
+            objectID: hit.objectID,
+            ...restUpdates,
+          }
+        })
+        try {
+          await client.partialUpdateObjects({
+            indexName,
+            objects,
+          })
+        } catch (_error) {
+          const error = errors.helpers.wrap(
+            _error,
+            'Post.hooks.afterOperation error',
+            'Error to partial update indexes in Algolia.',
+            { articleID, indexName, objects }
+          )
+          throw error
+        }
+
+        // `afterOperation` is done
+        return
+      } catch (error) {
+        console.log(
+          JSON.stringify({
+            severity: 'ERROR',
+            message: errors.helpers.printAll(error, {
+              withStack: true,
+              withPayload: true,
+            }),
+          })
+        )
+        throw error
+      }
+    },
   },
 })
+
+type ArticleRecord = {
+  url: string
+  title: string
+  subtitle?: string
+  desc?: string
+  publishedDate?: string
+  publishedTs?: number
+  contentChunks?: string[]
+  authorNames?: string[]
+  authorIDs?: string[]
+  imgSrc?: string
+}
+
+function prepareArticleRecord(
+  fromObject: Record<string, unknown>
+): ArticleRecord {
+  const url = `${envVars.kidsWebsiteUrlOrigin}/article/${fromObject.slug}`
+  const title = fromObject.title as string
+  const subtitle = fromObject.subtitle as string
+  const desc = fromObject.ogDescription as string
+  const publishedDate = fromObject.publishedDate as string
+  let publishedTs: number | undefined = undefined
+  if (publishedDate) {
+    publishedTs = Math.ceil(new Date(publishedDate as string).getTime() / 1000)
+  }
+
+  let contentText = ''
+
+  if (fromObject.brief) {
+    contentText = convertDraftToText(
+      (fromObject.brief as RawDraftContentState) || ''
+    )
+  }
+
+  if (fromObject.content) {
+    contentText += convertDraftToText(
+      (fromObject.content as RawDraftContentState) || ''
+    )
+  }
+
+  const contentChunks = splitText(contentText)
+
+  return {
+    url,
+    title,
+    subtitle,
+    desc,
+    publishedDate,
+    publishedTs,
+    contentChunks,
+  }
+}
+
+async function getAuthors(
+  postID: string,
+  context: KeystoneContext
+): Promise<{ id: string; name: string }[]> {
+  const { authors } = await context.query.Post.findOne({
+    where: {
+      id: postID,
+    },
+    query: 'authors { id, name }',
+  })
+
+  return authors
+}
+
+async function getHeroImage(
+  postID: string,
+  context: KeystoneContext
+): Promise<string> {
+  const { heroImage } = await context.query.Post.findOne({
+    where: {
+      id: postID,
+    },
+    query: 'heroImage { resized { medium }  }',
+  })
+
+  return heroImage?.resized?.medium || ''
+}
+
+// Extract texts from draftjs object.
+function convertDraftToText(draftRawData?: RawDraftContentState) {
+  const blocks = draftRawData?.blocks || []
+  const entityMap = draftRawData?.entityMap || {}
+
+  const contentText: string[] = []
+
+  blocks.forEach((block) => {
+    let text = block.text || ''
+
+    // convert inline entity, such as ANNOTATION entity
+    if (block.entityRanges && block.entityRanges.length > 0) {
+      //  + entity
+      let resultText = ''
+      let lastOffset = 0
+
+      block.entityRanges.forEach(({ offset, length, key }) => {
+        const entity = entityMap[key]
+        if (!entity) {
+          return
+        }
+
+        // Append plain text before the entity
+        resultText += text.slice(lastOffset, offset)
+
+        // Get the text covered by the entity
+        const entityText = text.slice(offset, offset + length)
+
+        if (entity.type === 'ANNOTATION') {
+          const rawContentState = entity.data?.rawContentState
+          const _text = convertDraftToText(rawContentState)
+          resultText += `${entityText} (${_text})`
+        } else {
+          // If it's an unknown entity type, keep the text as is
+          resultText += entityText
+        }
+
+        lastOffset = offset + length
+      })
+
+      // Move the cursor forward
+      resultText += text.slice(lastOffset)
+
+      text = resultText
+    }
+
+    // ----- Handle Atomic Blocks -----
+    if (block.type === 'atomic') {
+      const entityKey =
+        block.entityRanges.length > 0 ? block.entityRanges[0].key : null
+      const entity = entityKey !== null ? entityMap[entityKey] : null
+
+      if (entity) {
+        const entityType = entity.type.toUpperCase()
+
+        // Convert atomic blocks into plain text descriptions
+        switch (entityType) {
+          case 'INFOBOX': {
+            const rawContentState = entity.data?.rawContentState
+            text = convertDraftToText(rawContentState)
+            break
+          }
+          case 'BLOCKQUOTE': {
+            text = entity.data?.text
+            break
+          }
+        }
+      }
+    }
+
+    contentText.push(text)
+  })
+
+  return contentText.join('\n')
+}
+
+// split long text into different chunks
+function splitText(text: string, maxChars = 1500) {
+  // separate long text into paragraphs
+  const paragraphs = text
+    .split(/\n/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+
+  const chunks: string[] = []
+  let currentChunk = ''
+
+  paragraphs.forEach((paragraph) => {
+    // if the length of currentChunk + paragraph is less than maxChars,
+    // and then concat currentChunk and paragraph
+    if ((currentChunk + paragraph).length <= maxChars) {
+      currentChunk = currentChunk + paragraph
+    } else {
+      // otherwise, push currentChunk into chunks
+      if (currentChunk) {
+        chunks.push(currentChunk)
+      }
+      currentChunk = paragraph
+    }
+  })
+
+  // push the last one currentChunk
+  if (currentChunk) {
+    chunks.push(currentChunk)
+  }
+
+  return chunks
+}
 
 /**
  * This function is used to resolve field `authorsJSON`.

--- a/packages/cms/lists/post.ts
+++ b/packages/cms/lists/post.ts
@@ -840,7 +840,7 @@ const listConfigurations = list({
           }
 
           // Create records from `item`.
-          const newRecord = prepareArticleRecord(item)
+          const newRecord = prepareArticleRecord(item as FromObject)
           newRecord.authorIDs = authors?.map((author) =>
             getAuthorObjectID(author.id)
           )
@@ -933,8 +933,8 @@ const listConfigurations = list({
 })
 
 type ArticleRecord = {
-  url: string
-  title: string
+  url?: string
+  title?: string
   subtitle?: string
   desc?: string
   publishedDate?: string
@@ -945,31 +945,37 @@ type ArticleRecord = {
   imgSrc?: string
 }
 
-function prepareArticleRecord(
-  fromObject: Record<string, unknown>
-): ArticleRecord {
-  const url = `${envVars.kidsWebsiteUrlOrigin}/article/${fromObject.slug}`
-  const title = fromObject.title as string
-  const subtitle = fromObject.subtitle as string
-  const desc = fromObject.ogDescription as string
-  const publishedDate = fromObject.publishedDate as string
+type FromObject = {
+  slug?: string
+  title?: string
+  subtitle?: string
+  ogDescription?: string
+  publishedDate?: string
+  brief?: RawDraftContentState
+  content?: RawDraftContentState
+}
+
+function prepareArticleRecord(fromObject: FromObject): ArticleRecord {
+  const url = fromObject.slug
+    ? `${envVars.kidsWebsiteUrlOrigin}/article/${fromObject.slug}`
+    : undefined
+  const title = fromObject.title
+  const subtitle = fromObject.subtitle
+  const desc = fromObject.ogDescription
+  const publishedDate = fromObject.publishedDate
   let publishedTs: number | undefined = undefined
   if (publishedDate) {
-    publishedTs = Math.ceil(new Date(publishedDate as string).getTime() / 1000)
+    publishedTs = Math.ceil(new Date(publishedDate).getTime() / 1000)
   }
 
   let contentText = ''
 
   if (fromObject.brief) {
-    contentText = convertDraftToText(
-      (fromObject.brief as RawDraftContentState) || ''
-    )
+    contentText = convertDraftToText(fromObject.brief || '')
   }
 
   if (fromObject.content) {
-    contentText += convertDraftToText(
-      (fromObject.content as RawDraftContentState) || ''
-    )
+    contentText += convertDraftToText(fromObject.content || '')
   }
 
   const contentChunks = splitText(contentText)

--- a/packages/cms/lists/project.ts
+++ b/packages/cms/lists/project.ts
@@ -1,4 +1,5 @@
 import envVars from '../environment-variables'
+import { RawDraftContentState } from 'draft-js'
 import { KeystoneContext } from '@keystone-6/core/types'
 import {
   customFields,
@@ -21,6 +22,14 @@ import relationshipUtil, {
   OrderedRelationshipConfig,
 } from './utils/manual-order-relationship'
 import { slugConfig } from './config'
+import { algoliasearch } from 'algoliasearch'
+import {
+  topicIndexName,
+  getTopicObjectID,
+  convertDraftToText,
+  splitText,
+} from './utils/algolia'
+import errors from '@twreporter/errors'
 
 const relatedPosts: OrderedRelationshipConfig = {
   fieldName: 'relatedPosts',
@@ -251,7 +260,278 @@ const listConfigurations = list({
       })
       return resolvedData
     },
+    afterOperation: async ({
+      inputData,
+      item,
+      operation,
+      originalItem,
+      context,
+    }) => {
+      if (!envVars.enableAlgoliaFeatureToggle) {
+        return
+      }
+
+      try {
+        const indexName = topicIndexName
+        const client = algoliasearch(
+          envVars.algolia.appID,
+          envVars.algolia.apiKey
+        )
+
+        const topicID = item
+          ? `topic-${item.id.toString()}`
+          : `topic-${originalItem.id.toString()}`
+
+        // Topic is deleted or not published any more.
+        // Delete indexes on Algolia.
+        if (
+          operation === 'delete' ||
+          (item?.status !== 'published' && originalItem?.status === 'published')
+        ) {
+          try {
+            await client.deleteBy({
+              indexName,
+              deleteByParams: {
+                filters: `topicID:${topicID}`,
+              },
+            })
+          } catch (_error) {
+            const error = errors.helpers.wrap(
+              _error,
+              'Project.hooks.afterOperation error',
+              'Error to delete Algolia indexes.',
+              { topicID, indexName }
+            )
+            throw error
+          }
+
+          return
+        }
+
+        // There is no need to index the topic.
+        if (item.status !== 'published') {
+          // `afterOperation` is done.
+          return
+        }
+
+        const _fieldNames = [
+          'slug',
+          'title',
+          'subtitle',
+          'publishedDate',
+          'ogDescription',
+          'status',
+          'heroImage',
+        ]
+
+        const shouldPartialUpdate = _fieldNames.find((fieldName) => {
+          return Object.prototype.hasOwnProperty.call(inputData, fieldName)
+        })
+
+        if (
+          !shouldPartialUpdate &&
+          !inputData?.content &&
+          !inputData?.credits
+        ) {
+          // Data is unchanged; skip updating the index.
+          // `afterOperation` is done
+          return
+        }
+
+        let res
+
+        try {
+          res = await client.search({
+            requests: [
+              {
+                indexName,
+                query: '',
+                // @TODO we need to handle pagination if needed
+                hitsPerPage: 1000,
+                filters: `topicID:${topicID}`,
+              },
+            ],
+          })
+        } catch (_error) {
+          const error = errors.helpers.wrap(
+            _error,
+            'Project.hooks.afterOperation error',
+            'Error to search records in Algolia.',
+            { indexName, topicID }
+          )
+          throw error
+        }
+
+        // @ts-ignore Not sure why `res.results` is `SearchForFacetValuesResponse` type, rather than `SearchResponse` type
+        const hits = res.results?.[0]?.hits
+
+        const shouldReindexOrBuildIndexFromScratch =
+          hits?.length === 0 || inputData.credits || inputData.content
+
+        const heroImageSrc = await getHeroImage(item.id.toString(), context)
+
+        if (shouldReindexOrBuildIndexFromScratch) {
+          if (hits?.length > 0) {
+            // Delete old indexes
+            await client.deleteBy({
+              indexName,
+              deleteByParams: {
+                filters: `topicID:${topicID}`,
+              },
+            })
+          }
+
+          // Create records from `item`.
+          const newRecord = prepareTopicRecord(item as FromObject)
+          newRecord.imgSrc = heroImageSrc
+          const { contentChunks, ...restAttributes } = newRecord
+
+          // Algolia enforces a 10KB limit per record.
+          // Split content into smaller chunks to prevent exceeding this limit.
+          const objects = contentChunks?.map((chunk, index) => {
+            return {
+              objectID: getTopicObjectID(
+                item.id.toString(),
+                (index + 1).toString().padStart(3, '0')
+              ),
+              topicID: `topic-${item.id.toString()}`,
+              content: chunk,
+              ...restAttributes,
+            }
+          })
+
+          try {
+            if (objects) {
+              await client.saveObjects({
+                indexName,
+                objects,
+              })
+            }
+          } catch (_error) {
+            const error = errors.helpers.wrap(
+              _error,
+              'Project.hooks.afterOperation error',
+              'Error to save objects into Algolia.',
+              { topicID, indexName, objects }
+            )
+            throw error
+          }
+        }
+
+        // Update only the modified fields of previously indexed records.
+        const partialUpdate = prepareTopicRecord(inputData)
+        if (inputData.heroImage) {
+          partialUpdate.imgSrc = heroImageSrc
+        }
+        const { contentChunks, ...restUpdates } = partialUpdate // eslint-disable-line
+        const objects = hits?.map((hit: { objectID: string }) => {
+          return {
+            objectID: hit.objectID,
+            ...restUpdates,
+          }
+        })
+        try {
+          await client.partialUpdateObjects({
+            indexName,
+            objects,
+          })
+        } catch (_error) {
+          const error = errors.helpers.wrap(
+            _error,
+            'Project.hooks.afterOperation error',
+            'Error to partial update indexes in Algolia.',
+            { topicID, indexName, objects }
+          )
+          throw error
+        }
+
+        // `afterOperation` is done
+        return
+      } catch (error) {
+        console.log(
+          JSON.stringify({
+            severity: 'ERROR',
+            message: errors.helpers.printAll(error, {
+              withStack: true,
+              withPayload: true,
+            }),
+          })
+        )
+        throw error
+      }
+    },
   },
 })
+
+async function getHeroImage(
+  itemID: string,
+  context: KeystoneContext
+): Promise<string> {
+  const { heroImage } = await context.query.Project.findOne({
+    where: {
+      id: itemID,
+    },
+    query: 'heroImage { resized { medium }  }',
+  })
+
+  return heroImage?.resized?.medium || ''
+}
+
+type TopicRecord = {
+  url?: string
+  title?: string
+  subtitle?: string
+  desc?: string
+  publishedDate?: string
+  publishedTs?: number
+  contentChunks?: string[]
+  imgSrc?: string
+}
+
+type FromObject = {
+  slug?: string
+  title?: string
+  subtitle?: string
+  ogDescription?: string
+  publishedDate?: string
+  content?: RawDraftContentState
+  credits?: RawDraftContentState
+}
+
+function prepareTopicRecord(fromObject: FromObject): TopicRecord {
+  const url = fromObject.slug
+    ? `${envVars.kidsWebsiteUrlOrigin}/topic/${fromObject.slug}`
+    : undefined
+  const title = fromObject.title
+  const subtitle = fromObject.subtitle
+  const desc = fromObject.ogDescription
+  const publishedDate = fromObject.publishedDate
+  let publishedTs: number | undefined = undefined
+  if (publishedDate) {
+    publishedTs = Math.ceil(new Date(publishedDate).getTime() / 1000)
+  }
+
+  let contentText = ''
+
+  if (fromObject.content) {
+    contentText += convertDraftToText(fromObject.content || '')
+  }
+
+  if (fromObject.credits) {
+    contentText = convertDraftToText(fromObject.credits || '')
+  }
+
+  const contentChunks = splitText(contentText)
+
+  return {
+    url,
+    title,
+    subtitle,
+    desc,
+    publishedDate,
+    publishedTs,
+    contentChunks,
+  }
+}
 
 export default listConfigurations

--- a/packages/cms/lists/utils/algolia.ts
+++ b/packages/cms/lists/utils/algolia.ts
@@ -1,5 +1,8 @@
+import { RawDraftContentState } from 'draft-js'
+
 export const articleIndexName = 'article-index'
 export const authorIndexName = 'author-index'
+export const topicIndexName = 'topic-index'
 
 export function getArticleObjectID(aritlceID: string, paragraphID: string) {
   return `article-${aritlceID}-paragraph-${paragraphID}`
@@ -7,4 +10,117 @@ export function getArticleObjectID(aritlceID: string, paragraphID: string) {
 
 export function getAuthorObjectID(authorID: string) {
   return `author-${authorID}`
+}
+
+export function getTopicObjectID(topicID: string, paragraphID: string) {
+  return `topic-${topicID}-paragraph-${paragraphID}`
+}
+
+// Extract texts from draftjs object.
+export function convertDraftToText(draftRawData?: RawDraftContentState) {
+  const blocks = draftRawData?.blocks || []
+  const entityMap = draftRawData?.entityMap || {}
+
+  const contentText: string[] = []
+
+  blocks.forEach((block) => {
+    let text = block.text || ''
+
+    // convert inline entity, such as ANNOTATION entity
+    if (block.entityRanges && block.entityRanges.length > 0) {
+      //  + entity
+      let resultText = ''
+      let lastOffset = 0
+
+      block.entityRanges.forEach(({ offset, length, key }) => {
+        const entity = entityMap[key]
+        if (!entity) {
+          return
+        }
+
+        // Append plain text before the entity
+        resultText += text.slice(lastOffset, offset)
+
+        // Get the text covered by the entity
+        const entityText = text.slice(offset, offset + length)
+
+        if (entity.type === 'ANNOTATION') {
+          const rawContentState = entity.data?.rawContentState
+          const _text = convertDraftToText(rawContentState)
+          resultText += `${entityText} (${_text})`
+        } else {
+          // If it's an unknown entity type, keep the text as is
+          resultText += entityText
+        }
+
+        lastOffset = offset + length
+      })
+
+      // Move the cursor forward
+      resultText += text.slice(lastOffset)
+
+      text = resultText
+    }
+
+    // ----- Handle Atomic Blocks -----
+    if (block.type === 'atomic') {
+      const entityKey =
+        block.entityRanges.length > 0 ? block.entityRanges[0].key : null
+      const entity = entityKey !== null ? entityMap[entityKey] : null
+
+      if (entity) {
+        const entityType = entity.type.toUpperCase()
+
+        // Convert atomic blocks into plain text descriptions
+        switch (entityType) {
+          case 'INFOBOX': {
+            const rawContentState = entity.data?.rawContentState
+            text = convertDraftToText(rawContentState)
+            break
+          }
+          case 'BLOCKQUOTE': {
+            text = entity.data?.text
+            break
+          }
+        }
+      }
+    }
+
+    contentText.push(text)
+  })
+
+  return contentText.join('\n')
+}
+
+// split long text into different chunks
+export function splitText(text: string, maxChars = 1500) {
+  // separate long text into paragraphs
+  const paragraphs = text
+    .split(/\n/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+
+  const chunks: string[] = []
+  let currentChunk = ''
+
+  paragraphs.forEach((paragraph) => {
+    // if the length of currentChunk + paragraph is less than maxChars,
+    // and then concat currentChunk and paragraph
+    if ((currentChunk + paragraph).length <= maxChars) {
+      currentChunk = currentChunk + paragraph
+    } else {
+      // otherwise, push currentChunk into chunks
+      if (currentChunk) {
+        chunks.push(currentChunk)
+      }
+      currentChunk = paragraph
+    }
+  })
+
+  // push the last one currentChunk
+  if (currentChunk) {
+    chunks.push(currentChunk)
+  }
+
+  return chunks
 }

--- a/packages/cms/lists/utils/algolia.ts
+++ b/packages/cms/lists/utils/algolia.ts
@@ -1,0 +1,10 @@
+export const articleIndexName = 'article-index'
+export const authorIndexName = 'author-index'
+
+export function getArticleObjectID(aritlceID: string, paragraphID: string) {
+  return `article-${aritlceID}-paragraph-${paragraphID}`
+}
+
+export function getAuthorObjectID(authorID: string) {
+  return `author-${authorID}`
+}

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -20,17 +20,18 @@
     "@keystone-6/core": "5.2.0",
     "@kids-reporter/cms-core": "1.0.16",
     "@types/react-beautiful-dnd": "^13.1.4",
+    "algoliasearch": "^5.20.4",
     "axios": "^1.6.2",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
+    "draft-js": "^0.11.7",
     "express": "^4.17.1",
     "http-proxy-middleware": "^2.0.3",
     "jsonwebtoken": "^9.0.2",
     "otplib": "^12.0.1",
     "patch-package": "^6.4.7",
     "qrcode": "^1.5.3",
-    "react-beautiful-dnd": "^13.1.1",
-    "draft-js": "^0.11.7"
+    "react-beautiful-dnd": "^13.1.1"
   },
   "resolutions": {
     "**/next": "13.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,122 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
+"@algolia/client-abtesting@5.20.4":
+  version "5.20.4"
+  resolved "https://registry.yarnpkg.com/@algolia/client-abtesting/-/client-abtesting-5.20.4.tgz#eb1dfd010a61d136f26e51feb8e9e7c3a1e74d5f"
+  integrity sha512-OZ3Xvvf+k7NMcwmmioIVX+76E/KKtN607NCMNsBEKe+uHqktZ+I5bmi/EVr2m5VF59Gnh9MTlJCdXtBiGjruxw==
+  dependencies:
+    "@algolia/client-common" "5.20.4"
+    "@algolia/requester-browser-xhr" "5.20.4"
+    "@algolia/requester-fetch" "5.20.4"
+    "@algolia/requester-node-http" "5.20.4"
+
+"@algolia/client-analytics@5.20.4":
+  version "5.20.4"
+  resolved "https://registry.yarnpkg.com/@algolia/client-analytics/-/client-analytics-5.20.4.tgz#536140dbfc8ae8aed9215f3d0cd60503f2ae2bc0"
+  integrity sha512-8pM5zQpHonCIBxKmMyBLgQoaSKUNBE5u741VEIjn2ArujolhoKRXempRAlLwEg5hrORKl9XIlit00ff4g6LWvA==
+  dependencies:
+    "@algolia/client-common" "5.20.4"
+    "@algolia/requester-browser-xhr" "5.20.4"
+    "@algolia/requester-fetch" "5.20.4"
+    "@algolia/requester-node-http" "5.20.4"
+
+"@algolia/client-common@5.20.4":
+  version "5.20.4"
+  resolved "https://registry.yarnpkg.com/@algolia/client-common/-/client-common-5.20.4.tgz#e7451f4f96802fcaf3043796c74748733b2fe973"
+  integrity sha512-OCGa8hKAP6kQKBwi+tu9flTXshz4qeCK5P8J6bI1qq8KYs+/TU1xSotT+E7hO+uyDanGU6dT6soiMSi4A38JgA==
+
+"@algolia/client-insights@5.20.4":
+  version "5.20.4"
+  resolved "https://registry.yarnpkg.com/@algolia/client-insights/-/client-insights-5.20.4.tgz#5364d5898407f239bd17da9ab693fc258e8c0cd8"
+  integrity sha512-MroyJStJFLf/cYeCbguCRdrA2U6miDVqbi3t9ZGovBWWTef7BZwVQG0mLyInzp4MIjBfwqu3xTrhxsiiOavX3A==
+  dependencies:
+    "@algolia/client-common" "5.20.4"
+    "@algolia/requester-browser-xhr" "5.20.4"
+    "@algolia/requester-fetch" "5.20.4"
+    "@algolia/requester-node-http" "5.20.4"
+
+"@algolia/client-personalization@5.20.4":
+  version "5.20.4"
+  resolved "https://registry.yarnpkg.com/@algolia/client-personalization/-/client-personalization-5.20.4.tgz#37eeb952f1b535475a6f25fd1e9921c9abc2356c"
+  integrity sha512-bVR5sxFfgCQ+G0ZegGVhBqtaDd7jCfr33m5mGuT43U+bH//xeqAHQyIS4abcmRulwqeIAHNm5Yl2J7grT3z//A==
+  dependencies:
+    "@algolia/client-common" "5.20.4"
+    "@algolia/requester-browser-xhr" "5.20.4"
+    "@algolia/requester-fetch" "5.20.4"
+    "@algolia/requester-node-http" "5.20.4"
+
+"@algolia/client-query-suggestions@5.20.4":
+  version "5.20.4"
+  resolved "https://registry.yarnpkg.com/@algolia/client-query-suggestions/-/client-query-suggestions-5.20.4.tgz#49582d82d097c2d92e5f90b6390fb63a234090c5"
+  integrity sha512-ZHsV0vceNDR87wIVaz7VjxilwCUCkzbuy4QnqIdnQs3NnC43is7KKbEtKueuNw+YGMdx+wmD5kRI2XKip1R93A==
+  dependencies:
+    "@algolia/client-common" "5.20.4"
+    "@algolia/requester-browser-xhr" "5.20.4"
+    "@algolia/requester-fetch" "5.20.4"
+    "@algolia/requester-node-http" "5.20.4"
+
+"@algolia/client-search@5.20.4":
+  version "5.20.4"
+  resolved "https://registry.yarnpkg.com/@algolia/client-search/-/client-search-5.20.4.tgz#4310cd622c821443a7f00e3445cdef254de90f28"
+  integrity sha512-hXM2LpwTzG5kGQSyq3feIijzzl6vkjYPP+LF3ru1relNUIh7fWJ4uYQay2NMNbWX5LWQzF8Vr9qlIA139doQXg==
+  dependencies:
+    "@algolia/client-common" "5.20.4"
+    "@algolia/requester-browser-xhr" "5.20.4"
+    "@algolia/requester-fetch" "5.20.4"
+    "@algolia/requester-node-http" "5.20.4"
+
+"@algolia/ingestion@1.20.4":
+  version "1.20.4"
+  resolved "https://registry.yarnpkg.com/@algolia/ingestion/-/ingestion-1.20.4.tgz#bd7a116c9d37938d3c88e966c52d439803a5cc6c"
+  integrity sha512-idAe53XsTlLSSQ7pJcjscUEmc67vEM+VohYkr78Ebfb43vtfKH0ik8ux9OGQpLRNGntaHqpe/lfU5PDRi5/92w==
+  dependencies:
+    "@algolia/client-common" "5.20.4"
+    "@algolia/requester-browser-xhr" "5.20.4"
+    "@algolia/requester-fetch" "5.20.4"
+    "@algolia/requester-node-http" "5.20.4"
+
+"@algolia/monitoring@1.20.4":
+  version "1.20.4"
+  resolved "https://registry.yarnpkg.com/@algolia/monitoring/-/monitoring-1.20.4.tgz#4a13f1bee303d2e8fd70664b476461f3f2acf08a"
+  integrity sha512-O6HjdSWtyu5LhHR7gdU83oWbl1vVVRwoTxkENHF61Ar7l9C1Ok91VtnK7RtXB9pJL1kpIMDExwZOT5sEN2Ppfw==
+  dependencies:
+    "@algolia/client-common" "5.20.4"
+    "@algolia/requester-browser-xhr" "5.20.4"
+    "@algolia/requester-fetch" "5.20.4"
+    "@algolia/requester-node-http" "5.20.4"
+
+"@algolia/recommend@5.20.4":
+  version "5.20.4"
+  resolved "https://registry.yarnpkg.com/@algolia/recommend/-/recommend-5.20.4.tgz#5919aed5cafa9615a9f580fc6080f4c4cffadd8a"
+  integrity sha512-p8M78pQjPrN6PudO2TnkWiOJbyp/IPhgCFBW8aZrLshhZpPkV9N4u0YsU/w6OoeYDKSxmXntWQrKYiU1dVRWfg==
+  dependencies:
+    "@algolia/client-common" "5.20.4"
+    "@algolia/requester-browser-xhr" "5.20.4"
+    "@algolia/requester-fetch" "5.20.4"
+    "@algolia/requester-node-http" "5.20.4"
+
+"@algolia/requester-browser-xhr@5.20.4":
+  version "5.20.4"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.20.4.tgz#4ab94d44817a06fdc208fe5cf19ed6297588f62a"
+  integrity sha512-Y8GThjDVdhFUurZKKDdzAML/LNKOA/BOydEcaFeb/g4Iv4Iq0qQJs6aIbtdsngUU6cu74qH/2P84kr2h16uVvQ==
+  dependencies:
+    "@algolia/client-common" "5.20.4"
+
+"@algolia/requester-fetch@5.20.4":
+  version "5.20.4"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-fetch/-/requester-fetch-5.20.4.tgz#d8d640735b7a80f3497ab200f4451ee16415af6e"
+  integrity sha512-OrAUSrvbFi46U7AxOXkyl9QQiaW21XWpixWmcx3D2S65P/DCIGOVE6K2741ZE+WiKIqp+RSYkyDFj3BiFHzLTg==
+  dependencies:
+    "@algolia/client-common" "5.20.4"
+
+"@algolia/requester-node-http@5.20.4":
+  version "5.20.4"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-node-http/-/requester-node-http-5.20.4.tgz#fa493402a29af2a2197a62e8d2ecc37aa96f17e5"
+  integrity sha512-Jc/bofGBw4P9nBii4oCzCqqusv8DAFFORfUD2Ce1cZk3fvUPk+q/Qnu7i9JpTSHjMc0MWzqApLdq7Nwh1gelLg==
+  dependencies:
+    "@algolia/client-common" "5.20.4"
+
 "@alloc/quick-lru@^5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
@@ -3164,10 +3280,10 @@
   dependencies:
     webpack-bundle-analyzer "4.7.0"
 
-"@next/env@13.4.9":
-  version "13.4.9"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-13.4.9.tgz#b77759514dd56bfa9791770755a2482f4d6ca93e"
-  integrity sha512-vuDRK05BOKfmoBYLNi2cujG2jrYbEod/ubSSyqgmEx9n/W3eZaJQdRNhTfumO+qmq/QTzLurW487n/PM/fHOkw==
+"@next/env@13.3.4":
+  version "13.3.4"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-13.3.4.tgz#419bc4aaf67dff0060abcfb0ca097acb23e17a77"
+  integrity sha512-oTK/wRV2qga86m/4VdrR1+/56UA6U1Qv3sIgowB+bZjahniZLEG5BmmQjfoGv7ZuLXBZ8Eec6hkL9BqJcrEL2g==
 
 "@next/eslint-plugin-next@13.4.9":
   version "13.4.9"
@@ -3176,50 +3292,50 @@
   dependencies:
     glob "7.1.7"
 
-"@next/swc-darwin-arm64@13.4.9":
-  version "13.4.9"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.9.tgz#0ed408d444bbc6b0a20f3506a9b4222684585677"
-  integrity sha512-TVzGHpZoVBk3iDsTOQA/R6MGmFp0+17SWXMEWd6zG30AfuELmSSMe2SdPqxwXU0gbpWkJL1KgfLzy5ReN0crqQ==
+"@next/swc-darwin-arm64@13.3.4":
+  version "13.3.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.3.4.tgz#33a84042f6498398d99bf4aa091d7e2f1a3f5df3"
+  integrity sha512-vux7RWfzxy1lD21CMwZsy9Ej+0+LZdIIj1gEhVmzOQqQZ5N56h8JamrjIVCfDL+Lpj8KwOmFZbPHE8qaYnL2pg==
 
-"@next/swc-darwin-x64@13.4.9":
-  version "13.4.9"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.9.tgz#a08fccdee68201522fe6618ec81f832084b222f8"
-  integrity sha512-aSfF1fhv28N2e7vrDZ6zOQ+IIthocfaxuMWGReB5GDriF0caTqtHttAvzOMgJgXQtQx6XhyaJMozLTSEXeNN+A==
+"@next/swc-darwin-x64@13.3.4":
+  version "13.3.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-13.3.4.tgz#47bc98c575ab82ed4d220802ed2609e930702469"
+  integrity sha512-1tb+6JT98+t7UIhVQpKL7zegKnCs9RKU6cKNyj+DYKuC/NVl49/JaIlmwCwK8Ibl+RXxJrK7uSXSIO71feXsgw==
 
-"@next/swc-linux-arm64-gnu@13.4.9":
-  version "13.4.9"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.9.tgz#1798c2341bb841e96521433eed00892fb24abbd1"
-  integrity sha512-JhKoX5ECzYoTVyIy/7KykeO4Z2lVKq7HGQqvAH+Ip9UFn1MOJkOnkPRB7v4nmzqAoY+Je05Aj5wNABR1N18DMg==
+"@next/swc-linux-arm64-gnu@13.3.4":
+  version "13.3.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.3.4.tgz#7f9e89554b5410148b5c3640db58ff8b25002de6"
+  integrity sha512-UqcKkYTKslf5YAJNtZ5XV1D5MQJIkVtDHL8OehDZERHzqOe7jvy41HFto33IDPPU8gJiP5eJb3V9U26uifqHjw==
 
-"@next/swc-linux-arm64-musl@13.4.9":
-  version "13.4.9"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.9.tgz#cee04c51610eddd3638ce2499205083656531ea0"
-  integrity sha512-OOn6zZBIVkm/4j5gkPdGn4yqQt+gmXaLaSjRSO434WplV8vo2YaBNbSHaTM9wJpZTHVDYyjzuIYVEzy9/5RVZw==
+"@next/swc-linux-arm64-musl@13.3.4":
+  version "13.3.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.3.4.tgz#b282180d64580eae95e05e2ea7c7e1a9b717d7ea"
+  integrity sha512-HE/FmE8VvstAfehyo/XsrhGgz97cEr7uf9IfkgJ/unqSXE0CDshDn/4as6rRid74eDR8/exi7c2tdo49Tuqxrw==
 
-"@next/swc-linux-x64-gnu@13.4.9":
-  version "13.4.9"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.9.tgz#1932d0367916adbc6844b244cda1d4182bd11f7a"
-  integrity sha512-iA+fJXFPpW0SwGmx/pivVU+2t4zQHNOOAr5T378PfxPHY6JtjV6/0s1vlAJUdIHeVpX98CLp9k5VuKgxiRHUpg==
+"@next/swc-linux-x64-gnu@13.3.4":
+  version "13.3.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.3.4.tgz#645192393eecd1cd4f19f61f9415458e4f3789f0"
+  integrity sha512-xU+ugaupGA4SL5aK1ZYEqVHrW3TPOhxVcpaJLfpANm2443J4GfxCmOacu9XcSgy5c51Mq7C9uZ1LODKHfZosRQ==
 
-"@next/swc-linux-x64-musl@13.4.9":
-  version "13.4.9"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.9.tgz#a66aa8c1383b16299b72482f6360facd5cde3c7a"
-  integrity sha512-rlNf2WUtMM+GAQrZ9gMNdSapkVi3koSW3a+dmBVp42lfugWVvnyzca/xJlN48/7AGx8qu62WyO0ya1ikgOxh6A==
+"@next/swc-linux-x64-musl@13.3.4":
+  version "13.3.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.3.4.tgz#25e2f63e29f2723fa9ec658089d6e3a0e78e0992"
+  integrity sha512-cZvmf5KcYeTfIK6bCypfmxGUjme53Ep7hx94JJtGrYgCA1VwEuYdh+KouubJaQCH3aqnNE7+zGnVEupEKfoaaA==
 
-"@next/swc-win32-arm64-msvc@13.4.9":
-  version "13.4.9"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.9.tgz#39482ee856c867177a612a30b6861c75e0736a4a"
-  integrity sha512-5T9ybSugXP77nw03vlgKZxD99AFTHaX8eT1ayKYYnGO9nmYhJjRPxcjU5FyYI+TdkQgEpIcH7p/guPLPR0EbKA==
+"@next/swc-win32-arm64-msvc@13.3.4":
+  version "13.3.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.3.4.tgz#9a4b7ab348b4a2000aa6e36de1b180ca97461356"
+  integrity sha512-7dL+CAUAjmgnVbjXPIpdj7/AQKFqEUL3bKtaOIE1JzJ5UMHHAXCPwzQtibrsvQpf9MwcAmiv8aburD3xH1xf8w==
 
-"@next/swc-win32-ia32-msvc@13.4.9":
-  version "13.4.9"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.9.tgz#29db85e34b597ade1a918235d16a760a9213c190"
-  integrity sha512-ojZTCt1lP2ucgpoiFgrFj07uq4CZsq4crVXpLGgQfoFq00jPKRPgesuGPaz8lg1yLfvafkU3Jd1i8snKwYR3LA==
+"@next/swc-win32-ia32-msvc@13.3.4":
+  version "13.3.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.3.4.tgz#c3e245784b9f0002f00f5046e472ba77322d617c"
+  integrity sha512-qplTyzEl1vPkS+/DRK3pKSL0HeXrPHkYsV7U6gboHYpfqoHY+bcLUj3gwVUa9PEHRIoq4vXvPzx/WtzE6q52ng==
 
-"@next/swc-win32-x64-msvc@13.4.9":
-  version "13.4.9"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.9.tgz#0c2758164cccd61bc5a1c6cd8284fe66173e4a2b"
-  integrity sha512-QbT03FXRNdpuL+e9pLnu+XajZdm/TtIXVYY4lA9t+9l0fLZbHXDYEKitAqxrOj37o3Vx5ufxiRAniaIebYDCgw==
+"@next/swc-win32-x64-msvc@13.3.4":
+  version "13.3.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.3.4.tgz#a7a488e9a47b7ca726b7d458f1dcf09f5377b791"
+  integrity sha512-usdvZT7JHrTuXC+4OKN5mCzUkviFkCyJJTkEz8jhBpucg+T7s83e7owm3oNFzmj5iKfvxU2St6VkcnSgpFvEYA==
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3":
   version "2.1.8-no-fsevents.3"
@@ -4985,6 +5101,25 @@ ajv@^8.0.0, ajv@^8.0.1, ajv@^8.6.3, ajv@^8.9.0:
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
+
+algoliasearch@^5.20.4:
+  version "5.20.4"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-5.20.4.tgz#514a74569ccd58293d9c64e9f6a0fcdf81a24612"
+  integrity sha512-wjfzqruxovJyDqga8M6Xk5XtfuVg3igrWjhjgkRya87+WwfEa1kg+IluujBLzgAiMSd6rO6jqRb7czjgeeSYgQ==
+  dependencies:
+    "@algolia/client-abtesting" "5.20.4"
+    "@algolia/client-analytics" "5.20.4"
+    "@algolia/client-common" "5.20.4"
+    "@algolia/client-insights" "5.20.4"
+    "@algolia/client-personalization" "5.20.4"
+    "@algolia/client-query-suggestions" "5.20.4"
+    "@algolia/client-search" "5.20.4"
+    "@algolia/ingestion" "1.20.4"
+    "@algolia/monitoring" "1.20.4"
+    "@algolia/recommend" "5.20.4"
+    "@algolia/requester-browser-xhr" "5.20.4"
+    "@algolia/requester-fetch" "5.20.4"
+    "@algolia/requester-node-http" "5.20.4"
 
 ansi-colors@^4.1.1, ansi-colors@^4.1.3:
   version "4.1.3"
@@ -9667,29 +9802,27 @@ new-github-issue-url@0.2.1:
   resolved "https://registry.yarnpkg.com/new-github-issue-url/-/new-github-issue-url-0.2.1.tgz#e17be1f665a92de465926603e44b9f8685630c1d"
   integrity sha512-md4cGoxuT4T4d/HDOXbrUHkTKrp/vp+m3aOA7XXVYwNsUNMK49g3SQicTSeV5GIz/5QVGAeYRAOlyp9OvlgsYA==
 
-next@13.4.9, next@^13.3.0:
-  version "13.4.9"
-  resolved "https://registry.yarnpkg.com/next/-/next-13.4.9.tgz#473de5997cb4c5d7a4fb195f566952a1cbffbeba"
-  integrity sha512-vtefFm/BWIi/eWOqf1GsmKG3cjKw1k3LjuefKRcL3iiLl3zWzFdPG3as6xtxrGO6gwTzzaO1ktL4oiHt/uvTjA==
+next@13.3.4, next@13.4.9, next@^13.3.0:
+  version "13.3.4"
+  resolved "https://registry.yarnpkg.com/next/-/next-13.3.4.tgz#ce2d96053cabfca092cc829941efe5dfbe015d16"
+  integrity sha512-sod7HeokBSvH5QV0KB+pXeLfcXUlLrGnVUXxHpmhilQ+nQYT3Im2O8DswD5e4uqbR8Pvdu9pcWgb1CbXZQZlmQ==
   dependencies:
-    "@next/env" "13.4.9"
+    "@next/env" "13.3.4"
     "@swc/helpers" "0.5.1"
     busboy "1.6.0"
     caniuse-lite "^1.0.30001406"
     postcss "8.4.14"
     styled-jsx "5.1.1"
-    watchpack "2.4.0"
-    zod "3.21.4"
   optionalDependencies:
-    "@next/swc-darwin-arm64" "13.4.9"
-    "@next/swc-darwin-x64" "13.4.9"
-    "@next/swc-linux-arm64-gnu" "13.4.9"
-    "@next/swc-linux-arm64-musl" "13.4.9"
-    "@next/swc-linux-x64-gnu" "13.4.9"
-    "@next/swc-linux-x64-musl" "13.4.9"
-    "@next/swc-win32-arm64-msvc" "13.4.9"
-    "@next/swc-win32-ia32-msvc" "13.4.9"
-    "@next/swc-win32-x64-msvc" "13.4.9"
+    "@next/swc-darwin-arm64" "13.3.4"
+    "@next/swc-darwin-x64" "13.3.4"
+    "@next/swc-linux-arm64-gnu" "13.3.4"
+    "@next/swc-linux-arm64-musl" "13.3.4"
+    "@next/swc-linux-x64-gnu" "13.3.4"
+    "@next/swc-linux-x64-musl" "13.3.4"
+    "@next/swc-win32-arm64-msvc" "13.3.4"
+    "@next/swc-win32-ia32-msvc" "13.3.4"
+    "@next/swc-win32-x64-msvc" "13.3.4"
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -10670,13 +10803,13 @@ react-day-picker@^8.0.4:
   resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-8.10.0.tgz#729c5b9564967a924213978fb9c0751884a60595"
   integrity sha512-mz+qeyrOM7++1NCb1ARXmkjMkzWVh2GL9YiPbRjKe0zHccvekk4HE+0MPOZOrosn8r8zTHIIeOUXTmXRqmkRmg==
 
-react-dom@18.1.0, react-dom@18.2.0, react-dom@^18.2.0:
-  version "18.1.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.1.0.tgz#7f6dd84b706408adde05e1df575b3a024d7e8a2f"
-  integrity sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==
+react-dom@18.2.0, react-dom@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
+  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
   dependencies:
     loose-envify "^1.1.0"
-    scheduler "^0.22.0"
+    scheduler "^0.23.0"
 
 react-fast-compare@^3.0.1, react-fast-compare@^3.1.1:
   version "3.2.2"
@@ -10798,10 +10931,10 @@ react-transition-group@^4.3.0, react-transition-group@^4.4.2, react-transition-g
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@18.1.0, react@18.2.0, react@^18.1.0, react@^18.2.0:
-  version "18.1.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.1.0.tgz#6f8620382decb17fdc5cc223a115e2adbf104890"
-  integrity sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==
+react@18.2.0, react@^18.1.0, react@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
 
@@ -11187,10 +11320,10 @@ safe-regex-test@^1.0.3:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-scheduler@^0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.22.0.tgz#83a5d63594edf074add9a7198b1bae76c3db01b8"
-  integrity sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==
+scheduler@^0.23.0:
+  version "0.23.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.2.tgz#414ba64a3b282892e944cf2108ecc078d115cdc3"
+  integrity sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==
   dependencies:
     loose-envify "^1.1.0"
 
@@ -12666,7 +12799,7 @@ warning@^4.0.2:
   dependencies:
     loose-envify "^1.0.0"
 
-watchpack@2.4.0, watchpack@^2.4.0:
+watchpack@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d"
   integrity sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==
@@ -13119,8 +13252,3 @@ zlib@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/zlib/-/zlib-1.0.5.tgz#6e7c972fc371c645a6afb03ab14769def114fcc0"
   integrity sha512-40fpE2II+Cd3k8HWTWONfeKE2jL+P42iWJ1zzps5W51qcTsOUKM5Q5m2PFb0CLxlmFAaUuUdJGc3OfZy947v0w==
-
-zod@3.21.4:
-  version "3.21.4"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"
-  integrity sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==


### PR DESCRIPTION
### 前情提要
因為「議會透視版」需要做搜尋功能，但因為該服務的資料還沒有 ready，
所以我先拿少年報導者的資料來串接 Algolia，看看 Algolia 好不好用，以及符不符合我們的需求。
如果 Algolia 的效果不錯，我們也可趁機優化少年報導者的搜尋功能。

### 任務說明
在 Algolia 系統中，為少年報導者的「專題」、「文章」和「作者」建立索引。

### 實作細節
將專題和文章的「文字」從 `content`, `brief`, `credits` 等 DraftJS raw data object 中抓取出來，
並且與其他欄位，例如 `title`, `subtitle`, `authors`, `heroImage` 等組成一個 record，
透過 Algolia API，在 Algolia 服務中建立文章索引。

但因為 Algolia 有 record size 10Kb 的限制，當一篇文章內容文字量過大時，可能需要多個 records 來建立索引，
所以此 PR 花了比較多篇幅在處理多個 records 更新／刪除／創建的邏輯。