### PR TITLE
fix(cms): remove unnecessary authentication on GQL API causing login failure

### DIFF
--- a/packages/cms/keystone.ts
+++ b/packages/cms/keystone.ts
@@ -6,7 +6,6 @@ import { RoleEnum } from './lists/utils/access-control-list'
 import appConfig from './config'
 import envVar from './environment-variables'
 import jwt from 'jsonwebtoken'
-import { Request, Response, NextFunction } from 'express'
 import { createAuth } from '@keystone-6/auth'
 import { statelessSessions } from '@keystone-6/core/session'
 import { InMemoryLRUCache } from '@apollo/utils.keyvaluecache'
@@ -329,28 +328,9 @@ const authConfig = withAuth(
 
         const corsMiddleware = cors(corsOpts)
 
-        // Check if the request is sent by an authenticated user
-        const authenticationMw = async (
-          req: Request,
-          res: Response,
-          next: NextFunction
-        ) => {
-          const context = await commonContext.withRequest(req, res)
-
-          // User has been logged in
-          if (context?.session?.data?.role) {
-            return next()
-          }
-
-          res.status(401).json({
-            status: 'fail',
-            data: 'Authentication fails due to session is not valid.',
-          })
-        }
-
-        // enable cors and authentication middlewares
-        app.options('/api/graphql', authenticationMw, corsMiddleware)
-        app.post('/api/graphql', authenticationMw, corsMiddleware)
+        // enable cors middleware
+        app.options('/api/graphql', corsMiddleware)
+        app.post('/api/graphql', corsMiddleware)
 
         // enable 2FA middleware and related routes
         twoFactorAuth(app, commonContext)


### PR DESCRIPTION
### Bug 說明
綁在 `/api/graphql` endpoint 上的 `authenticationMw` middleware 會誤回傳 401 response 給「想要登入的 gql mutation」request，導致登入或是 cms 初始化時會遇到未知錯誤。

如果是 cms 初始化，會遇到下方錯誤畫面：
<img width="1046" height="453" alt="截圖 2025-09-16 下午4 04 10" src="https://github.com/user-attachments/assets/a9fc0c3b-1159-4921-a2b3-e7715b44e175" />

如果是登入，會遇到錯誤：
<img width="899" height="461" alt="截圖 2025-09-16 下午4 03 38" src="https://github.com/user-attachments/assets/a3a54b1b-d241-49c1-9f3a-0d8088efd1cd" />

### 解決辦法
移除不必要的 `authenticationMw` middleware，`authenticationMw` 原意是要阻擋 unauthenticated requests 去打 `/api/graphql` endpoint，但因為 keystonejs 在處理登入或是初始化時，都會需要打 `/api/graphql` 存取資料，所以不能綁定該 middleware 在 `/api/graphql` endpoint 上。