### PR TITLE
feat(api-gateway): handle requests along with Authorization header

### DIFF
--- a/packages/api-gateway/src/gql-proxy-mini-app.ts
+++ b/packages/api-gateway/src/gql-proxy-mini-app.ts
@@ -138,6 +138,12 @@ class TokenManager {
   }
 }
 
+// helpers
+const isBearerAuth = (req: express.Request) => {
+  const auth = req.get('authorization') || ''
+  return auth.startsWith('Bearer ')
+}
+
 /**
  *  This function creates a `GraphQLProxy` mini app.
  *  This mini app aims to add 'keystonejs-session' cookie on incoming requests' header
@@ -147,10 +153,7 @@ export function createGraphQLProxy({
   headlessAccount,
   apiOrigin,
 }: {
-  headlessAccount: {
-    email: string
-    password: string
-  }
+  headlessAccount: { email: string; password: string }
   apiOrigin: string
 }) {
   // create express mini app
@@ -159,18 +162,20 @@ export function createGraphQLProxy({
   // enable pre-flight request
   router.options('/api/graphql')
 
+  // Decide auth mode + (maybe) fetch headless token
   router.post(
     '/api/graphql',
+    // decide auth mode & fetch keystonejs-session only if needed
     async (req, res, next) => {
-      console.log(
-        JSON.stringify({
-          severity: 'DEBUG',
-          message:
-            'Get session token before proxying requests to backed API original server.',
-          ...res?.locals?.globalLogFields,
-        })
-      )
+      const usingBearer = isBearerAuth(req)
+      res.locals.authMode = usingBearer ? 'jwt' : 'cookie'
 
+      if (usingBearer) {
+        // JWT mode: do nothing here; just forward the Authorization header later
+        return next()
+      }
+
+      // Cookie mode: fetch/ensure headless session token
       try {
         const tokenManager = new TokenManager(
           headlessAccount.email,
@@ -189,53 +194,89 @@ export function createGraphQLProxy({
               0,
               0
             ),
+            ...res?.locals?.globalLogFields,
           })
         )
+        // Even if headless token cannot be obtained, continue
+        // and let Keystone respond with 401
       }
       next()
     },
 
-    // proxy request to API GraphQL endpoint
+    // proxy to Keystone GraphQL
     createProxyMiddleware({
       target: apiOrigin,
       changeOrigin: true,
+
       onProxyReq: (proxyReq, req, res) => {
-        const token = res.locals.sessionToken
-        const originalCookie = req.get('Cookie')
+        const mode: 'jwt' | 'cookie' = res.locals.authMode
+
+        // Always enforce Content-Type
+        proxyReq.setHeader('Content-Type', 'application/json')
+        proxyReq.setHeader('x-apollo-operation-name', '')
+
+        if (mode === 'jwt') {
+          // Forward Authorization header
+          proxyReq.setHeader('Authorization', req.get('Authorization') || '')
+
+          console.log(
+            JSON.stringify({
+              severity: 'DEBUG',
+              message: 'Proxy with Bearer JWT to ' + apiOrigin + proxyReq.path,
+              ...res?.locals?.globalLogFields,
+              debugPayload: {
+                req: {
+                  headers: {
+                    authorization: '[REDACTED]',
+                    'content-type': 'application/json',
+                  },
+                },
+              },
+            })
+          )
+          return
+        }
+
+        const originalCookie = req.get('Cookie') || ''
+        // Cookie mode: attach keystonejs-session token
+        const sessionToken = res.locals.sessionToken || ''
         const cookie = originalCookie
-          ? originalCookie + ';keystonejs-session=' + token
-          : 'keystonejs-session=' + token
+          ? `${originalCookie};keystonejs-session=${sessionToken}`
+          : `keystonejs-session=${sessionToken}`
+
+        proxyReq.setHeader('Cookie', cookie)
+        // Ensure Authorization is not present to avoid ambiguity
+        proxyReq.removeHeader?.('Authorization')
 
         console.log(
           JSON.stringify({
             severity: 'DEBUG',
             message:
-              'Proxy to backed API origin server: ' + apiOrigin + proxyReq.path,
+              'Proxy with keystonejs-session to ' + apiOrigin + proxyReq.path,
             ...res?.locals?.globalLogFields,
             debugPayload: {
               req: {
                 headers: {
-                  cookie: cookie,
+                  cookie: '[REDACTED]',
                   'content-type': 'application/json',
                 },
               },
             },
           })
         )
-        proxyReq.setHeader('Cookie', cookie)
-        proxyReq.setHeader('Content-Type', 'application/json')
-        proxyReq.setHeader('x-apollo-operation-name', '')
       },
 
       onProxyRes: async (proxyRes, req, res) => {
         const statusCode = proxyRes.statusCode
+        const mode: 'jwt' | 'cookie' = res.locals.authMode
 
-        // renew token if authentication fails
-        if (statusCode == 401) {
+        // Renew only for cookie mode (headless flow)
+        if (mode === 'cookie' && statusCode === 401) {
           console.log(
             JSON.stringify({
               severity: 'DEBUG',
-              message: 'Renew session token due to 401 (unauthorized) response',
+              message:
+                '401 from Keystone with cookie auth; try renewing headless session token',
               ...res?.locals?.globalLogFields,
             })
           )
@@ -250,7 +291,7 @@ export function createGraphQLProxy({
             const annotatedErr = errors.helpers.wrap(
               err,
               'GraphQLProxyError',
-              'Error to renew session token'
+              'Error renewing headless session token'
             )
             console.log(
               JSON.stringify({
@@ -261,41 +302,36 @@ export function createGraphQLProxy({
                   0,
                   0
                 ),
+                ...res?.locals?.globalLogFields,
               })
             )
           }
         }
 
         /**
-         * Try to fix [memory leak issue](https://github.com/kids-reporter/kids-reporter-monorepo/issues/467).
-         * This fix might not work.
-         * Need more time to observe the following metrics.
+         * Try to fix memory leak issue (#467). Cleanup listeners either way.
          */
         const cleanup = (err: Error) => {
-          console.log('clean up response')
           // cleanup event listeners to allow clean garbage collection
           proxyRes.removeListener('error', cleanup)
           proxyRes.removeListener('close', cleanup)
           res.removeListener('error', cleanup)
           res.removeListener('close', cleanup)
-
           // destroy all source streams to propagate the caught event backward
           req.destroy(err)
           proxyRes.destroy(err)
         }
