### PR TITLE
feat(api-gateway): add `/auth/access-token` endpoint for proxying token requests to go-api

### DIFF
--- a/packages/api-gateway/src/app.ts
+++ b/packages/api-gateway/src/app.ts
@@ -5,6 +5,7 @@ import cors from 'cors'
 import express from 'express'
 import middlewareCreator from './middlewares/index.js'
 import { createGraphQLProxy } from './gql-proxy-mini-app.js'
+import { createAuthMiniApp } from './auth-mini-app.js'
 
 // @twreporter/errors is a cjs module, therefore, we need to use its default property
 const errors = _errors.default
@@ -44,8 +45,11 @@ export function createApp({
   // 2. handle cors requests
   app.use(middlewareCreator.createLoggerMw(gcpProjectId), cors(corsOpts))
 
-  // mini app: weekly GraphQL API
+  // mini app: GraphQL API
   app.use(createGraphQLProxy(gql))
+
+  // Auth mini app
+  app.use(createAuthMiniApp())
 
   /**
    *  Application level error handler

--- a/packages/api-gateway/src/auth-mini-app.ts
+++ b/packages/api-gateway/src/auth-mini-app.ts
@@ -1,0 +1,68 @@
+import consts from './constants.js'
+import envVar from './environment-variables.js'
+// @ts-ignore `@twreporter/errors` does not have tyepscript definition file yet
+import _errors from '@twreporter/errors'
+import express from 'express'
+import { createProxyMiddleware } from 'http-proxy-middleware'
+
+// @twreporter/errors is a CommonJS module, so we must access its `default` property
+const errors = _errors.default
+
+const statusCodes = consts.statusCodes
+
+const apiOrigin = envVar.apis.goApi.origin
+
+/**
+ * Creates an Auth mini app.
+ *
+ * This mini app exposes the `/auth/access-token` endpoint,
+ * which proxies requests to the Go API (`/v2/auth/token`)
+ * and returns an `access_token` for authenticated twreporter
+ * and kids-reporter users.
+ */
+export function createAuthMiniApp() {
+  // Create an Express router
+  const router = express.Router()
+
+  // Enable preflight requests (CORS OPTIONS)
+  router.options('/auth/access-token')
+
+  router.post(
+    '/auth/access-token',
+    // proxy request to go-api endpoint
+    createProxyMiddleware({
+      target: apiOrigin,
+      changeOrigin: true,
+      logLevel: 'debug',
+      pathRewrite: {
+        '/auth/access-token': '/v2/auth/token',
+      },
+      onError: (err, req, res) => {
+        const annotatedErr = errors.helpers.wrap(
+          err,
+          'GoApiProxyError',
+          `Error occurs while proxying request to API origin server: ${apiOrigin} ` +
+            err.message
+        )
+
+        console.log(
+          JSON.stringify({
+            severity: 'ERROR',
+            message: errors.helpers.printAll(annotatedErr, {
+              withStack: true,
+              withPayload: true,
+            }),
+            ...res?.locals?.globalLogFields,
+          })
+        )
+
+        res.status(statusCodes.internalServerError).send({
+          status: 'error',
+          error: annotatedErr.message,
+        })
+      },
+    })
+  )
+
+  return router
+}

--- a/packages/api-gateway/src/environment-variables.ts
+++ b/packages/api-gateway/src/environment-variables.ts
@@ -4,6 +4,7 @@ const {
   GQL_ORIGIN,
   GQL_HEADLESS_ACCOUNT_EMAIL,
   GQL_HEADLESS_ACCOUNT_PASSWORD,
+  GO_API_ENV,
 } = process.env
 
 /**
@@ -35,6 +36,14 @@ const envVar = {
         email: GQL_HEADLESS_ACCOUNT_EMAIL || '',
         password: GQL_HEADLESS_ACCOUNT_PASSWORD || '',
       },
+    },
+    goApi: {
+      origin:
+        GO_API_ENV === 'prod'
+          ? 'https://go-api.twreporter.org'
+          : GO_API_ENV === 'staging'
+          ? 'https://staging-go-api.twreporter.org'
+          : 'http://localhost:8080',
     },
   },
   cors: {

--- a/packages/api-gateway/src/middlewares/logger.ts
+++ b/packages/api-gateway/src/middlewares/logger.ts
@@ -30,6 +30,14 @@ export function createLoggerMw(projectId: string): express.RequestHandler {
   const handler: express.RequestHandler = (req, res, next) => {
     const globalLogFields = getGlobalLogFields(req, projectId)
 
+    const authHeader = req.get('Authorization')
+    const safeAuthHeader =
+      authHeader && authHeader.startsWith('Bearer ')
+        ? 'Bearer ***REDACTED***'
+        : authHeader
+        ? '***REDACTED***'
+        : undefined
+
     console.log(
       JSON.stringify({
         severity: 'INFO',
@@ -38,7 +46,7 @@ export function createLoggerMw(projectId: string): express.RequestHandler {
           'req.headers': {
             'Content-Length': req.get('Content-Length'),
             'Content-Type': req.get('Content-Type'),
-            Authorization: req.get('Authorization'),
+            Authorization: safeAuthHeader,
           },
           'req.body': req.body,
         },


### PR DESCRIPTION
### 前情提要
此 PR 是為了實作少年報導者會員系統，可以參考[系統設計：少年報導者會員登入](https://www.notion.so/twreporter/25a8dbdca9328095a080ce900800cc43)了解全貌。

### 相關 PR
- https://github.com/kids-reporter/kids-reporter-monorepo/pull/757

### PR 說明
使用者在登入後，瀏覽器會拿到 `id_token` cookie，但需要近一步 request go-api 拿取 `access_token`，之後透過 `access_token` 來獲取和 GQL endpoint 溝通的權限。
此 PR 在 api-gateway 新增 `/auth/access-token` endpoint，將 request proxy 到 go-api 的 `/v2/auth/token` endpoint 去，讓 go-api 能夠驗證 `id_token` 和核發 `access_token`。

