### PR TITLE
chore(frontend): add .env.ndx.public file

### DIFF
--- a/packages/frontend/.env.ndx.public
+++ b/packages/frontend/.env.ndx.public
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_GQL_ENDPOINT=https://ndx-kids-api.twreporter.org/api/graphql


### PR DESCRIPTION
### PR 說明
為了建置「可以測試 nDX 專案的功能」的環境，整個 rlease pipeline 新增了 `ndx` 環境， `ndx` 環境擁有自己的 frontend, api-gateway 和 cms 服務。
為了讓 ndx frontend 能夠打 ndx api-gateway，此 PR 新增了 `.env.ndx.public` 檔案，並且在 cloud build trigger [ndx-frontend](https://console.cloud.google.com/cloud-build/triggers;region=asia-east1/edit/3699d613-2ab2-4be1-99df-5ddf0c48fb1c?project=kids-reporter) 設定 `.env.ndx.public` 為 ndx frontend 要讀取的 public 環境變數。

### Reference
[[工程] 建立專案測試環境](https://www.notion.so/twreporter/2718dbdca932806e8a2ad907dd725614)