### PR TITLE
feat(cms): add OpenAI integration for generating post opening

### DIFF
--- a/packages/cms/lists/post.ts
+++ b/packages/cms/lists/post.ts
@@ -113,15 +113,10 @@ const aiDialog = virtual({
   field: () =>
     graphql.field({
       type: graphql.JSON,
-      async resolve(item: Record<string, any>, args, context) {
-        const postID = item?.id
-        const post = await context.query.Post.findOne({
-          where: { id: postID },
-          query: 'id, content',
-        })
+      async resolve(item: Record<string, any>) {
         return {
           label: '生成內容',
-          content: post.content,
+          content: item.content,
           openAIKey: envVars.openAIKey,
         }
       },
@@ -147,15 +142,10 @@ const openingFieldConfig = group({
       field: () =>
         graphql.field({
           type: graphql.JSON,
-          async resolve(item: Record<string, any>, args, context) {
-            const postID = item?.id
-            const post = await context.query.Post.findOne({
-              where: { id: postID },
-              query: 'id, content',
-            })
+          async resolve(item: Record<string, any>) {
             return {
               label: 'AI助理生成',
-              content: post.content,
+              content: item.content,
               openAIKey: envVars.openAIKey,
             }
           },
@@ -191,15 +181,10 @@ const multipleChoiceQuestionsFieldConfig = group({
       field: () =>
         graphql.field({
           type: graphql.JSON,
-          async resolve(item: Record<string, any>, args, context) {
-            const postID = item?.id
-            const post = await context.query.Post.findOne({
-              where: { id: postID },
-              query: 'id, content',
-            })
+          async resolve(item: Record<string, any>) {
             return {
               label: 'AI助理生成',
-              content: post.content,
+              content: item.content,
               openAIKey: envVars.openAIKey,
             }
           },

--- a/packages/cms/lists/post.ts
+++ b/packages/cms/lists/post.ts
@@ -109,135 +109,172 @@ const TWReporterRelatedPostsConfig = isTWReporterRelatedPostsEnabled
     })
   : {}
 
-const isChatGPTSummaryEnabled = true
-const summaryFieldConfig = isChatGPTSummaryEnabled
-  ? {
-      summary: virtual({
-        field: () =>
-          graphql.field({
-            type: graphql.JSON,
-            async resolve(item: Record<string, any>, args, context) {
-              const postID = item?.id
-              const post = await context.query.Post.findOne({
-                where: { id: postID },
-                query: 'id, content',
-              })
-              return {
-                label: '生成內容',
-                content: post.content,
-                openAIKey: envVars.openAIKey,
-              }
-            },
-          }),
-        ui: {
-          views: './lists/views/ai-dialog',
-          createView: {
-            fieldMode: 'hidden',
+const aiDialog = virtual({
+  field: () =>
+    graphql.field({
+      type: graphql.JSON,
+      async resolve(item: Record<string, any>, args, context) {
+        const postID = item?.id
+        const post = await context.query.Post.findOne({
+          where: { id: postID },
+          query: 'id, content',
+        })
+        return {
+          label: '生成內容',
+          content: post.content,
+          openAIKey: envVars.openAIKey,
+        }
+      },
+    }),
+  ui: {
+    views: './lists/views/ai-dialog',
+    createView: {
+      fieldMode: 'hidden',
+    },
+    itemView: {
+      fieldPosition: 'sidebar',
+    },
+    listView: {
+      fieldMode: 'hidden',
+    },
+  },
+})
+
+const openingFieldConfig = group({
+  label: '進入對話',
+  fields: {
+    aiSuggestionOpening: virtual({
+      field: () =>
+        graphql.field({
+          type: graphql.JSON,
+          async resolve(item: Record<string, any>, args, context) {
+            const postID = item?.id
+            const post = await context.query.Post.findOne({
+              where: { id: postID },
+              query: 'id, content',
+            })
+            return {
+              label: 'AI助理生成',
+              content: post.content,
+              openAIKey: envVars.openAIKey,
+            }
           },
-          itemView: {
-            fieldPosition: 'sidebar',
-          },
-          listView: {
-            fieldMode: 'hidden',
-          },
+        }),
+      ui: {
+        views: './lists/views/ai-suggestion-opening',
+        createView: {
+          fieldMode: 'hidden',
         },
-      }),
-    }
-  : {}
-const multipleChoiceQuestionsFieldConfig = isChatGPTSummaryEnabled
-  ? group({
-      label: '選擇題組',
-      fields: {
-        aiSuggestion: virtual({
-          field: () =>
-            graphql.field({
-              type: graphql.JSON,
-              async resolve(item: Record<string, any>, args, context) {
-                const postID = item?.id
-                const post = await context.query.Post.findOne({
-                  where: { id: postID },
-                  query: 'id, content',
-                })
-                return {
-                  label: 'AI助理生成',
-                  content: post.content,
-                  openAIKey: envVars.openAIKey,
-                }
-              },
-            }),
-          ui: {
-            views: './lists/views/ai-suggestion-multiple-choice',
-            createView: {
-              fieldMode: 'hidden',
-            },
-            itemView: {
-              fieldMode: 'edit',
-            },
-            listView: {
-              fieldMode: 'hidden',
-            },
-          },
-        }),
-        multipleChoiceQuestionsJSON: json({
-          label: '選擇題',
-          defaultValue: [],
-          ui: {
-            views: './lists/views/multiple-choice-questions',
-            createView: { fieldMode: 'hidden' },
-            itemView: { fieldMode: 'edit' },
-            listView: { fieldMode: 'hidden' },
-          },
-        }),
+        itemView: {
+          fieldMode: 'read',
+        },
+        listView: {
+          fieldMode: 'hidden',
+        },
       },
-    })
-  : {}
-const essayQuestionsFieldConfig = isChatGPTSummaryEnabled
-  ? group({
-      label: '思辨題組',
-      fields: {
-        aiEssaySuggestion: virtual({
-          field: () =>
-            graphql.field({
-              type: graphql.JSON,
-              async resolve(item: Record<string, any>, args, context) {
-                const postID = item?.id
-                const post = await context.query.Post.findOne({
-                  where: { id: postID },
-                  query: 'id, content',
-                })
-                return {
-                  label: 'AI助理生成',
-                  content: post.content,
-                  openAIKey: envVars.openAIKey,
-                }
-              },
-            }),
-          ui: {
-            views: './lists/views/ai-suggestion-essay',
-            createView: {
-              fieldMode: 'hidden',
-            },
-            itemView: {
-              fieldMode: 'edit',
-            },
-            listView: {
-              fieldMode: 'hidden',
-            },
-          },
-        }),
-        essayQuestionsJSON: json({
-          label: '思辨題',
-          defaultValue: [],
-          ui: {
-            views: './lists/views/essay-questions',
-            createView: { fieldMode: 'hidden' },
-            itemView: { fieldMode: 'edit' },
-            listView: { fieldMode: 'hidden' },
-          },
-        }),
+    }),
+    opening: text({
+      label: '開場白',
+      ui: {
+        createView: { fieldMode: 'hidden' },
+        itemView: { fieldMode: 'edit' },
+        listView: { fieldMode: 'hidden' },
       },
-    })
-  : {}
+    }),
+  },
+})
+
+const multipleChoiceQuestionsFieldConfig = group({
+  label: '選擇題組',
+  fields: {
+    aiSuggestion: virtual({
+      field: () =>
+        graphql.field({
+          type: graphql.JSON,
+          async resolve(item: Record<string, any>, args, context) {
+            const postID = item?.id
+            const post = await context.query.Post.findOne({
+              where: { id: postID },
+              query: 'id, content',
+            })
+            return {
+              label: 'AI助理生成',
+              content: post.content,
+              openAIKey: envVars.openAIKey,
+            }
+          },
+        }),
+      ui: {
+        views: './lists/views/ai-suggestion-multiple-choice',
+        createView: {
+          fieldMode: 'hidden',
+        },
+        itemView: {
+          fieldMode: 'edit',
+        },
+        listView: {
+          fieldMode: 'hidden',
+        },
+      },
+    }),
+    multipleChoiceQuestionsJSON: json({
+      label: '選擇題',
+      defaultValue: [],
+      ui: {
+        views: './lists/views/multiple-choice-questions',
+        createView: { fieldMode: 'hidden' },
+        itemView: { fieldMode: 'edit' },
+        listView: { fieldMode: 'hidden' },
+      },
+    }),
+  },
+})
+
+const essayQuestionsFieldConfig = group({
+  label: '思辨題組',
+  fields: {
+    aiEssaySuggestion: virtual({
+      field: () =>
+        graphql.field({
+          type: graphql.JSON,
+          async resolve(item: Record<string, any>, args, context) {
+            const postID = item?.id
+            const post = await context.query.Post.findOne({
+              where: { id: postID },
+              query: 'id, content',
+            })
+            return {
+              label: 'AI助理生成',
+              content: post.content,
+              openAIKey: envVars.openAIKey,
+            }
+          },
+        }),
+      ui: {
+        views: './lists/views/ai-suggestion-essay',
+        createView: {
+          fieldMode: 'hidden',
+        },
+        itemView: {
+          fieldMode: 'edit',
+        },
+        listView: {
+          fieldMode: 'hidden',
+        },
+      },
+    }),
+    essayQuestionsJSON: json({
+      label: '思辨題',
+      defaultValue: [],
+      ui: {
+        views: './lists/views/essay-questions',
+        createView: { fieldMode: 'hidden' },
+        itemView: { fieldMode: 'edit' },
+        listView: { fieldMode: 'hidden' },
+      },
+    }),
+  },
+})
 
 const listConfigurations = list({
   fields: {
@@ -384,6 +421,8 @@ const listConfigurations = list({
       label: 'og:image',
       ref: 'Photo',
     }),
+    aiDialog,
+    ...openingFieldConfig,
     ...multipleChoiceQuestionsFieldConfig,
     ...essayQuestionsFieldConfig,
     createdAt: timestamp({
@@ -568,7 +607,6 @@ const listConfigurations = list({
         listView: { fieldMode: 'hidden' },
       },
     }),
-    ...summaryFieldConfig,
   },
   ui: {
     label: 'Posts',

--- a/packages/cms/lists/views/ai-suggestion-opening.tsx
+++ b/packages/cms/lists/views/ai-suggestion-opening.tsx
@@ -1,0 +1,5 @@
+import { FieldTemplate } from './ai-suggestion'
+
+export const Field = FieldTemplate(
+  '你是一個具有幽默感的閱讀陪伴精靈，請提供30字內，能引發10歲兒童好奇心的文章預告！'
+)

--- a/packages/cms/migrations/20250918082814_add_opening_field_in_post_list/migration.sql
+++ b/packages/cms/migrations/20250918082814_add_opening_field_in_post_list/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "opening" TEXT NOT NULL DEFAULT '';

--- a/packages/cms/schema.graphql
+++ b/packages/cms/schema.graphql
@@ -198,6 +198,9 @@ type Post {
   ogTitle: String
   ogDescription: String
   ogImage: Photo
+  aiDialog: JSON
+  aiSuggestionOpening: JSON
+  opening: String
   aiSuggestion: JSON
   multipleChoiceQuestionsJSON: JSON
   aiEssaySuggestion: JSON
@@ -211,7 +214,6 @@ type Post {
   preview: JSON
   listPreview: String
   onlineUsers: JSON
-  summary: JSON
 }
 
 input PostWhereUniqueInput {
@@ -241,6 +243,7 @@ input PostWhereInput {
   ogTitle: StringFilter
   ogDescription: StringFilter
   ogImage: PhotoWhereInput
+  opening: StringFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
   createdBy: UserWhereInput
@@ -287,6 +290,7 @@ input PostOrderByInput {
   heroCaption: OrderDirection
   ogTitle: OrderDirection
   ogDescription: OrderDirection
+  opening: OrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
 }
@@ -316,6 +320,7 @@ input PostUpdateInput {
   ogTitle: String
   ogDescription: String
   ogImage: PhotoRelateToOneForUpdateInput
+  opening: String
   multipleChoiceQuestionsJSON: JSON
   essayQuestionsJSON: JSON
   createdAt: DateTime
@@ -413,6 +418,7 @@ input PostCreateInput {
   ogTitle: String
   ogDescription: String
   ogImage: PhotoRelateToOneForCreateInput
+  opening: String
   multipleChoiceQuestionsJSON: JSON
   essayQuestionsJSON: JSON
   createdAt: DateTime

--- a/packages/cms/schema.prisma
+++ b/packages/cms/schema.prisma
@@ -57,6 +57,7 @@ model Post {
   ogDescription                              String               @default("")
   ogImage                                    Photo?               @relation("Post_ogImage", fields: [ogImageId], references: [id])
   ogImageId                                  Int?                 @map("ogImage")
+  opening                                    String               @default("")
   multipleChoiceQuestionsJSON                Json?                @default("[]")
   essayQuestionsJSON                         Json?                @default("[]")
   createdAt                                  DateTime?            @default(now())


### PR DESCRIPTION
### PR 說明
新增「進入對話」功能。
分別新增 
- `aiSuggestionOpening` virtual field
- `opening` text field

`aiSuggestionOpening` 欄位提供預設的 prompt `你是一個具有幽默感的閱讀陪伴精靈，請提供30字內，能引發10歲兒童好奇心的文章預告！`，使用者（編輯）點擊送出，會發送 API request 到 OpenAI，OpenAI 會根據該 prompt 和文章內容，回傳適合的文章摘要內容。

編輯可以針對 OpenAI 回傳的內容，儲存到 `opening` 欄位，該欄位的值會用於報導仔的文章進場開場白。

### 後續優化事項
目前「進入對話」、「選擇題組」和「思辨題組」都是以文章內容為基底，要求 OpenAI 產生內容，但卻是分開三個 API requests，可以考慮整合成一次的 requests，並在 prompt 中要求回傳的格式，減少 requests 數量和增加編輯效率。

### Reference
[[CMS] Posts 新增「進入對話」](https://www.notion.so/twreporter/CMS-Posts-17e8dbdca932803a9794c504b6b16d22)