### PR TITLE
fix(frontend): fix footer space and header padding

### DIFF
--- a/packages/frontend/src/components/header/desktop-header-compact.tsx
+++ b/packages/frontend/src/components/header/desktop-header-compact.tsx
@@ -26,31 +26,33 @@ export function DesktopHeaderCompact({
           : 'opacity-100 translate-y-0 pointer-events-auto'
       )}
     >
-      <div className="flex items-center justify-between py-[14px] desktop:px-16 max-w-300 mx-auto">
-        <div className="flex items-center gap-4">
-          <HamburgerButton onHamburgerOverlayOpen={onHamburgerOverlayOpen} />
+      <div className="py-[14px] desktop:px-16">
+        <div className="flex items-center justify-between max-w-300 mx-auto px-4">
+          <div className="flex items-center gap-4">
+            <HamburgerButton onHamburgerOverlayOpen={onHamburgerOverlayOpen} />
 
-          <div className="flex items-center gap-12">
-            <LogoLink />
-            {postTitle && (
-              <div className="hidden desktop:block pr-12">
-                <p className="prose-p2 text-neutral-900 font-medium tracking-wide max-w-124 text-ellipsis overflow-hidden whitespace-nowrap">
-                  {postTitle}
-                </p>
-              </div>
-            )}
+            <div className="flex items-center gap-12">
+              <LogoLink />
+              {postTitle && (
+                <div className="hidden desktop:block pr-12">
+                  <p className="prose-p2 text-neutral-900 font-medium tracking-wide max-w-124 text-ellipsis overflow-hidden whitespace-nowrap">
+                    {postTitle}
+                  </p>
+                </div>
+              )}
+            </div>
           </div>
-        </div>
 
-        <div className="flex items-center gap-4">
-          <ActionButtons hideCtaButtons={true} tags={keywords} />
-          <Link
-            href="/login"
-            className="flex items-center justify-center w-8 h-8 rounded-full hover:bg-gray-100 transition-colors duration-200"
-            aria-label="登入"
-          >
-            {LoginIcon}
-          </Link>
+          <div className="flex items-center gap-4">
+            <ActionButtons hideCtaButtons={true} tags={keywords} />
+            <Link
+              href="/login"
+              className="flex items-center justify-center w-8 h-8 rounded-full hover:bg-gray-100 transition-colors duration-200"
+              aria-label="登入"
+            >
+              {LoginIcon}
+            </Link>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/frontend/src/components/header/desktop-header.tsx
+++ b/packages/frontend/src/components/header/desktop-header.tsx
@@ -13,30 +13,34 @@ export function DesktopHeader({
   keywords,
 }: DesktopHeaderProps) {
   return (
-    <div className="w-full bg-transparent px-12 hidden desktop:block">
-      <div className="flex items-center justify-between px-4 py-[18px]">
-        <div className="flex items-center gap-8">
-          <LogoLink />
-          <div>
-            <span className="prose-p2 text-neutral-900 font-medium tracking-wide">
-              理解世界 × 參與未來
-            </span>
-          </div>
-        </div>
+    <div className="hidden desktop:block w-full ">
+      <div className="w-full bg-transparent px-12 hidden desktop:block">
+        <div className="max-w-300 mx-auto">
+          <div className="flex items-center justify-between px-4 py-[18px]">
+            <div className="flex items-center gap-8">
+              <LogoLink />
+              <div>
+                <span className="prose-p2 text-neutral-900 font-medium tracking-wide">
+                  理解世界 × 參與未來
+                </span>
+              </div>
+            </div>
 
-        <div className="flex items-center gap-4">
-          <ActionButtons tags={keywords} />
-          <Link
-            href="/login"
-            className="flex items-center justify-center w-8 h-8 rounded-full hover:bg-gray-100 transition-colors duration-200"
-            aria-label="登入"
-          >
-            {LoginIcon}
-          </Link>
+            <div className="flex items-center gap-4">
+              <ActionButtons tags={keywords} />
+              <Link
+                href="/login"
+                className="flex items-center justify-center w-8 h-8 rounded-full hover:bg-gray-100 transition-colors duration-200"
+                aria-label="登入"
+              >
+                {LoginIcon}
+              </Link>
+            </div>
+          </div>
+
+          <BottomNavigation onHamburgerOverlayOpen={onHamburgerOverlayOpen} />
         </div>
       </div>
-
-      <BottomNavigation onHamburgerOverlayOpen={onHamburgerOverlayOpen} />
     </div>
   )
 }

--- a/packages/frontend/src/components/header/index.tsx
+++ b/packages/frontend/src/components/header/index.tsx
@@ -28,12 +28,10 @@ function Header() {
 
   return (
     <>
-      <div className="hidden desktop:block w-full max-w-300 mx-auto">
-        <DesktopHeader
-          onHamburgerOverlayOpen={onHamburgerOverlayOpen}
-          keywords={keywords}
-        />
-      </div>
+      <DesktopHeader
+        onHamburgerOverlayOpen={onHamburgerOverlayOpen}
+        keywords={keywords}
+      />
       <MobileHeader
         onCloseMenu={onCloseMenu}
         showCloseButtonWhenMenuOpen={isMobile}


### PR DESCRIPTION
## Summary

This PR fixes layout issues with footer spacing and header padding in the frontend components. The changes improve the overall visual consistency and spacing of the header components across desktop and mobile views.

## Changes

- **Desktop Header Compact**: Restructured the layout container to properly center content with `max-w-300 mx-auto` and added proper padding with `px-4`
- **Desktop Header**: Added proper container structure with `max-w-300 mx-auto` wrapper and improved layout hierarchy
- **Header Index**: Removed redundant wrapper div that was causing layout issues and simplified the component structure
- **Layout Improvements**: Enhanced spacing and alignment consistency across all header variants

## Additional Notes

These changes address the footer defect mentioned in the Notion page and ensure proper spacing and alignment of header components. The modifications maintain the existing functionality while improving the visual layout structure.

## Screenshot(s)

<img width="1299" height="317" alt="image" src="https://github.com/user-attachments/assets/9875623d-d6a1-4aa4-acbb-9739b559d141" />

<img width="396" height="196" alt="image" src="https://github.com/user-attachments/assets/c03f43bb-b1ed-4d03-9fbb-0f54bfc84575" />

<img width="310" height="194" alt="image" src="https://github.com/user-attachments/assets/13b085b3-9e3a-461d-b288-cea53132ab2f" />

## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/defect-footer-1-2788dbdca9328050a67bd4232172ed41?source=copy_link)