### PR TITLE
fix(frontend): switch from ISR to SSR to resolve stale page issue behind CDN

### DIFF
--- a/packages/frontend/src/app/page.tsx
+++ b/packages/frontend/src/app/page.tsx
@@ -15,11 +15,9 @@ import {
   Theme,
 } from '@/app/constants'
 import { getPostSummaries, sendGQLRequest } from '@/app/utils'
-import { isProduction } from '@/environment-variables'
 
-// Specify revalidation time for static rendering in production env
-console.log('isProduction:', isProduction)
-export const revalidate = isProduction ? 300 : 0
+export const dynamic = 'force-dynamic'
+
 export const metadata: Metadata = {
   title: '少年報導者 The Reporter for Kids - 理解世界 參與未來',
   description: GENERAL_DESCRIPTION,


### PR DESCRIPTION
### Bug 說明
首頁使用 ISR (Incremental Static Regeneration) 的方式產生頁面，該方式在 request 進來時，先看有沒有 cache 的版本
- 如果沒有，產生頁面，並且回傳頁面，將該次產生的頁面放入 cache 中
- 如果有，先回傳 cache 的版本；如果 cache 的版本已經過期，則「再次」產生頁面，並且更新 cache

ISR 產生的 response 會根據 `export const revalidate=300` 產生 `Cache-Cotnrol: public, s-max-age=300, stale-while-revalidate` response header，這個 response header 會讓 response 被 CDN Cloudflare cache 起來。

但尚不清楚原因為何，Cloudflare cache 首頁後，就算時間過了 300 秒，仍會一直回傳 cache 的資料。根據編輯的回報，即便過了半天，仍然會拿到 cache 的版本。

### 解決辦法
因為 Cloudflare 的 Page Rule 上面，本來就有針對 `https://kids.twreporter.org/*` 進行 cache，所以像是文章頁、專題頁的 response header 都會被 Cloudflare cache 五分鐘。因此，首頁其實不需要自己做 ISR 進行 cache，可以統一都讓 Cloudflare 幫忙 cache。