### PR TITLE
fix(frontend): unexpected error while generating metadata of author page

### DIFF
--- a/packages/frontend/src/app/(sticky-header)/author/[[...slug]]/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/author/[[...slug]]/page.tsx
@@ -65,6 +65,7 @@ export async function generateMetadata({
   const authorMeta = authorMetaRes?.data?.data?.author
   if (!authorMeta) {
     log(LogLevel.WARNING, `Author meta not found! ${slug}`)
+    return {}
   }
 
   return {


### PR DESCRIPTION
### Bug 
`authorMeta.name` causes "TypeError: Cannot read properties of null(reading 'name')"

### Error Reporting
https://console.cloud.google.com/errors/detail/CNS_maG_0o3wygE;locations=global;time=P30D?project=kids-reporter&utm_source=error-reporting-notification&utm_medium=slack&utm_content=resolved-error&invt=Abub2w


