### PR TITLE
fix(frontend): fix baodaozai trigger once logic and improve modal styling

### DIFF
--- a/packages/frontend/src/app/(sticky-header)/_components/article/start-reading-baodaozai-event-trigger.tsx
+++ b/packages/frontend/src/app/(sticky-header)/_components/article/start-reading-baodaozai-event-trigger.tsx
@@ -1,7 +1,7 @@
 import { useIsAtTop } from '@kids-reporter/routing-ui'
 import { useEffect, useState } from 'react'
 
-import BaodaozaiEventTrigger from '@/services/call-baodaozai/components/baodaozai-event-trigger'
+import { BaodaozaiEventTrigger } from '@/services/call-baodaozai'
 
 type StartReadingBaodaozaiEventTriggerProps = {
   isSubmitted: boolean

--- a/packages/frontend/src/services/call-baodaozai/components/baodaozai-event-trigger.tsx
+++ b/packages/frontend/src/services/call-baodaozai/components/baodaozai-event-trigger.tsx
@@ -36,6 +36,7 @@ function BaodaozaiEventTrigger({
   } = useCallBaodaozaiContext()
   const { action, isActive, shouldTriggerStep } = newBaodaozaiState
   const containerRef = useRef<HTMLDivElement>(null)
+  const triggeredOnceRef = useRef(false)
 
   const handleInView = useCallback(() => {
     onDialogPropsChange({ ...newDialogState })
@@ -64,7 +65,7 @@ function BaodaozaiEventTrigger({
 
   useEffect(() => {
     const element = containerRef.current
-    if (!element || disabled) return
+    if (!element || disabled || triggeredOnceRef.current) return
 
     const observer = new IntersectionObserver(
       (entries) => {
@@ -73,6 +74,7 @@ function BaodaozaiEventTrigger({
             handleInView()
             if (once) {
               observer.disconnect()
+              triggeredOnceRef.current = true
             }
           }
         })

--- a/packages/frontend/src/services/call-baodaozai/components/qa-modal/index.tsx
+++ b/packages/frontend/src/services/call-baodaozai/components/qa-modal/index.tsx
@@ -135,7 +135,7 @@ function QAModal({ questions, onClose, onSubmit, isOpen }: QAModalProps) {
   const renderModalContent = useMemo(() => {
     if (isLeaving) {
       return (
-        <div className="mb-4 flex w-full flex-col items-start p-6 tablet:mb-0">
+        <div className="mb-5 flex w-full flex-col items-start p-6 tablet:mb-0">
           <h2 className="prose-h6-large mb-3 text-neutral-900">
             確定要放棄作答嗎？
           </h2>
@@ -479,10 +479,10 @@ function QAModal({ questions, onClose, onSubmit, isOpen }: QAModalProps) {
           <div
             className={cn(
               'flex w-full flex-col justify-end px-6 pt-5 pb-6 tablet:pt-6',
-              (isLeaving ||
-                currentModalStep?.type === 'choice-result' ||
+              (currentModalStep?.type === 'choice-result' ||
                 currentModalStep?.type === 'essay-result') &&
-                'bg-neutral-100'
+                'bg-neutral-100',
+              isLeaving && 'pt-0 tablet:pt-0'
             )}
           >
             {renderModalButtons}


### PR DESCRIPTION
## Summary

This PR fixes the baodaozai trigger logic to ensure it only triggers once and improves the modal styling for better user experience.

## Changes

- Fix baodaozai trigger to only execute once by adding `triggeredOnceRef` to prevent multiple triggers
- Update import statement to use named export from `@/services/call-baodaozai`
- Improve QA modal styling by adjusting margin and padding classes
- Fix conditional styling logic for modal footer background

## Additional Notes

The changes ensure that the baodaozai event trigger respects the `once` prop and prevents multiple executions, while also improving the visual appearance of the QA modal.

## Screenshot(s)

## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/defect-QA-UI-2938dbdca932804f9d1dcee78f6dfabf)