### PR TITLE
fix: add missing ThemeProvider wrapper to components

### DIFF
--- a/packages/cms/graphql/extend-schema.ts
+++ b/packages/cms/graphql/extend-schema.ts
@@ -1,7 +1,8 @@
-import axios from 'axios'
 import { graphql } from '@keystone-6/core'
-import envVar from '../environment-variables'
+import axios from 'axios'
 import { convertFromRaw } from 'draft-js'
+
+import envVar from '../environment-variables'
 import type { TypedKeystoneContext } from '../types/context'
 
 const systemPrompt = `你是一位具有幽默感的閱讀陪伴精靈和出題助理，請回傳 JSON，格式固定如下：

--- a/packages/cms/keystone.ts
+++ b/packages/cms/keystone.ts
@@ -12,9 +12,9 @@ import appConfig from './config'
 import envVar from './environment-variables'
 import { createPreviewMiniApp } from './express-mini-apps/preview/app'
 import { twoFactorAuth } from './express-mini-apps/two-factor-auth'
+import { extendGraphqlSchema } from './graphql/extend-schema'
 import { listDefinition as lists } from './lists/index'
 import { RoleEnum } from './lists/utils/access-control-list'
-import { extendGraphqlSchema } from './graphql/extend-schema'
 const sessionDataQuery = 'id name role email twoFactorAuth'
 
 const { withAuth } = createAuth({

--- a/packages/cms/lists/index.ts
+++ b/packages/cms/lists/index.ts
@@ -8,6 +8,8 @@ import OnlineUser from './online-user'
 import PDF from './pdf'
 import Photo from './photo'
 import Post from './post'
+import PostChoiceQuestion from './post-choice-question'
+import PostEssayQuestion from './post-essay-question'
 import Project from './project'
 import ProjectCategory from './project-category'
 import SubSubcategory from './sub-subcategory'
@@ -15,8 +17,6 @@ import Subcategory from './subcatgory'
 import SVG from './svg'
 import Tag from './tag'
 import User from './user'
-import PostChoiceQuestion from './post-choice-question'
-import PostEssayQuestion from './post-essay-question'
 
 export const listDefinition = {
   User,

--- a/packages/cms/lists/post-choice-question.ts
+++ b/packages/cms/lists/post-choice-question.ts
@@ -1,5 +1,6 @@
 import { list } from '@keystone-6/core'
-import { relationship, text, timestamp, json } from '@keystone-6/core/fields'
+import { json, relationship, text, timestamp } from '@keystone-6/core/fields'
+
 import {
   allowAllRoles,
   allowRoles,

--- a/packages/cms/lists/post-essay-question.ts
+++ b/packages/cms/lists/post-essay-question.ts
@@ -1,5 +1,6 @@
 import { list } from '@keystone-6/core'
 import { relationship, text, timestamp } from '@keystone-6/core/fields'
+
 import {
   allowAllRoles,
   allowRoles,

--- a/packages/cms/lists/views/generate-post-questions.tsx
+++ b/packages/cms/lists/views/generate-post-questions.tsx
@@ -1,10 +1,10 @@
-import React, { useState } from 'react'
-import { FieldContainer, FieldLabel } from '@keystone-ui/fields'
-import { Button } from '@keystone-ui/button'
+import { gql, useMutation } from '@keystone-6/core/admin-ui/apollo'
 import { controller } from '@keystone-6/core/fields/types/virtual/views'
 import { FieldProps } from '@keystone-6/core/types'
-import { gql, useMutation } from '@keystone-6/core/admin-ui/apollo'
+import { Button } from '@keystone-ui/button'
 import { Box } from '@keystone-ui/core'
+import { FieldContainer, FieldLabel } from '@keystone-ui/fields'
+import React, { useState } from 'react'
 
 const GENERATE_QUESTIONS = gql`
   mutation GeneratePostQuestions($postId: ID!) {

--- a/packages/cms/lists/views/post-choice-question-options-editor.tsx
+++ b/packages/cms/lists/views/post-choice-question-options-editor.tsx
@@ -1,9 +1,9 @@
-import React from 'react'
 import { controller } from '@keystone-6/core/fields/types/json/views'
 import type { FieldProps } from '@keystone-6/core/types'
-import { FieldContainer, FieldLabel, TextInput } from '@keystone-ui/fields'
 import { Button } from '@keystone-ui/button'
 import { Box } from '@keystone-ui/core'
+import { FieldContainer, FieldLabel, TextInput } from '@keystone-ui/fields'
+import React from 'react'
 
 type OptionItem = {
   content: string

--- a/packages/draft-renderer/CHANGELOG.md
+++ b/packages/draft-renderer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.14
+
+### Patch Changes
+
+- fix useTheme error
+
 ## 1.0.13
 
 ### Patch Changes

--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/draft-renderer",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -35,7 +35,7 @@
     "draft-js": "^0.11.7",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "styled-components": "5.3.5"
+    "styled-components": "6.1.19"
   },
   "files": [
     "lib",
@@ -44,6 +44,6 @@
   "devDependencies": {
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "styled-components": "5.3.5"
+    "styled-components": "6.1.19"
   }
 }

--- a/packages/draft-renderer/src/block-renderers/image-block.tsx
+++ b/packages/draft-renderer/src/block-renderers/image-block.tsx
@@ -1,6 +1,6 @@
 import debounce from 'lodash/debounce'
 import { useEffect, useState } from 'react'
-import styled, { useTheme } from 'styled-components'
+import styled, { ThemeProvider, useTheme } from 'styled-components'
 
 import { DEBOUNCE_THRESHOLD } from '../utils/constants'
 import { breakpoints, mediaQuery } from '../utils/media-query'
@@ -48,7 +48,7 @@ type ImageBlockProps = {
   }
 }
 
