### PR TITLE
fix(cms): prisma migration failure due to missing migration script

### DIFF
--- a/packages/cms/migrations/20250918082814_add_opening_field_in_post_list/migration.sql
+++ b/packages/cms/migrations/20250918082814_add_opening_field_in_post_list/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "opening" TEXT NOT NULL DEFAULT '';

--- a/packages/cms/migrations/20251014030954_add_questions_in_post_list/migration.sql
+++ b/packages/cms/migrations/20251014030954_add_questions_in_post_list/migration.sql
@@ -7,8 +7,7 @@
 */
 -- AlterTable
 ALTER TABLE "Post" DROP COLUMN "essayQuestionsJSON",
-DROP COLUMN "multipleChoiceQuestionsJSON",
-ADD COLUMN     "opening" TEXT NOT NULL DEFAULT '';
+DROP COLUMN "multipleChoiceQuestionsJSON";
 
 -- CreateTable
 CREATE TABLE "PostChoiceQuestion" (


### PR DESCRIPTION
### Bug 說明 
因為 prisma migration 失敗的關係，導致 [Cloud Build](https://console.cloud.google.com/cloud-build/builds;region=asia-east1/42db931e-d861-4301-bcf2-df2e34798eef?project=kids-reporter) 無法將新產生的 image 部署到 Cloud Run 上。
主要是因為 ndx branch 和 prod branch migraitons 有差異，prod branch 多一個 `packages/cms/migrations/20250918082814_add_opening_field_in_post_list/migration.sql`。

但因為 ndx branch 和 prod branch 共用 database，所以 ndx branch 在做 prisma migration 時，會因為 `Post.opening` 欄位已經存在而無法順利執行 migration。

此 PR 將 ndx branch 上的 missing migration 加回來，同時調整 migration script，讓 migration script 略過已經新增的欄位。