### PR TITLE
refactor(frontend): update category page. Provide dynamic metadata.

### DIFF
--- a/packages/cms/lists/subcatgory.ts
+++ b/packages/cms/lists/subcatgory.ts
@@ -19,6 +19,18 @@ const listConfigurations = list({
       label: '次類別中文名稱（使用於 CMS）',
       validation: { isRequired: true },
     }),
+    ogTitle: text({
+      label: 'og:title',
+      validation: { isRequired: false },
+    }),
+    ogDescription: text({
+      label: 'og:description',
+      validation: { isRequired: false },
+    }),
+    ogImage: relationship({
+      label: 'og:image',
+      ref: 'Photo',
+    }),
     category: relationship({
       ref: 'Category.subcategories',
       many: false,

--- a/packages/cms/lists/utils/access-control-list.ts
+++ b/packages/cms/lists/utils/access-control-list.ts
@@ -22,7 +22,7 @@ export const RoleEnum = {
 }
 
 export const allowRoles = (roles: string[]) => {
-  return ({ session }: { session: Session }) => {
+  return ({ session }: { session?: Session }) => {
     if (envVars.nodeEnv === 'test') {
       return true
     }
@@ -30,6 +30,11 @@ export const allowRoles = (roles: string[]) => {
     if (!Array.isArray(roles)) {
       return false
     }
+
+    if (!session) {
+      return false
+    }
+
     return roles.indexOf(session?.data.role) > -1
   }
 }
@@ -50,10 +55,15 @@ export const allowAllRoles = () => {
 }
 
 export const denyRoles = (roles: string[]) => {
-  return ({ session }: { session: Session }) => {
+  return ({ session }: { session?: Session }) => {
     if (!Array.isArray(roles)) {
       return true
     }
+
+    if (!session) {
+      return false
+    }
+
     return roles.indexOf(session?.data.role) === -1
   }
 }

--- a/packages/cms/migrations/20250408022709_add_og_fields_in_subcategory_list/migration.sql
+++ b/packages/cms/migrations/20250408022709_add_og_fields_in_subcategory_list/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable
+ALTER TABLE "Subcategory" ADD COLUMN     "ogDescription" TEXT NOT NULL DEFAULT '',
+ADD COLUMN     "ogImage" INTEGER,
+ADD COLUMN     "ogTitle" TEXT NOT NULL DEFAULT '';
+
+-- CreateIndex
+CREATE INDEX "Subcategory_ogImage_idx" ON "Subcategory"("ogImage");
+
+-- AddForeignKey
+ALTER TABLE "Subcategory" ADD CONSTRAINT "Subcategory_ogImage_fkey" FOREIGN KEY ("ogImage") REFERENCES "Photo"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/cms/schema.graphql
+++ b/packages/cms/schema.graphql
@@ -943,6 +943,9 @@ type Subcategory {
   slug: String
   name: String
   nameForCMS: String
+  ogTitle: String
+  ogDescription: String
+  ogImage: Photo
   category: Category
   subSubcategories(where: SubSubcategoryWhereInput! = {}, orderBy: [SubSubcategoryOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: SubSubcategoryWhereUniqueInput): [SubSubcategory!]
   subSubcategoriesCount(where: SubSubcategoryWhereInput! = {}): Int
@@ -966,6 +969,9 @@ input SubcategoryWhereInput {
   slug: StringFilter
   name: StringFilter
   nameForCMS: StringFilter
+  ogTitle: StringFilter
+  ogDescription: StringFilter
+  ogImage: PhotoWhereInput
   category: CategoryWhereInput
   subSubcategories: SubSubcategoryManyRelationFilter
   createdAt: DateTimeNullableFilter
@@ -977,6 +983,8 @@ input SubcategoryOrderByInput {
   slug: OrderDirection
   name: OrderDirection
   nameForCMS: OrderDirection
+  ogTitle: OrderDirection
+  ogDescription: OrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
 }
@@ -985,6 +993,9 @@ input SubcategoryUpdateInput {
   slug: String
   name: String
   nameForCMS: String
+  ogTitle: String
+  ogDescription: String
+  ogImage: PhotoRelateToOneForUpdateInput
   category: CategoryRelateToOneForUpdateInput
   subSubcategories: SubSubcategoryRelateToManyForUpdateInput
   createdAt: DateTime
@@ -1006,6 +1017,9 @@ input SubcategoryCreateInput {
   slug: String
   name: String
   nameForCMS: String
+  ogTitle: String
+  ogDescription: String
+  ogImage: PhotoRelateToOneForCreateInput
   category: CategoryRelateToOneForCreateInput
   subSubcategories: SubSubcategoryRelateToManyForCreateInput
   createdAt: DateTime

--- a/packages/cms/schema.prisma
+++ b/packages/cms/schema.prisma
@@ -101,6 +101,7 @@ model Photo {
   from_ProjectCategory_ogImage   ProjectCategory[] @relation("ProjectCategory_ogImage")
   from_Category_heroImage        Category[]        @relation("Category_heroImage")
   from_Category_ogImage          Category[]        @relation("Category_ogImage")
+  from_Subcategory_ogImage       Subcategory[]     @relation("Subcategory_ogImage")
   from_Tag_ogImage               Tag[]             @relation("Tag_ogImage")
 }
 
@@ -202,12 +203,17 @@ model Subcategory {
   slug             String           @unique @default("")
   name             String           @default("")
   nameForCMS       String           @unique @default("")
+  ogTitle          String           @default("")
+  ogDescription    String           @default("")
+  ogImage          Photo?           @relation("Subcategory_ogImage", fields: [ogImageId], references: [id])
+  ogImageId        Int?             @map("ogImage")
   category         Category?        @relation("Subcategory_category", fields: [categoryId], references: [id])
   categoryId       Int?             @map("category")
   subSubcategories SubSubcategory[] @relation("SubSubcategory_subcategory")
   createdAt        DateTime?        @default(now())
   updatedAt        DateTime?        @updatedAt
 
+  @@index([ogImageId])
   @@index([categoryId])
 }
 

--- a/packages/frontend/src/app/(sticky-header)/category/[[...path]]/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/category/[[...path]]/page.tsx
@@ -12,9 +12,79 @@ import {
 } from '@/app/constants'
 import { getPostSummaries, sendGQLRequest, log, LogLevel } from '@/app/utils'
 
-export const metadata: Metadata = {
-  title: '分類: 少年報導者 The Reporter for Kids',
-  description: GENERAL_DESCRIPTION,
+const seoFields = `
+  ogTitle
+  ogDescription
+  ogImage {
+    resized {
+      medium
+    }
+  }
+`
+
+const query = `
+  query GetCategory($categoryWhere: CategoryWhereUniqueInput!, $subcategoryWhere: SubcategoryWhereInput!) {
+    category(where: $categoryWhere) {
+      ${seoFields}
+      subcategories(where: $subcategoryWhere) {
+        ${seoFields}
+      }
+    }
+  }
+`
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { path: string[] }
+}): Promise<Metadata> {
+  const categorySlug = params.path?.[0]
+  const subcategorySlug = params.path?.[1] ?? ''
+
+  const res = await sendGQLRequest({
+    query,
+    variables: {
+      categoryWhere: {
+        slug: categorySlug,
+      },
+      subcategoryWhere: {
+        slug: {
+          equals: subcategorySlug,
+        },
+      },
+    },
+  })
+
+  const category = res?.data?.data?.category
+
+  if (!category) {
+    log(
+      LogLevel.INFO,
+      `Category metadata not found. URL path is: /${params.path.join('/')}`
+    )
+    return {}
+  }
+
+  const title =
+    category?.subcategories?.[0]?.ogTitle ||
+    category?.ogTitle ||
+    '分類: 少年報導者 The Reporter for Kids'
+  const description =
+    category?.subcategories?.[0]?.ogDescription ||
+    category?.ogDescription ||
+    GENERAL_DESCRIPTION
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images:
+        category?.subcategories?.[0]?.ogImage?.resized?.medium ??
+        category?.ogImage?.resized?.medium,
+    },
+  }
 }
 
 const subcategoriesGQL = `


### PR DESCRIPTION
### 任務說明
舊的程式碼寫死所有 category 的 title 和 description，
所以不管是 `https://kids.twreporter.org/category/news`

[任務卡](https://www.notion.so/twreporter/title-1ce8dbdca93280c580d7f26c858631d6)

### 實作細節
Replace named export: `metadata` -> `generateMetadata`.
在 `generateMetadata` function 中，向 GQL API 詢問 `ogTitle`, `ogDescription` 和 `ogImage` 等資訊，再將資訊交由 nextjs 產生 html metadata。