### PR TITLE
fix: set user pointer event none when search is closed

### DIFF
--- a/packages/frontend/src/components/header/shared-components.tsx
+++ b/packages/frontend/src/components/header/shared-components.tsx
@@ -68,6 +68,11 @@ const searchDropdownVariants = cva(
         class: 'p-4 h-min opacity-100',
       },
       {
+        mode: 'popover',
+        isSearchOpen: false,
+        class: 'pointer-events-none',
+      },
+      {
         mode: 'inline',
         isFocused: true,
         class:


### PR DESCRIPTION
## Summary

This PR fixes a header defect by adding proper pointer event handling for the search dropdown when it's closed in popover mode. The change ensures that users cannot interact with the search dropdown when it's not visible, improving the user experience and preventing potential UI issues.

## Changes

- Added new compound variant in `searchDropdownVariants` for popover mode when search is closed
- Set `pointer-events-none` class when `mode: 'popover'` and `isSearchOpen: false`
- This prevents user interaction with the search dropdown when it's not visible

## Additional Notes

This fix addresses a specific UI interaction issue where users could potentially interact with hidden search dropdown elements. The `pointer-events-none` CSS class ensures that the dropdown is completely non-interactive when closed, which is the expected behavior for popover-style dropdowns.
