### PR TITLE
chore(root): update babel configuration and dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ packages/**/dist
 
 # cursor
 .cursor
+
+# vscode
+.vscode

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,6 +1,7 @@
 /* global process */
 const isProduction = process.env.NODE_ENV === 'production'
 
+/** @type {import('@babel/core').TransformOptions} */
 module.exports = {
   babelrcRoots: [',', 'packages/*'],
   presets: [
@@ -17,6 +18,7 @@ module.exports = {
       '@babel/preset-react',
       {
         development: !isProduction,
+        runtime: 'automatic',
       },
     ],
     '@babel/preset-typescript',

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@babel/preset-env": "^7.18.2",
     "@babel/preset-react": "^7.17.12",
     "@babel/preset-typescript": "^7.17.12",
+    "@babel/types": "^7.28.4",
     "@changesets/cli": "^2.27.1",
     "@eslint/eslintrc": "^3.3.1",
     "@types/draft-js": "^0.11.10",
@@ -50,7 +51,9 @@
     "lint-staged": "^16.2.0",
     "prettier": "^3.6.2",
     "typescript": "^5.9.2",
-    "webpack-dev-server": "^4.15.1"
+    "webpack-dev-server": "^4.15.1",
+    "@types/babel__core": "^7.20.5",
+    "@types/eslint-config-prettier": "^6.11.3"
   },
   "lint-staged": {
     "*.{js,ts,jsx,tsx}": "eslint --config eslint.config.mjs --cache --fix"
@@ -60,8 +63,5 @@
     "react-dom": "18.3.1"
   },
   "version": "0.0.0",
-  "packageManager": "yarn@1.22.19",
-  "dependencies": {
-    "@types/eslint-config-prettier": "^6.11.3"
-  }
+  "packageManager": "yarn@1.22.19"
 }

--- a/packages/draft-renderer/babel.config.cjs
+++ b/packages/draft-renderer/babel.config.cjs
@@ -5,8 +5,12 @@ const pkg = require('./package.json')
 const pkgName = pkg.name
 const pkgVersion = pkg.version
 
+/**
+ * @param {import('@babel/core').ConfigAPI} api
+ * @returns {import('@babel/core').TransformOptions}
+ */
 module.exports = function (api) {
-  api.cache(true)
+  api.cache.forever()
   const plugins = [
     [
       'file-loader',
@@ -49,6 +53,7 @@ module.exports = function (api) {
         '@babel/preset-react',
         {
           development: process.env.NODE_ENV !== 'production',
+          runtime: 'automatic',
         },
       ],
       '@babel/preset-typescript',

--- a/packages/draft-renderer/eslint.config.mjs
+++ b/packages/draft-renderer/eslint.config.mjs
@@ -23,7 +23,7 @@ export default [
     files: ['src/**/*.{js,jsx}'],
   },
   {
-    files: ['**/*.config.{js,mjs}', '**/.babelrc.js'],
+    files: ['**/*.config.{js,mjs,cjs}'],
     languageOptions: {
       ecmaVersion: 2022,
       sourceType: 'module',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1059,10 +1059,20 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz#9478c707febcbbe1ddb38a3d91a2e054ae622d83"
   integrity sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==
 
+"@babel/helper-string-parser@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
+  integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
+
 "@babel/helper-validator-identifier@^7.22.20":
   version "7.22.20"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz#c4ae002c61d2879e724581d96665583dbc1dc0e0"
   integrity sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==
+
+"@babel/helper-validator-identifier@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz#a7054dcc145a967dd4dc8fee845a57c1316c9df8"
+  integrity sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==
 
 "@babel/helper-validator-option@^7.22.15", "@babel/helper-validator-option@^7.23.5":
   version "7.23.5"
@@ -1100,6 +1110,13 @@
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.9.tgz#7b903b6149b0f8fa7ad564af646c4c38a77fc44b"
   integrity sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==
+
+"@babel/parser@^7.1.0", "@babel/parser@^7.20.7":
+  version "7.28.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.28.4.tgz#da25d4643532890932cc03f7705fe19637e03fa8"
+  integrity sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==
+  dependencies:
+    "@babel/types" "^7.28.4"
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.23.3":
   version "7.23.3"
@@ -1861,6 +1878,14 @@
     "@babel/types" "^7.23.9"
     debug "^4.3.1"
     globals "^11.1.0"
+
+"@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.28.2", "@babel/types@^7.28.4":
+  version "7.28.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.28.4.tgz#0a4e618f4c60a7cd6c11cb2d48060e4dbe38ac3a"
+  integrity sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==
+  dependencies:
+    "@babel/helper-string-parser" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.27.1"
 
 "@babel/types@^7.22.15", "@babel/types@^7.22.19", "@babel/types@^7.22.5", "@babel/types@^7.23.0", "@babel/types@^7.23.4", "@babel/types@^7.23.6", "@babel/types@^7.23.9", "@babel/types@^7.4.4":
   version "7.23.9"
@@ -3966,6 +3991,39 @@
   integrity sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==
   dependencies:
     tslib "^2.4.0"
+
+"@types/babel__core@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
+  integrity sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==
+  dependencies:
+    "@babel/parser" "^7.20.7"
+    "@babel/types" "^7.20.7"
+    "@types/babel__generator" "*"
+    "@types/babel__template" "*"
+    "@types/babel__traverse" "*"
+
+"@types/babel__generator@*":
+  version "7.27.0"
+  resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.27.0.tgz#b5819294c51179957afaec341442f9341e4108a9"
+  integrity sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@types/babel__template@*":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.4.4.tgz#5672513701c1b2199bc6dad636a9d7491586766f"
+  integrity sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@types/babel__traverse@*":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.28.0.tgz#07d713d6cce0d265c9849db0cbe62d3f61f36f74"
+  integrity sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==
+  dependencies:
+    "@babel/types" "^7.28.2"
 
 "@types/body-parser@*":
   version "1.19.5"


### PR DESCRIPTION
## Summary

This PR updates the Babel configuration across the monorepo to fix jsx runtime and add proper TypeScript support. The changes include updating Babel presets, adding type annotations, and reorganizing package dependencies.

## Changes

- Updated root `babel.config.cjs` with proper TypeScript type annotations and React runtime configuration
- Added `runtime: 'automatic'` to React preset for better JSX handling
- Updated `packages/draft-renderer/babel.config.cjs` with improved caching strategy and React runtime
- Enhanced ESLint configuration in draft-renderer to include `.cjs` files
- Added new dependencies: `@babel/types`, `@types/babel__core`, `@types/eslint-config-prettier`
- Reorganized package.json dependencies structure
- Updated `.gitignore` to exclude `.vscode` directory
- Updated yarn.lock with new dependency versions

## Additional Notes

- Modify the syntax of babel caching to fit the type
- Type annotations improve IDE support and type checking for Babel configurations
- Dependency reorganization moves type definitions to appropriate sections
