### PR TITLE
fix(frontend): fix baodaozai retrigger and adjust UI

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -14,7 +14,7 @@
     "@googleapis/customsearch": "^1.0.4",
     "@kids-reporter/draft-renderer": "^1.0.13",
     "@next/third-parties": "^14.1.1",
-    "@kids-reporter/routing-ui": "0.1.0-alpha.1",
+    "@kids-reporter/routing-ui": "0.1.0-alpha.2",
     "@radix-ui/react-slot": "^1.2.3",
     "@tailwindcss/postcss": "^4.1.14",
     "@twreporter/errors": "^1.1.2",

--- a/packages/frontend/src/app/(sticky-header)/_components/article/article.tsx
+++ b/packages/frontend/src/app/(sticky-header)/_components/article/article.tsx
@@ -1,8 +1,10 @@
 'use client'
 import './article.css'
+import './article.css'
 
-import { useCallback, useEffect, useState } from 'react'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useCallback, useState } from 'react'
 
 import AuthorCard, { Author } from '@/components/author-card'
 import Divider from '@/components/divider'
@@ -14,6 +16,12 @@ import {
   DEFAULT_THEME_COLOR,
   FontSizeLevel,
 } from '@/constants'
+import {
+  BaodaozaiActionSetter,
+  BaodaozaiEventTrigger,
+  BaodaozaiQAModal,
+} from '@/services/call-baodaozai'
+import { QAModalEvent } from '@/services/call-baodaozai/components/qa-modal'
 import { getPostSummaries } from '@/utils'
 
 import { ArticleContext } from './article-context'
@@ -21,24 +29,15 @@ import Brief, { AuthorGroup } from './brief'
 import CallToAction from './call-to-action'
 import HeroImage from './hero-image'
 import ImageModal from './image-modal'
+import { IS_LOGIN, QUESTIONS } from './mock'
 import { NewsReading } from './news-reading'
 import PostRenderer from './post-renderer'
 import PublishedDate from './published-date'
 import RelatedPosts from './related-posts'
 import { MobileSidebar, Sidebar } from './sidebar'
+import StartReadingBaodaozaiEventTrigger from './start-reading-baodaozai-event-trigger'
 import SubSubcategory from './subSubcategory'
 import Title from './title'