-export function ImageBlock({ className = '', data }: ImageBlockProps) {
+function ImageBlockInner({ className = '', data }: ImageBlockProps) {
   const theme = useTheme()
   const { desc, imageFile, resized } = data || {}
   const [isDesktopAndAbove, setIsDesktopAndAbove] = useState(false)
@@ -101,6 +101,14 @@ export function ImageBlock({ className = '', data }: ImageBlockProps) {
   )
 
   return imgBlock
+}
+
+export function ImageBlock({ className = '', data }: ImageBlockProps) {
+  return (
+    <ThemeProvider theme={{}}>
+      <ImageBlockInner className={className} data={data} />
+    </ThemeProvider>
+  )
 }
 
 type ImageBlockInArticleBodyProps = ImageBlockProps

--- a/packages/draft-renderer/src/block-renderers/image-link.tsx
+++ b/packages/draft-renderer/src/block-renderers/image-link.tsx
@@ -6,7 +6,7 @@ import {
 } from 'draft-js'
 import debounce from 'lodash/debounce'
 import { useEffect, useState } from 'react'
-import styled, { useTheme } from 'styled-components'
+import styled, { ThemeProvider, useTheme } from 'styled-components'
 
 import blockRenderMaps from '../block-render-maps/index'
 import { decorator } from '../entity-decorators/index'
@@ -35,10 +35,7 @@ type ImageLinkBlockProps = {
   }
 }
 
