### PR TITLE
feat(cms): new session strategy

### DIFF
--- a/packages/cms/environment-variables.ts
+++ b/packages/cms/environment-variables.ts
@@ -23,6 +23,9 @@ const {
   OPEN_AI_KEY,
   TWREPORTER_ID,
   SEARCH_API_KEY,
+  GO_API_JWT_SECRET,
+  GO_API_JWT_ISSUER,
+  GO_API_JWT_AUDIENCE,
 } = process.env
 
 enum DatabaseProvider {
@@ -94,6 +97,11 @@ const environmentVariables = {
   searchAPIKey: SEARCH_API_KEY || 'search-api-key',
   nodeEnv: NODE_ENV || 'development', // value could be 'development', 'production' or 'test'
   openAIKey: OPEN_AI_KEY || 'open-ai-key',
+  goApiJwt: {
+    secret: GO_API_JWT_SECRET || '',
+    issuer: GO_API_JWT_ISSUER || 'https://go-api.twreporter.org',
+    audience: GO_API_JWT_AUDIENCE || 'https://www.twreporter.org',
+  },
 }
 
 export default environmentVariables

--- a/packages/cms/keystone.ts
+++ b/packages/cms/keystone.ts
@@ -1,20 +1,25 @@
 import Path from 'node:path'
 import cors from 'cors'
 import { config } from '@keystone-6/core'
-import { listDefinition as lists } from './lists'
+import { listDefinition as lists } from './lists/index'
+import { RoleEnum } from './lists/utils/access-control-list'
 import appConfig from './config'
 import envVar from './environment-variables'
+import jwt from 'jsonwebtoken'
 import { Request, Response, NextFunction } from 'express'
 import { createAuth } from '@keystone-6/auth'
 import { statelessSessions } from '@keystone-6/core/session'
 import { InMemoryLRUCache } from '@apollo/utils.keyvaluecache'
 import { createPreviewMiniApp } from './express-mini-apps/preview/app'
 import { twoFactorAuth } from './express-mini-apps/two-factor-auth'
+import type { KeystoneContext, SessionStrategy } from '@keystone-6/core/types'
+
+const sessionDataQuery = 'id name role email twoFactorAuth'
 
 const { withAuth } = createAuth({
   listKey: 'User',
   identityField: 'email',
-  sessionData: 'id name role email twoFactorAuth',
+  sessionData: sessionDataQuery,
   secretField: 'password',
   initFirstItem: {
     // If there are no items in the database, keystone will ask you to create
@@ -23,9 +28,214 @@ const { withAuth } = createAuth({
   },
 })
 
-const session = statelessSessions(appConfig.session)
+/**
+ *  Existing Keystone cookie-based session: used for Admin login/logout
+ */
+const adminUISession = statelessSessions(appConfig.session)
 
-export default withAuth(
+/**
+ *  Generate Keystone Session from an external JWT
+ *    - Extract token from Authorization: Bearer <token>
+ *    - Verify signature + iss/aud/exp
+ *    - Map to a Keystone Member itemId (if not found, either create a new one or reject)
+ */
+async function getSessionFromGoApiJwt({
+  context,
+}: {
+  context: KeystoneContext
+}): Promise<any | undefined> {
+  const req = context.req
+  if (!req) {
+    return
+  }
+
+  const auth = req.headers['authorization'] as string | undefined
+
+  if (!auth?.startsWith('Bearer ')) {
+    return
+  }
+
+  const token = auth.slice('Bearer '.length)
+
+  if (!token) {
+    return
+  }
+
+  let decoded
+
+  try {
+    decoded = jwt.verify(token, envVar.goApiJwt.secret, {
+      algorithms: ['HS256'],
+      ignoreNotBefore: true,
+    }) as jwt.JwtPayload
+    // extra claims validation
+    if (decoded.iss !== envVar.goApiJwt.issuer) {
+      throw new Error(`Invalid issuer: ${decoded.iss}`)
+    }
+    if (!decoded.user_id) {
+      throw new Error(`Missing identity claim`)
+    }
+    if (decoded.aud !== envVar.goApiJwt.audience) {
+      throw new Error(`Invalid audience: ${decoded.aud}`)
+    }
+  } catch (err) {
+    console.log(
+      JSON.stringify({
+        severity: 'INFO',
+        message:
+          'Authorization Bearer token is invalid. ' +
+          (err instanceof Error ? err.message : 'Invalid JWT'),
+        context: {
+          function: 'getSessionFromGoApiJwt',
+        },
+      })
+    )
+
+    // JWT verification fails, treat it as no session
+    return
+  }
+
+  let member
+  try {
+    member = await context.prisma.member.findUnique({
+      where: {
+        twreporter_user_id: `${decoded.user_id}`,
+      },
+      select: {
+        id: true,
+        twreporter_user_id: true,
+        email: true,
+      },
+    })
+
+    if (!member) {
+      const data = {
+        email: decoded.email,
+        twreporter_user_id: `${decoded.user_id}`,
+      }
+      member = await context.prisma.member.create({
+        data,
+        select: {
+          id: true,
+          twreporter_user_id: true,
+          email: true,
+        },
+      })
+    }
+  } catch (_err) {
+    const err = _err instanceof Error ? _err : new Error(String(_err))
+
+    console.log(
+      JSON.stringify({
+        severity: 'ERROR',
+        context: {
+          twreporter_user_id: decoded.user_id,
+          email: decoded.email,
+        },
+        message: err.stack, // trigger error reporting
+      })
+    )
+
+    // JWT verification fails, treat it as no session
+    return
+  }
+
+  /**
+   *  Return a session object expected by Keystone
+   *    ⚠️ Important:
+   *    - Admin UI session authentication maps to listKey: 'User'
+   *    - External JWT auth maps to listKey: 'Member'
+   *      → Make sure the listKey corresponds to the correct list
+   *        depending on the authentication source
+   */
+  return {
+    listKey: 'Member',
+    itemId: member.id,
+    data: {
+      memberId: member.id,
+      twreporterUserId: member.twreporter_user_id,
+      role: RoleEnum.Member,
+
+      // bypass two-factor authentication
+      twoFactorAuth: {
+        bypass: true,
+      },
+    },
+  }
+}
+
+type AdminSession = {
+  listKey: string
+  itemId: number
+}
+
+/**
+ *  Composite strategy:
+ *    - get(): try Admin UI session first, if not found then try external JWT
+ *    - start/end: delegate directly to Admin UI session (Admin login/logout)
+ */
+const compositeSession: SessionStrategy<any> = {
+  async get({ context }) {
+    // First, try Admin UI session
+    let session = (await adminUISession.get({ context })) as AdminSession | null
+
+    if (session) {
+      const sudoContext = context.sudo()
+
+      const { listKey, itemId }: { listKey: string; itemId: number } = session
+
+      if (!listKey || !itemId) {
+        return
+      }
+
+      try {
+        const data = await sudoContext.query[listKey].findOne({
+          where: { id: itemId },
+          query: sessionDataQuery,
+        })
+
+        if (!data) {
+          return
+        }
+
+        return {
+          listKey,
+          itemId,
+          data,
+        }
+      } catch (_err) {
+        const err = _err instanceof Error ? _err : new Error(String(_err))
+
+        console.log(
+          JSON.stringify({
+            severity: 'ERROR',
+            context: {
+              listKey,
+              itemId,
+            },
+            message: err.stack, // trigger error reporting
+          })
+        )
+        return
+      }
+    }
+
+    // Then try external JWT
+    session = await getSessionFromGoApiJwt({ context })
+
+    return session
+  },
+  async start({ context, data }) {
+    // Only Admin login calls this: this will set keystonejs-session cookie
+    return adminUISession.start({ context, data })
+  },
+  async end({ context }) {
+    // Only Admin logout calls this: this will unset keystonejs-session cookie
+    return adminUISession.end({ context })
+  },
+}
+
+const authConfig = withAuth(
   config({
     db: {
       provider: appConfig.database.provider,
@@ -38,7 +248,12 @@ export default withAuth(
       // If `isDisabled` is set to `true` then the Admin UI will be completely disabled.
       isDisabled: envVar.isUIDisabled,
       // For our starter, we check that someone has session data before letting them see the Admin UI.
-      isAccessAllowed: (context) => !!context.session?.data,
+      isAccessAllowed: (context) => {
+        // Member role has no permission to access Admin UI.
+        return (
+          context.session?.data && context.session.data.role !== RoleEnum.Member
+        )
+      },
       // Replace default favicon, ref: https://github.com/keystonejs/keystone/discussions/7506
       getAdditionalFiles: [
         async () => [
@@ -61,7 +276,7 @@ export default withAuth(
       ],
     },
     lists,
-    session,
+    session: adminUISession,
     storage: {
       files: {
         kind: 'local',
@@ -121,21 +336,16 @@ export default withAuth(
           next: NextFunction
         ) => {
           const context = await commonContext.withRequest(req, res)
-          const token = req?.cookies?.['keystonejs-session']
 
           // User has been logged in
           if (context?.session?.data?.role) {
             return next()
           }
 
-          if (token) {
-            res.status(401).json({
-              status: 'fail',
-              data: 'Authentication fails due to session cookie is not valid.',
-            })
-          }
-
-          return next()
+          res.status(401).json({
+            status: 'fail',
+            data: 'Authentication fails due to session is not valid.',
+          })
         }
 
         // enable cors and authentication middlewares
@@ -156,3 +366,7 @@ export default withAuth(
     },
   })
 )
+
+authConfig.session = compositeSession
+
+export default authConfig

--- a/packages/cms/keystone.ts
+++ b/packages/cms/keystone.ts
@@ -367,6 +367,16 @@ const authConfig = withAuth(
   })
 )
 
+/**
+ * ⚠️  Note:
+ * `withAuth` overrides the return value of the session strategy
+ * and only recognizes the `listKey: 'User'` defined in `createAuth`.
+ * Any other return value (e.g. `{ listKey: 'Member', ... }`) would be
+ * replaced with `undefined`.
+ *
+ * To preserve the compositeSession config, it must be assigned directly
+ * to `authConfig.session` instead of passing it through `withAuth`.
+ */
 authConfig.session = compositeSession
 
 export default authConfig

--- a/packages/cms/lists/index.ts
+++ b/packages/cms/lists/index.ts
@@ -2,6 +2,7 @@ import Author from './author'
 import CallBaodaozai from './call-baodaozai'
 import Category from './category'
 import EditorPicksSetting from './editor-picks-setting'
+import Member from './member'
 import OnlineUser from './online-user'
 import PDF from './pdf'
 import Photo from './photo'
@@ -33,4 +34,5 @@ export const listDefinition = {
   SVG,
   CallBaodaozai,
   OnlineUser,
+  Member,
 }

--- a/packages/cms/lists/member.ts
+++ b/packages/cms/lists/member.ts
@@ -1,0 +1,110 @@
+import { list, graphql } from '@keystone-6/core'
+import { text, timestamp, virtual } from '@keystone-6/core/fields'
+import { allowRoles, RoleEnum } from './utils/access-control-list'
+
+const operationAccessControl = allowRoles([
+  RoleEnum.FrontendHeadlessAccount,
+  RoleEnum.Admin,
+  RoleEnum.Owner,
+])
+
+const filterAccessControl = ({ session }: { session?: any }) => {
+  const userRole = session.data.role
+
+  if (userRole === RoleEnum.Admin || userRole === RoleEnum.Owner) {
+    return true
+  }
+
+  const memberID = session.data?.member?.id
+  if (memberID) {
+    return { id: { equals: memberID } }
+  }
+
+  return false
+}
+
+const listConfigurations = list({
+  fields: {
+    name: text({
+      label: '稱呼',
+    }),
+    email: text({
+      label: 'Email',
+      isIndexed: true,
+    }),
+    twreporter_user_id: text({
+      label: 'membership_user.users.id',
+      validation: { isRequired: true },
+      isIndexed: 'unique',
+    }),
+    role: text({
+      defaultValue: 'member',
+      ui: {
+        createView: {
+          fieldMode: 'hidden',
+        },
+        itemView: {
+          fieldMode: 'read',
+        },
+        listView: {
+          fieldMode: 'hidden',
+        },
+      },
+    }),
+    twoFactorAuth: virtual({
+      field: graphql.field({
+        type: graphql.JSON,
+        async resolve() {
+          return {
+            bypass: true,
+          }
+        },
+      }),
+      ui: {
+        createView: {
+          fieldMode: 'hidden',
+        },
+        itemView: {
+          fieldMode: 'read',
+        },
+        listView: {
+          fieldMode: 'hidden',
+        },
+      },
+    }),
+    createdAt: timestamp({
+      defaultValue: { kind: 'now' },
+    }),
+    updatedAt: timestamp({
+      db: {
+        updatedAt: true,
+      },
+    }),
+  },
+  ui: {
+    listView: {
+      initialColumns: ['id', 'name', 'email'],
+    },
+  },
+  db: {
+    idField: {
+      kind: 'cuid',
+    },
+  },
+  access: {
+    operation: {
+      query: operationAccessControl,
+      create: operationAccessControl,
+      update: operationAccessControl,
+      delete: operationAccessControl,
+    },
+    filter: {
+      query: filterAccessControl,
+      update: filterAccessControl,
+      delete: filterAccessControl,
+    },
+  },
+  hooks: {},
+})
+
+export default listConfigurations

--- a/packages/cms/lists/member.ts
+++ b/packages/cms/lists/member.ts
@@ -36,6 +36,11 @@ const listConfigurations = list({
       label: 'membership_user.users.id',
       validation: { isRequired: true },
       isIndexed: 'unique',
+      access: {
+        read: allowRoles([RoleEnum.Admin, RoleEnum.Owner]),
+        create: () => false,
+        update: () => false,
+      },
     }),
     role: text({
       defaultValue: 'member',
@@ -44,11 +49,16 @@ const listConfigurations = list({
           fieldMode: 'hidden',
         },
         itemView: {
-          fieldMode: 'read',
+          fieldMode: 'hidden',
         },
         listView: {
           fieldMode: 'hidden',
         },
+      },
+      access: {
+        read: allowRoles([RoleEnum.Admin, RoleEnum.Owner]),
+        create: () => false,
+        update: () => false,
       },
     }),
     twoFactorAuth: virtual({
@@ -65,11 +75,16 @@ const listConfigurations = list({
           fieldMode: 'hidden',
         },
         itemView: {
-          fieldMode: 'read',
+          fieldMode: 'hidden',
         },
         listView: {
           fieldMode: 'hidden',
         },
+      },
+      access: {
+        read: allowRoles([RoleEnum.Admin, RoleEnum.Owner]),
+        create: () => false,
+        update: () => false,
       },
     }),
     createdAt: timestamp({

--- a/packages/cms/lists/utils/access-control-list.ts
+++ b/packages/cms/lists/utils/access-control-list.ts
@@ -19,6 +19,7 @@ export const RoleEnum = {
   FrontendHeadlessAccount: 'frontend_headless_account',
   PreviewHeadlessAccount: 'preview_headless_account',
   CronjobHeadlessAccount: 'cronjob_headless_account',
+  Member: 'member',
 }
 
 export const allowRoles = (roles: string[]) => {
@@ -50,6 +51,7 @@ export const allowAllRoles = () => {
     RoleEnum.FrontendHeadlessAccount,
     RoleEnum.PreviewHeadlessAccount,
     RoleEnum.CronjobHeadlessAccount,
+    RoleEnum.Member,
   ]
   return allowRoles(roles)
 }

--- a/packages/cms/migrations/20250814091101_add_member_list/migration.sql
+++ b/packages/cms/migrations/20250814091101_add_member_list/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "Member" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL DEFAULT '',
+    "email" TEXT NOT NULL DEFAULT '',
+    "twreporter_user_id" TEXT NOT NULL DEFAULT '',
+    "createdAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3),
+
+    CONSTRAINT "Member_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Member_twreporter_user_id_key" ON "Member"("twreporter_user_id");
+
+-- CreateIndex
+CREATE INDEX "Member_email_idx" ON "Member"("email");

--- a/packages/cms/migrations/20250826023350_update_member_list/migration.sql
+++ b/packages/cms/migrations/20250826023350_update_member_list/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Member" ADD COLUMN     "role" TEXT NOT NULL DEFAULT 'member';

--- a/packages/cms/schema.graphql
+++ b/packages/cms/schema.graphql
@@ -1629,6 +1629,62 @@ input OnlineUserCreateInput {
   updatedAt: DateTime
 }
 
+type Member {
+  id: ID!
+  name: String
+  email: String
+  twreporter_user_id: String
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
+input MemberWhereUniqueInput {
+  id: ID
+  twreporter_user_id: String
+}
+
+input MemberWhereInput {
+  AND: [MemberWhereInput!]
+  OR: [MemberWhereInput!]
+  NOT: [MemberWhereInput!]
+  id: IDFilter
+  name: StringFilter
+  email: StringFilter
+  twreporter_user_id: StringFilter
+  createdAt: DateTimeNullableFilter
+  updatedAt: DateTimeNullableFilter
+}
+
+input MemberOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  email: OrderDirection
+  twreporter_user_id: OrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+}
+
+input MemberUpdateInput {
+  name: String
+  email: String
+  twreporter_user_id: String
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
+input MemberUpdateArgs {
+  where: MemberWhereUniqueInput!
+  data: MemberUpdateInput!
+}
+
+input MemberCreateInput {
+  name: String
+  email: String
+  twreporter_user_id: String
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
 """
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
@@ -1737,6 +1793,12 @@ type Mutation {
   updateOnlineUsers(data: [OnlineUserUpdateArgs!]!): [OnlineUser]
   deleteOnlineUser(where: OnlineUserWhereUniqueInput!): OnlineUser
   deleteOnlineUsers(where: [OnlineUserWhereUniqueInput!]!): [OnlineUser]
+  createMember(data: MemberCreateInput!): Member
+  createMembers(data: [MemberCreateInput!]!): [Member]
+  updateMember(where: MemberWhereUniqueInput!, data: MemberUpdateInput!): Member
+  updateMembers(data: [MemberUpdateArgs!]!): [Member]
+  deleteMember(where: MemberWhereUniqueInput!): Member
+  deleteMembers(where: [MemberWhereUniqueInput!]!): [Member]
   endSession: Boolean!
   authenticateUserWithPassword(email: String!, password: String!): UserAuthenticationWithPasswordResult
   createInitialUser(data: CreateInitialUserInput!): UserAuthenticationWithPasswordSuccess!
@@ -1812,6 +1874,9 @@ type Query {
   onlineUsers(where: OnlineUserWhereInput! = {}, orderBy: [OnlineUserOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: OnlineUserWhereUniqueInput): [OnlineUser!]
   onlineUser(where: OnlineUserWhereUniqueInput!): OnlineUser
   onlineUsersCount(where: OnlineUserWhereInput! = {}): Int
+  members(where: MemberWhereInput! = {}, orderBy: [MemberOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: MemberWhereUniqueInput): [Member!]
+  member(where: MemberWhereUniqueInput!): Member
+  membersCount(where: MemberWhereInput! = {}): Int
   keystone: KeystoneMeta!
   authenticatedItem: AuthenticatedItem
 }

--- a/packages/cms/schema.graphql
+++ b/packages/cms/schema.graphql
@@ -1634,6 +1634,8 @@ type Member {
   name: String
   email: String
   twreporter_user_id: String
+  role: String
+  twoFactorAuth: JSON
   createdAt: DateTime
   updatedAt: DateTime
 }
@@ -1651,6 +1653,7 @@ input MemberWhereInput {
   name: StringFilter
   email: StringFilter
   twreporter_user_id: StringFilter
+  role: StringFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
 }
@@ -1660,6 +1663,7 @@ input MemberOrderByInput {
   name: OrderDirection
   email: OrderDirection
   twreporter_user_id: OrderDirection
+  role: OrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
 }
@@ -1668,6 +1672,7 @@ input MemberUpdateInput {
   name: String
   email: String
   twreporter_user_id: String
+  role: String
   createdAt: DateTime
   updatedAt: DateTime
 }
@@ -1681,6 +1686,7 @@ input MemberCreateInput {
   name: String
   email: String
   twreporter_user_id: String
+  role: String
   createdAt: DateTime
   updatedAt: DateTime
 }

--- a/packages/cms/schema.prisma
+++ b/packages/cms/schema.prisma
@@ -331,3 +331,14 @@ model OnlineUser {
   @@index([canonicalPath])
   @@index([lastOnlineAt])
 }
+
+model Member {
+  id                 String    @id @default(cuid())
+  name               String    @default("")
+  email              String    @default("")
+  twreporter_user_id String    @unique @default("")
+  createdAt          DateTime? @default(now())
+  updatedAt          DateTime? @updatedAt
+
+  @@index([email])
+}

--- a/packages/cms/schema.prisma
+++ b/packages/cms/schema.prisma
@@ -337,6 +337,7 @@ model Member {
   name               String    @default("")
   email              String    @default("")
   twreporter_user_id String    @unique @default("")
+  role               String    @default("member")
   createdAt          DateTime? @default(now())
   updatedAt          DateTime? @updatedAt
 

--- a/packages/cms/types/context.ts
+++ b/packages/cms/types/context.ts
@@ -1,0 +1,13 @@
+// Define a fallback context type (untyped) to prevent build-time errors
+type UnsafeFallbackContext =
+  import('@keystone-6/core/types').KeystoneContext<any>
+
+// Attempt to import the fully typed context from .keystone/types
+// This is a type-only import — it won’t cause runtime issues
+import type { Context as SafeContext } from '.keystone/types'
+
+// Export a unified context type for safe use across the project
+// Fallback to UnsafeFallbackContext only if SafeContext is unavailable
+export type TypedKeystoneContext = unknown extends SafeContext
+  ? UnsafeFallbackContext
+  : SafeContext


### PR DESCRIPTION
### 前情提要
此 PR 是為了實作少年報導者會員系統，可以參考[系統設計：少年報導者會員登入](https://www.notion.so/twreporter/25a8dbdca9328095a080ce900800cc43)了解全貌。

### PR 說明
實作目標是讓使用者可以用 go-api 核發的 access_token 來與 kids-cms Keystone GraphQL API 溝通。

現行的 kids-api 如果要與 kids-cms 溝通，預設的作法，是先透過 headless account 的 Admin 帳號密碼來換取 session token，再將後續的 request 帶上 `cookie: keystonejs-session=<session token>` header，來通過 Keystone server 的 access control 打 GQL。

此 PR 的作法更改 Keystone 處理 session 的機制：如果進來的 request 帶有 `keystonejs-session` cookie 的話，就依照舊有 的方法驗證 Admin 身份和權限；但若是進來的 request 不是帶 `keystonejs-session` cookie，而是帶 `Authorization: Bearer <access_token>` 的話，就改用 jwt 來驗證會員（Member）的身份。 我們便能透過 Member 和 Admin 的區別來設定不同的 access control。

### 實作細節
1. 新增 Member（會員） list：存放會員資料和該名會員在報導者的 `user_id`
2. 修改 keystone session strategy，從 `statelessSession`（只驗 cookie） 改成 `compositeSession`（驗 cookie 和 access_token）

當 request 是搭配 `Authorization: Bearer <access_token>` 進到系統時，keystone 會先驗證 access_token 是否合格，如果合格，則解開 access_token 的 payload，查看 `user_id` claim，得到該 request 在報導者的 user id，接著查看少報是否已經為此 user 建立會員，如果已經建立，則用該會員的資料產生 keystone session；若沒有會員資料，則建立資料後，再產生 keystone session。後續的 resolvers 和 hooks 就能夠透過 keystone session 拿到該名會員的資訊。

go-api 實作 JWT access_token 時，採用的演算法是 HS256，若 kids-cms 如果要驗證 token，會需要  JWT secret，所以設計讓 kids-cms 需要從環境變數讀取 JWT secret。

註：
比較好的作法，是 go-api 在產生 JWT 時採用非對稱簽名的方式，如此一來，kids-cms 就不需要知道 JWT secret（私鑰），僅用公鑰就可以驗證 JWT。此優化可以排入後續任務。