-import './article.css'
-import {
-  BaodaozaiActionSetter,
-  BaodaozaiEventTrigger,
-  BaodaozaiQAModal,
-} from '@/services/call-baodaozai'
-import { QAModalEvent } from '@/services/call-baodaozai/components/qa-modal'
-import { useRouter } from 'next/navigation'
-import { IS_LOGIN, QUESTIONS } from './mock'
-
-import { useIsAtTop } from '@kids-reporter/routing-ui'
 
 const getPostContents = (post: any) => {
   // Assemble authors for brief
@@ -206,15 +205,6 @@ const Article = ({ post }: { post: any }) => {
     </div>
   )
 
-  const isAtTop = useIsAtTop()
-  const [isFirstRenderAtTop, setIsFirstRenderAtTop] = useState(isAtTop)
-
-  useEffect(() => {
-    if (!isAtTop && isFirstRenderAtTop) {
-      setIsFirstRenderAtTop(false)
-    }
-  }, [isAtTop, isFirstRenderAtTop])
-
   const [isQAModalOpen, setIsQAModalOpen] = useState(false)
 
   const handleBaodaozaiConfirmation = useCallback(
@@ -259,6 +249,11 @@ const Article = ({ post }: { post: any }) => {
     [router]
   )
 
+  const handleQAModalClose = useCallback(({ setHide }: QAModalEvent) => {
+    setIsQAModalOpen(false)
+    setHide(false)
+  }, [])
+
   return (
     <>
       <div className={`post${theme ? ` theme-${theme}` : ''}`}>
@@ -278,20 +273,7 @@ const Article = ({ post }: { post: any }) => {
             imgProps={imgProps}
             handleImgModalClose={handleImgModalClose}
           />
-          <BaodaozaiEventTrigger
-            dialogState={{
-              isOpen: true,
-              confirmText: '開始閱讀',
-              hideCancelButton: true,
-              // TODO: get content from backend
-              // content: post?.intro
-            }}
-            baodaozaiState={{
-              isActive: true,
-              action: 'speak',
-            }}
-            disabled={!isFirstRenderAtTop || isSubmitted}
-          />
+          <StartReadingBaodaozaiEventTrigger isSubmitted={isSubmitted} />
           <HeroImage
             image={post?.heroImage}
             caption={post?.heroCaption}
@@ -303,6 +285,7 @@ const Article = ({ post }: { post: any }) => {
           )}
 
           <BaodaozaiEventTrigger
+            id="hide-start-reading"
             dialogState={{
               isOpen: false,
               hideCancelButton: true,
@@ -332,6 +315,7 @@ const Article = ({ post }: { post: any }) => {
                   action: 'none',
                 }}
                 disabled={isSubmitted}
+                id="change-to-ask-questions"
               />
             </div>
           </div>
@@ -348,6 +332,7 @@ const Article = ({ post }: { post: any }) => {
               action: 'speak',
             }}
             disabled={isSubmitted}
+            id="show-ask-questions"
           />
           <AuthorCard title="誰幫我們完成這篇文章" authors={orderedAuthors} />
         </ArticleContext.Provider>
@@ -356,9 +341,7 @@ const Article = ({ post }: { post: any }) => {
       <RelatedPosts posts={relatedPosts ?? []} sliderTheme={theme} />
       <BaodaozaiQAModal
         questions={QUESTIONS}
-        onClose={() => {
-          setIsQAModalOpen(false)
-        }}
+        onClose={handleQAModalClose}
         onSubmit={handleQAModalSubmit}
         isOpen={isQAModalOpen}
       />

--- a/packages/frontend/src/app/(sticky-header)/_components/article/start-reading-baodaozai-event-trigger.tsx
+++ b/packages/frontend/src/app/(sticky-header)/_components/article/start-reading-baodaozai-event-trigger.tsx
@@ -1,0 +1,41 @@
+import { useIsAtTop } from '@kids-reporter/routing-ui'
+import { useEffect, useState } from 'react'
+
+import BaodaozaiEventTrigger from '@/services/call-baodaozai/components/baodaozai-event-trigger'
+
+type StartReadingBaodaozaiEventTriggerProps = {
+  isSubmitted: boolean
+}
+
+function StartReadingBaodaozaiEventTrigger({
+  isSubmitted,
+}: StartReadingBaodaozaiEventTriggerProps) {
+  const isAtTop = useIsAtTop(35)
+  const [isFirstRenderAtTop, setIsFirstRenderAtTop] = useState(isAtTop)
+
+  useEffect(() => {
+    if (!isAtTop && isFirstRenderAtTop) {
+      setIsFirstRenderAtTop(false)
+    }
+  }, [isAtTop, isFirstRenderAtTop])
+
+  return (
+    <BaodaozaiEventTrigger
+      id="show-start-reading"
+      dialogState={{
+        isOpen: true,
+        confirmText: '開始閱讀',
+        hideCancelButton: true,
+        // TODO: get content from backend
+        // content: post?.intro
+      }}
+      baodaozaiState={{
+        isActive: true,
+        action: 'speak',
+      }}
+      disabled={!isFirstRenderAtTop || isSubmitted}
+    />
+  )
+}
+
+export default StartReadingBaodaozaiEventTrigger

--- a/packages/frontend/src/services/call-baodaozai/components/baodaozai-event-trigger.tsx
+++ b/packages/frontend/src/services/call-baodaozai/components/baodaozai-event-trigger.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useCallback, useEffect, useRef } from 'react'
+import { memo, useCallback, useEffect, useRef } from 'react'
+
+import { useCallBaodaozaiContext } from '../context'
 import { BaodaozaiAction, BaodaozaiActionSetter } from '../types'
 import { DialogBoxProps } from './dialog-box'
-import { useCallBaodaozaiContext } from '../context'
 
 export type BaodaozaiEventTriggerProps = {
   dialogState?: Partial<
@@ -19,6 +20,7 @@ export type BaodaozaiEventTriggerProps = {
   }>
   once?: boolean
   disabled?: boolean
+  id?: string
 }
 
 function BaodaozaiEventTrigger({
@@ -26,10 +28,11 @@ function BaodaozaiEventTrigger({
   baodaozaiState: newBaodaozaiState = {},
   once = true,
   disabled = false,
+  id,
 }: BaodaozaiEventTriggerProps) {
   const {
     onDialogPropsChange,
-    baodaozaiProps: { setAction, setIsActive, triggerStep },
+    baodaozaiProps: { setAction, setIsActive, triggerStep, isInitialized },
   } = useCallBaodaozaiContext()
   const { action, isActive, shouldTriggerStep } = newBaodaozaiState
   const containerRef = useRef<HTMLDivElement>(null)
@@ -85,7 +88,7 @@ function BaodaozaiEventTrigger({
     return () => observer.disconnect()
   }, [handleInView, once, disabled])
 
-  return <div ref={containerRef} />
+  return isInitialized ? <div ref={containerRef} id={id} /> : null
 }
 
-export default BaodaozaiEventTrigger
+export default memo(BaodaozaiEventTrigger)

--- a/packages/frontend/src/services/call-baodaozai/components/dialog-box.tsx
+++ b/packages/frontend/src/services/call-baodaozai/components/dialog-box.tsx
@@ -3,29 +3,35 @@
 import { Button } from '@kids-reporter/routing-ui'
 import { cn } from '@kids-reporter/routing-ui'
 
-const DialogArrow = (
+const DialogArrow = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="32"
-    height="44"
-    viewBox="0 0 32 44"
+    width="62"
+    height="64"
+    viewBox="0 0 62 64"
     fill="none"
   >
     <defs>
-      <filter id="drop-shadow" x="-50%" y="0%" width="200%" height="150%">
-        <feDropShadow
-          dx="0"
-          dy="4"
-          stdDeviation="8"
-          floodColor="rgba(0,0,0,0.05)"
-        />
+      <filter id="shadowBox">
+        {/* Left shadow */}
+        <feDropShadow dx="-3" dy="0" stdDeviation="2" floodOpacity="0.025" />
+
+        {/* Bottom shadow - layered for depth */}
+        <feDropShadow dx="0" dy="3" stdDeviation="2" floodOpacity="0.02" />
+        <feDropShadow dx="0" dy="6" stdDeviation="4" floodOpacity="0.015" />
+        <feDropShadow dx="0" dy="10" stdDeviation="6" floodOpacity="0.01" />
+
+        {/* Right shadow - layered for depth */}
+        <feDropShadow dx="3" dy="0" stdDeviation="2" floodOpacity="0.002" />
+        <feDropShadow dx="6" dy="0" stdDeviation="4" floodOpacity="0.0015" />
+        <feDropShadow dx="10" dy="0" stdDeviation="6" floodOpacity="0.001" />
       </filter>
     </defs>
     <path
       data-figma-bg-blur-radius="16"
       d="M0 2.72773e-05L32 44L32 -1.39876e-06L0 2.72773e-05Z"
       fill="white"
-      filter="url(#drop-shadow)"
+      filter="url(#shadowBox)"
     />
   </svg>
 )
@@ -88,13 +94,8 @@ function DialogBox({
             </Button>
           </div>
         </div>
-        <div
-          className={cn(
-            'hidden transition-all duration-300 ease-out tablet:block',
-            isOpen ? 'translate-y-0 opacity-100' : 'translate-y-2 opacity-0'
-          )}
-        >
-          {DialogArrow}
+        <div className="hidden translate-x-5 translate-y-0 transition-all duration-300 ease-out tablet:block">
+          <DialogArrow />
         </div>
       </div>
     </div>

--- a/packages/frontend/src/services/call-baodaozai/components/qa-modal/index.tsx
+++ b/packages/frontend/src/services/call-baodaozai/components/qa-modal/index.tsx
@@ -435,10 +435,10 @@ function QAModal({ questions, onClose, onSubmit, isOpen }: QAModalProps) {
 
   return (
     <div className="scrollbar-thin fixed inset-0 z-1002 flex items-end justify-center tablet:items-center">
-      <div className="absolute inset-0 z-0 bg-neutral-600/50" />
+      <div className="absolute inset-0 z-0 bg-neutral-black/20" />
       <div
         className={cn(
-          'relative z-1 flex h-[calc(100vh-156px)] w-full flex-col rounded-t-[30px] shadow-[0px_2px_16px_0px_rgba(0,0,0,0.15)] tablet:h-144 tablet:w-120 tablet:rounded-[30px]',
+          'relative z-1 flex h-[calc(100vh-80px)] w-full flex-col rounded-t-[30px] shadow-[0px_2px_16px_0px_rgba(0,0,0,0.15)] tablet:h-144 tablet:w-120 tablet:rounded-[30px]',
           isLeaving && 'h-auto tablet:h-auto'
         )}
       >
@@ -478,7 +478,7 @@ function QAModal({ questions, onClose, onSubmit, isOpen }: QAModalProps) {
           </div>
           <div
             className={cn(
-              'flex w-full flex-col justify-end px-6 pb-6',
+              'flex w-full flex-col justify-end px-6 pt-5 pb-6 tablet:pt-6',
               (isLeaving ||
                 currentModalStep?.type === 'choice-result' ||
                 currentModalStep?.type === 'essay-result') &&

--- a/packages/frontend/src/services/call-baodaozai/context/index.tsx
+++ b/packages/frontend/src/services/call-baodaozai/context/index.tsx
@@ -1,7 +1,19 @@
 'use client'
 
-import { useContext, useState, useCallback, useMemo } from 'react'
+import { cn } from '@kids-reporter/routing-ui'
+import {
+  useRive,
+  useViewModel,
+  useViewModelInstance,
+  useViewModelInstanceBoolean,
+  useViewModelInstanceEnum,
+  useViewModelInstanceTrigger,
+} from '@rive-app/react-webgl2'
+import { useCallback, useContext, useMemo, useState } from 'react'
 import { createContext } from 'react'
+
+import { DialogBoxProps } from '../components/dialog-box'
+import { BaodaozaiAction, BaodaozaiActionSetter } from '../types'
 import {
   ACTION_KEY,
   ACTIVE_KEY,
@@ -12,17 +24,6 @@ import {
   STEP_KEY,
   VIEW_MODEL_NAME,
 } from './constants'
-import {
-  useRive,
-  useViewModel,
-  useViewModelInstance,
-  useViewModelInstanceBoolean,
-  useViewModelInstanceEnum,
-  useViewModelInstanceTrigger,
-} from '@rive-app/react-webgl2'
-import { BaodaozaiAction, BaodaozaiActionSetter } from '../types'
-import { cn } from '@kids-reporter/routing-ui'
-import { DialogBoxProps } from '../components/dialog-box'
 
 export type CallBaodaozaiProps = {
   dialogWithActionProps: Omit<DialogBoxProps, 'onConfirm' | 'onCancel'> & {
@@ -38,6 +39,7 @@ export type CallBaodaozaiProps = {
     toggleActive: () => void
     hide: boolean
     setHide: (hide: boolean) => void
+    isInitialized: boolean
   }
   renderBaodaozai: React.ReactNode
 }
@@ -114,6 +116,7 @@ export function CallBaodaozaiProvider({
       toggleActive,
       hide,
       setHide,
+      isInitialized: !!viewModel,
     }),
     [
       action,
@@ -124,6 +127,7 @@ export function CallBaodaozaiProvider({
       toggleActive,
       hide,
       setHide,
+      viewModel,
     ]
   )
 

--- a/packages/routing-ui/package.json
+++ b/packages/routing-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kids-reporter/routing-ui",
   "license": "MIT",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "Routing UI for Kids Reporter",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/routing-ui/src/components/button.tsx
+++ b/packages/routing-ui/src/components/button.tsx
@@ -16,13 +16,13 @@ const buttonVariants = cva(
           'text-white border-0 bg-red-400',
           'hover:bg-red-500',
           'active:bg-red-600',
-          'disabled:bg-gray-400 disabled:text-white disabled:cursor-default',
+          'disabled:text-white disabled:cursor-default disabled:bg-neutral-400',
         ],
         secondary: [
           'bg-white text-gray-900 border-2 border-red-400',
           'hover:text-white hover:border-red-500 hover:bg-red-500',
           'active:text-white active:border-red-600 active:bg-red-600',
-          'disabled:border-gray-400 disabled:bg-white disabled:text-gray-400 disabled:cursor-default',
+          'disabled:bg-white disabled:cursor-default disabled:border-neutral-400 disabled:text-neutral-400',
         ],
       },
       size: {

--- a/packages/routing-ui/src/footer.tsx
+++ b/packages/routing-ui/src/footer.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import Image from 'next/image'
-
 import Button from './components/button'
 import {
   ADDITIONAL_MENU_ITEMS,
@@ -37,7 +35,7 @@ const Footer = ({
             <div className="max-w-100 gap-6 flex w-full flex-col items-center desktop:items-start">
               <div className="flex items-center">
                 <a href="/" className="flex items-center">
-                  <Image
+                  <img
                     src="/assets/images/footer-logo.svg"
                     alt="少年報導者"
                     loading="lazy"

--- a/packages/routing-ui/src/header/menu/index.tsx
+++ b/packages/routing-ui/src/header/menu/index.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import Image from 'next/image'
 import { useEffect } from 'react'
 
 import Button from '../../components/button'
@@ -95,7 +94,7 @@ function Menu({
           <div className="px-6 tablet:px-8 py-4 mt-4 hidden items-center justify-between tablet:flex">
             <div className="flex items-center">
               <a href="/">
-                <Image
+                <img
                   src="/assets/images/brand-icon.svg"
                   alt="少年報導者 The Reporter for Kids"
                   className="h-5"

--- a/packages/routing-ui/src/header/shared-components.tsx
+++ b/packages/routing-ui/src/header/shared-components.tsx
@@ -1,6 +1,5 @@
 'use client'
 import { cva } from 'class-variance-authority'
-import Image from 'next/image'
 import { useEffect, useRef, useState } from 'react'
 
 import { Button, Input } from '../components'
@@ -89,7 +88,7 @@ const searchDropdownVariants = cva(
 export function LogoLink({ compactMode = false }: { compactMode?: boolean }) {
   return (
     <a href="/" className="flex items-center" rel="home">
-      <Image
+      <img
         src="/assets/images/brand-icon.svg"
         alt="少年報導者 The Reporter for Kids"
         loading="eager"


### PR DESCRIPTION
## Summary

This PR fixes the Baodaozai (報導仔) retrigger issue and adjusts the UI components. The changes include refactoring the start reading trigger logic and improving the dialog box styling.

## Changes

- **Refactor start reading trigger logic**: Extracted `StartReadingBaodaozaiEventTrigger` component to prevent other `BaodaozaiEventTrigger` retrigger
- **Fix Baodaozai event trigger**: Added `id` prop support and improved initialization check to prevent unnecessary renders
- **Enhance dialog box styling**: Updated `DialogArrow` component with improved shadow effects and better visual hierarchy
- **Improve QA modal UI**: Adjusted modal height, background opacity, and padding for better mobile and tablet experience
- **Add context initialization**: Added `isInitialized` flag to prevent rendering before Baodaozai is ready
- **Update button disabled states**: Improved disabled button styling using neutral colors for better accessibility

## Additional Notes

The changes ensure that the Baodaozai feature works correctly on first page load and provides a smoother user experience with better visual feedback.

## Screenshot(s)

## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/defect-QA-UI-2938dbdca932804f9d1dcee78f6dfabf?v=1588dbdca93281dfa43c000c8415265e&source=copy_link)