### PR TITLE
feat(cms): add member list and provision member if authorization header present

### DIFF
--- a/packages/cms/environment-variables.ts
+++ b/packages/cms/environment-variables.ts
@@ -23,6 +23,7 @@ const {
   OPEN_AI_KEY,
   TWREPORTER_ID,
   SEARCH_API_KEY,
+  TWREPORTER_JWT_SECRET,
 } = process.env
 
 enum DatabaseProvider {
@@ -94,6 +95,7 @@ const environmentVariables = {
   searchAPIKey: SEARCH_API_KEY || 'search-api-key',
   nodeEnv: NODE_ENV || 'development', // value could be 'development', 'production' or 'test'
   openAIKey: OPEN_AI_KEY || 'open-ai-key',
+  twreporterJWTSecret: TWREPORTER_JWT_SECRET || '',
 }
 
 export default environmentVariables

--- a/packages/cms/keystone.ts
+++ b/packages/cms/keystone.ts
@@ -4,12 +4,14 @@ import { config } from '@keystone-6/core'
 import { listDefinition as lists } from './lists'
 import appConfig from './config'
 import envVar from './environment-variables'
+import jwt from 'jsonwebtoken'
 import { Request, Response, NextFunction } from 'express'
 import { createAuth } from '@keystone-6/auth'
 import { statelessSessions } from '@keystone-6/core/session'
 import { InMemoryLRUCache } from '@apollo/utils.keyvaluecache'
 import { createPreviewMiniApp } from './express-mini-apps/preview/app'
 import { twoFactorAuth } from './express-mini-apps/two-factor-auth'
+import type { TypedKeystoneContext } from './types/context'
 
 const { withAuth } = createAuth({
   listKey: 'User',
@@ -138,9 +140,85 @@ export default withAuth(
           return next()
         }
 
+        /**
+         * Middleware: Verify JWT and provision member if needed.
+         *
+         * 1. Check if the request contains an Authorization header with the format `Bearer <token>`.
+         * 2. Verify the JWT using HS256 and the configured secret.
+         * 3. Ensure the decoded token contains a valid `user_id`.
+         * 4. Query the local database for an existing member record with the given `user_id`.
+         *    - If not found, create a new member record using `email` and `user_id` from the token.
+         * 5. Attach the member data to the session context for downstream resolvers/middleware.
+         *
+         * Note: This middleware only runs when an Authorization header is present.
+         */
+        const jwtVerifyAndProvisionMember = async (
+          req: Request,
+          res: Response,
+          next: NextFunction
+        ) => {
+          const context: TypedKeystoneContext = await commonContext.withRequest(
+            req,
+            res
+          )
+          const auth = req.headers.authorization || ''
+          const token = auth.startsWith('Bearer ') ? auth.slice(7) : ''
+          if (token) {
+            const decoded = jwt.verify(token, envVar.twreporterJWTSecret, {
+              algorithms: ['HS256'],
+              ignoreNotBefore: true,
+            }) as jwt.JwtPayload
+
+            if (!decoded || !decoded.user_id) {
+              return res.status(401).json({
+                status: 'fail',
+                data: 'Unauthorized due to invalid access token.',
+              })
+            }
+
+            try {
+              let member = await context.prisma.member.findUnique({
+                where: {
+                  twreporter_user_id: `${decoded.user_id}`,
+                },
+                select: {
+                  id: true,
+                  twreporter_user_id: true,
+                },
+              })
+
+              if (!member) {
+                const data = {
+                  email: decoded.email,
+                  twreporter_user_id: `${decoded.user_id}`,
+                }
+                member = await context.prisma.member.create({
+                  data,
+                  select: {
+                    id: true,
+                    twreporter_user_id: true,
+                  },
+                })
+
+                context.session.data.member = member
+              }
+            } catch (err) {
+              // @TODO error reporting
+              console.error(err)
+            }
+          }
+
+          return next()
+        }
+
         // enable cors and authentication middlewares
         app.options('/api/graphql', authenticationMw, corsMiddleware)
-        app.post('/api/graphql', authenticationMw, corsMiddleware)
+        app.post(
+          '/api/graphql',
+          authenticationMw,
+          jwtVerifyAndProvisionMember,
+          corsMiddleware
+        )
 
         // enable 2FA middleware and related routes
         twoFactorAuth(app, commonContext)

--- a/packages/cms/lists/index.ts
+++ b/packages/cms/lists/index.ts
@@ -2,6 +2,7 @@ import Author from './author'
 import CallBaodaozai from './call-baodaozai'
 import Category from './category'
 import EditorPicksSetting from './editor-picks-setting'
+import Member from './member'
 import OnlineUser from './online-user'
 import PDF from './pdf'
 import Photo from './photo'
@@ -33,4 +34,5 @@ export const listDefinition = {
   SVG,
   CallBaodaozai,
   OnlineUser,
+  Member,
 }

--- a/packages/cms/lists/member.ts
+++ b/packages/cms/lists/member.ts
@@ -1,0 +1,75 @@
+import { list } from '@keystone-6/core'
+import { text, timestamp } from '@keystone-6/core/fields'
+import { allowRoles, RoleEnum } from './utils/access-control-list'
+
+const operationAccessControl = allowRoles([
+  RoleEnum.FrontendHeadlessAccount,
+  RoleEnum.Admin,
+  RoleEnum.Owner,
+])
+
+const filterAccessControl = ({ session }: { session?: any }) => {
+  const userRole = session.data.role
+
+  if (userRole === RoleEnum.Admin || userRole === RoleEnum.Owner) {
+    return true
+  }
+
+  const memberID = session.data?.member?.id
+  if (memberID) {
+    return { id: { equals: memberID } }
+  }
+
+  return false
+}
+
+const listConfigurations = list({
+  fields: {
+    name: text({
+      label: '稱呼',
+    }),
+    email: text({
+      label: 'Email',
+      isIndexed: true,
+    }),
+    twreporter_user_id: text({
+      label: 'membership_user.users.id',
+      validation: { isRequired: true },
+      isIndexed: 'unique',
+    }),
+    createdAt: timestamp({
+      defaultValue: { kind: 'now' },
+    }),
+    updatedAt: timestamp({
+      db: {
+        updatedAt: true,
+      },
+    }),
+  },
+  ui: {
+    listView: {
+      initialColumns: ['id', 'name', 'email'],
+    },
+  },
+  db: {
+    idField: {
+      kind: 'cuid',
+    },
+  },
+  access: {
+    operation: {
+      query: operationAccessControl,
+      create: operationAccessControl,
+      update: operationAccessControl,
+      delete: operationAccessControl,
+    },
+    filter: {
+      query: filterAccessControl,
+      update: filterAccessControl,
+      delete: filterAccessControl,
+    },
+  },
+  hooks: {},
+})
+
+export default listConfigurations

--- a/packages/cms/migrations/20250814091101_add_member_list/migration.sql
+++ b/packages/cms/migrations/20250814091101_add_member_list/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "Member" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL DEFAULT '',
+    "email" TEXT NOT NULL DEFAULT '',
+    "twreporter_user_id" TEXT NOT NULL DEFAULT '',
+    "createdAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3),
+
+    CONSTRAINT "Member_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Member_twreporter_user_id_key" ON "Member"("twreporter_user_id");
+
+-- CreateIndex
+CREATE INDEX "Member_email_idx" ON "Member"("email");

--- a/packages/cms/schema.graphql
+++ b/packages/cms/schema.graphql
@@ -1629,6 +1629,62 @@ input OnlineUserCreateInput {
   updatedAt: DateTime
 }
 
+type Member {
+  id: ID!
+  name: String
+  email: String
+  twreporter_user_id: String
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
+input MemberWhereUniqueInput {
+  id: ID
+  twreporter_user_id: String
+}
+
+input MemberWhereInput {
+  AND: [MemberWhereInput!]
+  OR: [MemberWhereInput!]
+  NOT: [MemberWhereInput!]
+  id: IDFilter
+  name: StringFilter
+  email: StringFilter
+  twreporter_user_id: StringFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+}
+
+input MemberOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  email: OrderDirection
+  twreporter_user_id: OrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+}
+
+input MemberUpdateInput {
+  name: String
+  email: String
+  twreporter_user_id: String
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
+input MemberUpdateArgs {
+  where: MemberWhereUniqueInput!
+  data: MemberUpdateInput!
+}
+
+input MemberCreateInput {
+  name: String
+  email: String
+  twreporter_user_id: String
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
 """
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
@@ -1737,6 +1793,12 @@ type Mutation {
   updateOnlineUsers(data: [OnlineUserUpdateArgs!]!): [OnlineUser]
   deleteOnlineUser(where: OnlineUserWhereUniqueInput!): OnlineUser
   deleteOnlineUsers(where: [OnlineUserWhereUniqueInput!]!): [OnlineUser]
+  createMember(data: MemberCreateInput!): Member
+  createMembers(data: [MemberCreateInput!]!): [Member]
+  updateMember(where: MemberWhereUniqueInput!, data: MemberUpdateInput!): Member
+  updateMembers(data: [MemberUpdateArgs!]!): [Member]
+  deleteMember(where: MemberWhereUniqueInput!): Member
+  deleteMembers(where: [MemberWhereUniqueInput!]!): [Member]
   endSession: Boolean!
   authenticateUserWithPassword(email: String!, password: String!): UserAuthenticationWithPasswordResult
   createInitialUser(data: CreateInitialUserInput!): UserAuthenticationWithPasswordSuccess!
@@ -1812,6 +1874,9 @@ type Query {
   onlineUsers(where: OnlineUserWhereInput! = {}, orderBy: [OnlineUserOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: OnlineUserWhereUniqueInput): [OnlineUser!]
   onlineUser(where: OnlineUserWhereUniqueInput!): OnlineUser
   onlineUsersCount(where: OnlineUserWhereInput! = {}): Int
+  members(where: MemberWhereInput! = {}, orderBy: [MemberOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: MemberWhereUniqueInput): [Member!]
+  member(where: MemberWhereUniqueInput!): Member
+  membersCount(where: MemberWhereInput! = {}): Int
   keystone: KeystoneMeta!
   authenticatedItem: AuthenticatedItem
 }

--- a/packages/cms/schema.prisma
+++ b/packages/cms/schema.prisma
@@ -331,3 +331,14 @@ model OnlineUser {
   @@index([canonicalPath])
   @@index([lastOnlineAt])
 }
+
+model Member {
+  id                 String    @id @default(cuid())
+  name               String    @default("")
+  email              String    @default("")
+  twreporter_user_id String    @unique @default("")
+  createdAt          DateTime? @default(now())
+  updatedAt          DateTime? @updatedAt
+
+  @@index([email])
+}

--- a/packages/cms/types/context.ts
+++ b/packages/cms/types/context.ts
@@ -1,0 +1,13 @@
+// Define a fallback context type (untyped) to prevent build-time errors
+type UnsafeFallbackContext =
+  import('@keystone-6/core/types').KeystoneContext<any>
+
+// Attempt to import the fully typed context from .keystone/types
+// This is a type-only import — it won’t cause runtime issues
+import type { Context as SafeContext } from '.keystone/types'
+
+// Export a unified context type for safe use across the project
+// Fallback to UnsafeFallbackContext only if SafeContext is unavailable
+export type TypedKeystoneContext = unknown extends SafeContext
+  ? UnsafeFallbackContext
+  : SafeContext


### PR DESCRIPTION
### 前情提要
少年報導者網站要做會員登入。會員登入後，便可以管理在少年報導者網站的設定，包含設定「報導仔」出現的時機和個人化的內容。

### 功能需求
登入需要實作 SSO（Single Sign On）：
1. 當使用者在報導者主網站登入後，到少年報導者網站也會處於登入狀態；反之亦然，當使用者在少年報導者登入後，到主網站也會處於登入狀態。
2. 當使用者從主網站登出，再到少年報導者網站時，也會處於登出狀態；反之亦然。

### 系統設計
註：
1. 少年報導者簡稱少報。
2. 報導者的 db 和 table name 是用 `membership_user` 和 `users`，而少報的 db 和 table name 則是 `kids-cms` 和 `members`（因為 `users` 已經被用來紀錄系統使者，所以改用 `members`）。以下文字說明，報導者會用 user，少報會用 member。
3. 根據之前的結論，少報會自己維護一個 `members` table 來存放使用者在少報這邊的資料。

沿用報導者登入系統 ( https://accounts.twreporter.org )。完成登入後（不管是 google, facebook 第三方平台登入，或是透過寄認證信登入），go-api 會回傳帶有 `id_token` cookie 的 response，所以 kids-frontend 可以使用該 `id_token` 去和 go-api 拿 `access_token`。
當 kids-frontend 要 request graphql api 時，可以將 `access_token` 放在 `Authorization` header 中，供 kids-cms 核對身份，確認 `access_token` 是合法的，而 `access_token` 中的 `user_id` 便是該使用者在報導者的 user id。kids-cms 接著會檢查該 user 是否已經加入少報 member，如果還沒有資料，變為其創建 member record。建立 member record 後，kids-cms 會有報導者 user 和 少報 member 的對照表。
之後，不管使用者從報導者或是少報登入後，kids-frontend 都可以拿 go-api 核發的 `access_token` 來 kids graphql api 詢問 member 的資料。

### 實作細節
go-api 實作 JWT token 時，採用的演算法是 HS256，若 kids-cms 如果要驗證 token，會需要  JWT secret，所以設計讓 kids-cms 需要從環境變數讀取 JWT secret。

註：
比較好的作法，是 go-api 在產生 JWT 時採用非對稱簽名的方式，如此一來，kids-cms 就不需要知道 JWT secret（私鑰），僅用公鑰就可以驗證 JWT。此優化可以排入後續任務。

因為使用者可以從報導者那邊登入，而非從少報這邊登入，所以 provision member record 不能只在登入的時候做。當有合格的 access token 時，就必須檢查該 user 是否已經產生 member record，如果沒有，就為其產生 member record。最後，將 member record 塞到 keystone `context.session.data` 中，讓後續的 resolvers 和 hooks 能拿到 member 的資訊。
