### PR TITLE
fix(frontend): add missing graphql dependency and improve port configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prepare": "husky",
     "update": "yarn changeset && yarn changeset version",
     "dev:cms": "cd packages/cms && dotenv -e .env.local -- yarn dev",
-    "dev:frontend": "cd packages/frontend && yarn dev --port 3001",
+    "dev:frontend": "cd packages/frontend && PORT=3001 yarn dev",
     "dev:api-gateway": "cd packages/api-gateway && dotenv -e .env.local -- yarn dev",
     "format:write": "yarn workspaces run prettier --write .",
     "format:check": "yarn workspaces run prettier --check .",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.10",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"yarn codegen:local:watch\" \"next dev\"",
+    "dev": "concurrently \"yarn codegen:local:watch\" \"next dev --port ${PORT:-3000}\"",
     "build": "yarn codegen:production && next build",
     "start": "next start",
     "analyze": "ANALYZE=true yarn build",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -61,6 +61,7 @@
     "@graphql-codegen/typescript-operations": "^5.0.2",
     "@parcel/watcher": "^2.5.1",
     "concurrently": "^9.1.2",
-    "onchange": "^7.1.0"
+    "onchange": "^7.1.0",
+    "graphql": "^16.8.1"
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes a missing GraphQL dependency in the frontend package and improves port configuration consistency across the development scripts.

## Changes

- Added missing `graphql` dependency (`^16.8.1`) to frontend package.json
- Updated frontend dev script to use `${PORT:-3000}` environment variable for port configuration
- Modified root dev:frontend script to use `PORT=3001` environment variable instead of `--port 3001` flag

## Additional Notes

The GraphQL dependency was likely missing and causing build or runtime issues. The port configuration changes ensure consistency between the root package script and the frontend package script, making it easier to configure ports through environment variables.

## Screenshot(s)

N/A

## Reference(s)

N/A