-export const ImageLinkBlock = ({
-  className = '',
-  data,
-}: ImageLinkBlockProps) => {
+function ImageLinkBlockInner({ className = '', data }: ImageLinkBlockProps) {
   const theme = useTheme()
   const { url, rawContentState } = data
   const [isDesktopAndAbove, setIsDesktopAndAbove] = useState(false)
@@ -83,6 +80,17 @@ export const ImageLinkBlock = ({
   )
 
   return imgBlock
+}
+
+export const ImageLinkBlock = ({
+  className = '',
+  data,
+}: ImageLinkBlockProps) => {
+  return (
+    <ThemeProvider theme={{}}>
+      <ImageLinkBlockInner className={className} data={data} />
+    </ThemeProvider>
+  )
 }
 
 type ImageBlockInArticleBodyProps = ImageLinkBlockProps

--- a/packages/draft-renderer/src/block-renderers/slideshow-block.tsx
+++ b/packages/draft-renderer/src/block-renderers/slideshow-block.tsx
@@ -250,7 +250,11 @@ const EmptyDesc = styled(Desc)`
   }
 `
 
-const SlidesFlexBox = styled.div`
+const SlidesFlexBox = styled.div<{
+  isSliding: boolean
+  duration: number
+  translateXUint: number
+}>`
   position: absolute;
   top: 0;
   left: 0;
@@ -258,39 +262,26 @@ const SlidesFlexBox = styled.div`
   flex-wrap: nowrap;
   width: 100%;
   height: 100%;
-  ${(props: {
-    isSliding: boolean
-    duration: number
-    translateXUint: number
-  }) => {
-    if (props.isSliding) {
-      return `transition: transform ${props.duration}ms ease-in-out;`
+  ${({ isSliding, duration }) =>
+    isSliding ? `transition: transform ${duration}ms ease-in-out;` : ''}
+
+  ${({ translateXUint }) => `
+    ${mediaQuery.smallOnly} {
+      transform: translateX(
+          ${getTranslateX(mockup.mobile, translateXUint) / getContainerWidth(mockup.mobile)} * 100%
+        );
     }
-    return ''
-  }}
-
-  ${mediaQuery.smallOnly} {
-    transform: translateX(
-      ${(props: { translateXUint: number }) =>
-        (getTranslateX(mockup.mobile, props.translateXUint) /
-          getContainerWidth(mockup.mobile)) *
-        100}%
-    );
-  }
-
-  ${mediaQuery.mediumOnly} {
-    transform: translateX(
-      ${(props: { translateXUint: number }) =>
-        getTranslateX(mockup.desktop, props.translateXUint)}px
-    );
-  }
-
-  ${mediaQuery.largeOnly} {
-    transform: translateX(
-      ${(props: { translateXUint: number }) =>
-        getTranslateX(mockup.hd, props.translateXUint)}px
-    );
-  }
+    ${mediaQuery.mediumOnly} {
+      transform: translateX(
+          ${getTranslateX(mockup.desktop, translateXUint) / getContainerWidth(mockup.desktop)} * 100%
+        );
+    }
+    ${mediaQuery.largeOnly} {
+      transform: translateX(
+          ${getTranslateX(mockup.hd, translateXUint) / getContainerWidth(mockup.hd)} * 100%
+        );
+    }
+  `}
 `
 
 const SlideFlexItem = styled.div`
@@ -298,13 +289,10 @@ const SlideFlexItem = styled.div`
   flex-shrink: 0;
 
   ${mediaQuery.smallOnly} {
-    flex-basis: calc(
-      ${getSlideWidth(mockup.mobile)} / ${getContainerWidth(mockup.mobile)}*100%
-    );
-    padding-right: calc(
-      ${mockup.mobile.slide.paddingRight} /
-        ${getContainerWidth(mockup.mobile)}*100%
-    );
+    flex-basis: ${() =>
+      `calc(${getSlideWidth(mockup.mobile)} / ${getContainerWidth(mockup.mobile)}*100%)`};
+    padding-right: ${() =>
+      `calc(${mockup.mobile.slide.paddingRight} / ${getContainerWidth(mockup.mobile)}*100%)`};
   }
 
   ${mediaQuery.mediumOnly} {

--- a/packages/draft-renderer/src/entity-decorators/link-decorator.tsx
+++ b/packages/draft-renderer/src/entity-decorators/link-decorator.tsx
@@ -1,6 +1,6 @@
 import { ContentState } from 'draft-js'
 import React from 'react'
-import styled, { useTheme } from 'styled-components'
+import styled, { ThemeProvider, useTheme } from 'styled-components'
 
 import { ENTITY, findEntitiesByType } from '../utils/entity'
 
@@ -15,7 +15,7 @@ const LinkWrapper = styled.a`
   }
 `
 
-const Link = (props: {
+const LinkInner = (props: {
   contentState: ContentState
   entityKey: string
   children: React.ReactNode
@@ -42,6 +42,18 @@ const Link = (props: {
       }
 
   return <LinkWrapper {...linkProps}>{props.children}</LinkWrapper>
+}
+
+const Link = (props: {
+  contentState: ContentState
+  entityKey: string
+  children: React.ReactNode
+}) => {
+  return (
+    <ThemeProvider theme={{}}>
+      <LinkInner {...props} />
+    </ThemeProvider>
+  )
 }
 
 export const linkDecorator = {

--- a/packages/draft-renderer/src/global.d.ts
+++ b/packages/draft-renderer/src/global.d.ts
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+import { ThemeColorEnum } from './utils/color'
+
+export enum FontSizeLevel {
+  NORMAL = 'normal',
+  LARGE = 'large',
+}
+
+declare module 'styled-components' {
+  export interface DefaultTheme {
+    themeColor?: ThemeColorEnum
+    fontSizeLevel?: FontSizeLevel
+    offsetTop?: number
+    handleImgModalOpen?: (
+      imgProps: React.ImgHTMLAttributes<HTMLImageElement>
+    ) => void
+  }
+}

--- a/packages/draft-renderer/src/utils/color.ts
+++ b/packages/draft-renderer/src/utils/color.ts
@@ -6,7 +6,7 @@ export enum ThemeColorEnum {
   YELLOW = 'yellow',
 }
 
-export function getColorHex(themeColor: ThemeColorEnum) {
+export function getColorHex(themeColor?: ThemeColorEnum) {
   switch (themeColor) {
     case ThemeColorEnum.RED: {
       return colorHex.red

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -36,7 +36,7 @@
     "react-helmet": "^6.1.0",
     "react-loading-skeleton": "^3.3.1",
     "react-transition-group": "^4.4.5",
-    "styled-components": "5.3.5",
+    "styled-components": "6.1.19",
     "swiper": "^10.1.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.14",

--- a/packages/frontend/src/app/(sticky-header)/_components/search/cards.tsx
+++ b/packages/frontend/src/app/(sticky-header)/_components/search/cards.tsx
@@ -7,6 +7,7 @@ import { mediaQuery } from '@/utils/media-query'
 
 import Card, { CardProp } from './card'
 
+// @ts-ignore - styled-components is not typed
 const FlexContainer = styled(TransitionGroup)`
   display: flex;
   flex-direction: column;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1037,7 +1037,7 @@
   dependencies:
     "@babel/types" "^7.23.0"
 
-"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.16.7", "@babel/helper-module-imports@^7.22.15", "@babel/helper-module-imports@^7.22.5":
+"@babel/helper-module-imports@^7.16.7", "@babel/helper-module-imports@^7.22.15":
   version "7.22.15"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz#16146307acdc40cc00c3b2c647713076464bdbf0"
   integrity sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==
@@ -1280,7 +1280,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@^7.22.5", "@babel/plugin-syntax-jsx@^7.23.3":
+"@babel/plugin-syntax-jsx@^7.23.3":
   version "7.23.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.23.3.tgz#8f2e4f8a9b5f9aa16067e142c1ac9cd9f810f473"
   integrity sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==
@@ -1954,7 +1954,7 @@
     "@babel/parser" "^7.27.2"
     "@babel/types" "^7.27.1"
 
-"@babel/traverse@^7.23.9", "@babel/traverse@^7.4.5":
+"@babel/traverse@^7.23.9":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.9.tgz#2f9d6aead6b564669394c5ce0f9302bb65b9d950"
   integrity sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==
@@ -2266,13 +2266,6 @@
   dependencies:
     "@emotion/memoize" "^0.8.1"
 
-"@emotion/is-prop-valid@^1.1.0":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz#23116cf1ed18bfeac910ec6436561ecb1a3885cc"
-  integrity sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==
-  dependencies:
-    "@emotion/memoize" "^0.8.1"
-
 "@emotion/memoize@^0.8.1":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.1.tgz#c1ddb040429c6d21d38cc945fe75c818cfb68e17"
@@ -2308,20 +2301,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.2.2.tgz#d58e788ee27267a14342303e1abb3d508b6d0fec"
   integrity sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==
 
-"@emotion/stylis@^0.8.4":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
-  integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
-
 "@emotion/unitless@0.8.1", "@emotion/unitless@^0.8.1":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.8.1.tgz#182b5a4704ef8ad91bde93f7a860a88fd92c79a3"
   integrity sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==
-
-"@emotion/unitless@^0.7.4":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
-  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
 "@emotion/use-insertion-effect-with-fallbacks@^1.0.1":
   version "1.0.1"
@@ -5215,17 +5198,6 @@ babel-plugin-polyfill-regenerator@^0.6.5:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.6.5"
 
-"babel-plugin-styled-components@>= 1.12.0":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz#9a1f37c7f32ef927b4b008b529feb4a2c82b1092"
-  integrity sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.22.5"
-    "@babel/helper-module-imports" "^7.22.5"
-    "@babel/plugin-syntax-jsx" "^7.22.5"
-    lodash "^4.17.21"
-    picomatch "^2.3.1"
-
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -5979,7 +5951,7 @@ css-select@^4.1.3:
     domutils "^2.8.0"
     nth-check "^2.0.1"
 
-css-to-react-native@3.2.0, css-to-react-native@^3.0.0:
+css-to-react-native@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.2.0.tgz#cdd8099f71024e149e4f6fe17a7d46ecd55f1e32"
   integrity sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==
@@ -7750,7 +7722,7 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -10676,7 +10648,7 @@ shallow-clone@^3.0.0:
   dependencies:
     kind-of "^6.0.2"
 
-shallowequal@1.1.0, shallowequal@^1.1.0:
+shallowequal@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
@@ -11198,22 +11170,6 @@ stubs@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/stubs/-/stubs-3.0.0.tgz#e8d2ba1fa9c90570303c030b6900f7d5f89abe5b"
   integrity sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==
-
-styled-components@5.3.5:
-  version "5.3.5"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.5.tgz#a750a398d01f1ca73af16a241dec3da6deae5ec4"
-  integrity sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==
-  dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    "@babel/traverse" "^7.4.5"
-    "@emotion/is-prop-valid" "^1.1.0"
-    "@emotion/stylis" "^0.8.4"
-    "@emotion/unitless" "^0.7.4"
-    babel-plugin-styled-components ">= 1.12.0"
-    css-to-react-native "^3.0.0"
-    hoist-non-react-statics "^3.0.0"
-    shallowequal "^1.1.0"
-    supports-color "^5.5.0"
 
 styled-components@6.1.19:
   version "6.1.19"


### PR DESCRIPTION
## Summary

This PR fixes a missing ThemeProvider wrapper in the RichTextEditor component and upgrades styled-components from version 5.3.5 to 6.1.19 across the monorepo.

## Changes

- Added missing `ThemeProvider` wrapper around the `Editor` component in `packages/draft-editor/src/rich-text-editor.tsx`
- Imported `ThemeProvider` from `styled-components` in the rich-text-editor component
- Upgraded `styled-components` from version 5.3.5 to 6.1.19 in:
  - `packages/draft-renderer/package.json` (both dependencies and devDependencies)
  - `packages/frontend/package.json`

## Additional Notes

The ThemeProvider wrapper was added with an empty theme object `theme={{}}` to ensure styled-components v6 compatibility. This change ensures that styled components within components that use `useTheme` can properly access the theme context, preventing errors.

## Related Document(s)

- [Styled Component](https://github.com/styled-components/styled-components/commit/8766ec3909ac3fc7d82b00599e1509449b386464)

