### PR TITLE
fix(frontend): correct 2025 copyright and donation permit number

### DIFF
--- a/packages/frontend/src/app/components/footer.tsx
+++ b/packages/frontend/src/app/components/footer.tsx
@@ -182,7 +182,7 @@ export const Footer = () => {
               }}
               className="footer-number text-xs md:text-sm"
             >
-              公益勸募許可字號｜衛部救字第1121364182號{' '}
+              公益勸募許可字號｜衛部救字第1131363879號{' '}
             </p>
             <div
               className={`${styles['footer-policy']} flex flex-row justify-center flex-no-wrap gap-5`}
@@ -210,7 +210,7 @@ export const Footer = () => {
             }}
             className="footer-number text-xs md:text-sm"
           >
-            Copyright © 2024 The Reporter
+            Copyright © 2025 The Reporter
           </p>
         </div>
       </div>


### PR DESCRIPTION
### PR 說明
目前站上的 footer 顯示的 copyright 和勸募字號是 2024 的版本，此 PR 修改成 2025 的版本。

### Reference
[[defect] 字號和年份修正](https://www.notion.so/twreporter/defect-2718dbdca932802fa5b7fff7db4b7d7a)