### PR TITLE
fix(frontend): add missing classname to footer link

### DIFF
--- a/packages/frontend/src/components/footer.tsx
+++ b/packages/frontend/src/components/footer.tsx
@@ -100,7 +100,7 @@ export const Footer = () => {
                 <Link
                   key={social.label}
                   href={social.href}
-                  className="text-neutral-white hover:text-neutral-200 transition-colors duration-200"
+                  className="text-neutral-white hover:text-neutral-200 transition-colors duration-200 relative"
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label={social.label}


### PR DESCRIPTION
## Summary

This PR fixes a missing CSS classname in the footer component that was causing positioning issues with social media links during rebasing.

## Changes

- Added `relative` class to social media link in footer component
- This ensures proper CSS positioning for the hover effect overlay

## Additional Notes

The social media links in the footer were missing the `relative` positioning class, which is required for the hover effect overlay to position correctly. This fix ensures the visual feedback works as intended when users hover over social media icons.

## Screenshot(s)

<img width="309" height="96" alt="image" src="https://github.com/user-attachments/assets/8100c3ee-64fc-468f-a60e-894344ec7d4d" />

## Reference(s)

- [Notion Defect Report](https://www.notion.so/twreporter/defect-footer-1-2788dbdca9328050a67bd4232172ed41?source=copy_link)