-
         proxyRes.once('error', cleanup)
         proxyRes.once('close', cleanup)
         res.once('error', cleanup)
         res.once('close', cleanup)
       },
 
-      onError: (err, req, res, target) => { // eslint-disable-line
+      onError: (err, req, res) => {
         const annotatedErr = errors.helpers.wrap(
           err,
           'GraphQLProxyError',
-          `Error occurs while proxying request to API origin server: ${apiOrigin}` +
-            err.message
+          `Error while proxying to API origin: ${apiOrigin}${err.message}`
         )
 
         console.log(
@@ -317,11 +353,12 @@ export function createGraphQLProxy({
     })
   )
 
+  // unified error handler
   const errorHandler: express.ErrorRequestHandler = (err, req, res, next) => {
     const annotatedErr = errors.helpers.wrap(
       err,
       'GraphQLProxyError',
-      'Unknow error happens when `GraphQLProxy` mini app deals with proxied requests and responses'
+      'Unknown error in GraphQLProxy mini app'
     )
     console.log(
       JSON.stringify({
@@ -333,12 +370,10 @@ export function createGraphQLProxy({
         ...res?.locals?.globalLogFields,
       })
     )
-
     // Let main application level error handle to deal with the error
     next(annotatedErr)
   }
 
   router.use(errorHandler)
-
   return router
 }


### PR DESCRIPTION
### 前情提要
此 PR 是為了實作少年報導者會員系統，可以參考[系統設計：少年報導者會員登入](https://www.notion.so/twreporter/25a8dbdca9328095a080ce900800cc43)了解全貌。

### 相關 PR
- [feat(cms): new session strategy
](https://github.com/kids-reporter/kids-reporter-monorepo/pull/756)

### PR 說明
frontend 會用 id_token 去換取 access_token，並發送帶有 `Authorization: Bearer <access_token>` header 的 request 到 api-gateway 來，api-gateway 需要檢查 incoming requests 是否帶有 `Authorization: Bearer <access_token>` header，如果有，則 proxy 該 request 到 cms 去；如果沒有帶有 `Authorization` header，則用 headless account 的方式產生 Keystone session cookie，並改走 Keystone 預設的 Admin 驗證模式，來呼叫 cms 的 GQL API。