### PR TITLE
fix(cms): upgrade @keystone-6/core to 5.8.0 to fix build failures

### DIFF
--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -17,8 +17,8 @@
   "license": "MIT",
   "dependencies": {
     "@keystone-6/auth": "7.0.0",
-    "@keystone-6/core": "5.2.0",
-    "@kids-reporter/cms-core": "1.0.16",
+    "@keystone-6/core": "5.8.0",
+    "@kids-reporter/cms-core": "^1.0.17",
     "@types/react-beautiful-dnd": "^13.1.4",
     "axios": "^1.6.2",
     "cookie-parser": "^1.4.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/cms-core",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "",
   "main": "lib/index.js",
   "types": "src/index.ts",
@@ -25,7 +25,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@keystone-6/core": "5.2.0"
+    "@keystone-6/core": "5.8.0"
   },
   "dependencies": {
     "@google-cloud/storage": "^5.18.0",
@@ -33,7 +33,7 @@
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",
     "@twreporter/errors": "^1.1.1",
-    "@kids-reporter/draft-editor": "1.0.16",
+    "@kids-reporter/draft-editor": "^1.0.17",
     "axios": "^0.26.0",
     "draft-convert": "^2.1.12",
     "draft-js": "^0.11.7",

--- a/packages/draft-editor/package.json
+++ b/packages/draft-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/draft-editor",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -28,7 +28,7 @@
     "draft-js": "^0.11.7"
   },
   "peerDependencies": {
-    "@keystone-6/core": "5.2.0",
+    "@keystone-6/core": "5.8.0",
     "@keystone-ui/button": "^7.0.2",
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",


### PR DESCRIPTION
### PR 說明
PR https://github.com/kids-reporter/kids-reporter-monorepo/pull/734 、 https://github.com/kids-reporter/kids-reporter-monorepo/pull/735 將 next 升級到 13.5.11 後，會遇到 @keystone-6/core 無法順利 `keystone build` 的問題，相關訊息請見 https://github.com/keystonejs/keystone/pull/8788 。

因此，我們必須將 monorepo 中的 @keystone-6/core 升級到  > 5.5.1 的版本，才會解決 `keystone build` 無法順利執行完畢的問題。