### PR TITLE
feat(cms): add baodaozai setting fields to Post and Member

### DIFF
--- a/packages/cms/lists/member.ts
+++ b/packages/cms/lists/member.ts
@@ -1,5 +1,11 @@
 import { graphql, list } from '@keystone-6/core'
-import { text, timestamp, virtual } from '@keystone-6/core/fields'
+import {
+  checkbox,
+  integer,
+  text,
+  timestamp,
+  virtual,
+} from '@keystone-6/core/fields'
 
 import type { ListType } from '../types/keystone-list-types'
 import {
@@ -77,6 +83,14 @@ export default list<ListType<'Member'>>({
           fieldMode: 'hidden',
         },
       },
+    }),
+    showBaodaozai: checkbox({
+      label: '是否顯示報導仔',
+      defaultValue: true,
+    }),
+    essayQuestionCount: integer({
+      label: '思辨題數量',
+      defaultValue: 3,
     }),
     createdAt: timestamp({
       defaultValue: { kind: 'now' },

--- a/packages/cms/lists/post.ts
+++ b/packages/cms/lists/post.ts
@@ -1,5 +1,6 @@
 import { graphql, group, list } from '@keystone-6/core'
 import {
+  checkbox,
   json,
   relationship,
   select,
@@ -300,7 +301,7 @@ const listConfigurations: ListConfig<any> = list({
       ui: {
         views: './lists/views/essay-questions',
         createView: { fieldMode: 'hidden' },
-        itemView: { fieldMode: 'edit' },
+        itemView: { fieldMode: 'hidden' },
         listView: { fieldMode: 'hidden' },
       },
     }),
@@ -349,6 +350,10 @@ const listConfigurations: ListConfig<any> = list({
         },
         inlineConnect: true,
       },
+    }),
+    showBaodaozai: checkbox({
+      label: '是否顯示報導仔？',
+      defaultValue: false,
     }),
     createdAt: timestamp({
       defaultValue: { kind: 'now' },

--- a/packages/cms/migrations/20251028143148_add_baodaozai_fields_to_post_and_member/migration.sql
+++ b/packages/cms/migrations/20251028143148_add_baodaozai_fields_to_post_and_member/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "Member" ADD COLUMN     "essayQuestionCount" INTEGER DEFAULT 3,
+ADD COLUMN     "showBaodaozai" BOOLEAN NOT NULL DEFAULT true;
+
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "showBaodaozai" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/cms/schema.graphql
+++ b/packages/cms/schema.graphql
@@ -206,6 +206,7 @@ type Post {
   postChoiceQuestionsCount(where: PostChoiceQuestionWhereInput! = {}): Int
   postEssayQuestions(where: PostEssayQuestionWhereInput! = {}, orderBy: [PostEssayQuestionOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PostEssayQuestionWhereUniqueInput): [PostEssayQuestion!]
   postEssayQuestionsCount(where: PostEssayQuestionWhereInput! = {}): Int
+  showBaodaozai: Boolean
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: User
@@ -248,6 +249,7 @@ input PostWhereInput {
   opening: StringFilter
   postChoiceQuestions: PostChoiceQuestionManyRelationFilter
   postEssayQuestions: PostEssayQuestionManyRelationFilter
+  showBaodaozai: BooleanFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
   createdBy: UserWhereInput
@@ -307,6 +309,7 @@ input PostOrderByInput {
   ogTitle: OrderDirection
   ogDescription: OrderDirection
   opening: OrderDirection
+  showBaodaozai: OrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
 }
@@ -341,6 +344,7 @@ input PostUpdateInput {
   opening: String
   postChoiceQuestions: PostChoiceQuestionRelateToManyForUpdateInput
   postEssayQuestions: PostEssayQuestionRelateToManyForUpdateInput
+  showBaodaozai: Boolean
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForUpdateInput
@@ -455,6 +459,7 @@ input PostCreateInput {
   opening: String
   postChoiceQuestions: PostChoiceQuestionRelateToManyForCreateInput
   postEssayQuestions: PostEssayQuestionRelateToManyForCreateInput
+  showBaodaozai: Boolean
   createdAt: DateTime
   updatedAt: DateTime
   createdBy: UserRelateToOneForCreateInput
@@ -1686,6 +1691,8 @@ type Member {
   twreporter_user_id: String
   role: String
   twoFactorAuth: JSON
+  showBaodaozai: Boolean
+  essayQuestionCount: Int
   createdAt: DateTime
   updatedAt: DateTime
 }
@@ -1704,6 +1711,8 @@ input MemberWhereInput {
   email: StringFilter
   twreporter_user_id: StringFilter
   role: StringFilter
+  showBaodaozai: BooleanFilter
+  essayQuestionCount: IntNullableFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
 }
@@ -1714,6 +1723,8 @@ input MemberOrderByInput {
   email: OrderDirection
   twreporter_user_id: OrderDirection
   role: OrderDirection
+  showBaodaozai: OrderDirection
+  essayQuestionCount: OrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
 }
@@ -1723,6 +1734,8 @@ input MemberUpdateInput {
   email: String
   twreporter_user_id: String
   role: String
+  showBaodaozai: Boolean
+  essayQuestionCount: Int
   createdAt: DateTime
   updatedAt: DateTime
 }
@@ -1737,6 +1750,8 @@ input MemberCreateInput {
   email: String
   twreporter_user_id: String
   role: String
+  showBaodaozai: Boolean
+  essayQuestionCount: Int
   createdAt: DateTime
   updatedAt: DateTime
 }

--- a/packages/cms/schema.prisma
+++ b/packages/cms/schema.prisma
@@ -62,6 +62,7 @@ model Post {
   opening                                    String               @default("")
   postChoiceQuestions                        PostChoiceQuestion[] @relation("PostChoiceQuestion_post")
   postEssayQuestions                         PostEssayQuestion[]  @relation("PostEssayQuestion_post")
+  showBaodaozai                              Boolean              @default(false)
   createdAt                                  DateTime?            @default(now())
   updatedAt                                  DateTime?            @updatedAt
   createdBy                                  User?                @relation("Post_createdBy", fields: [createdById], references: [id])
@@ -341,6 +342,8 @@ model Member {
   email                           String                @default("")
   twreporter_user_id              String                @unique @default("")
   role                            String                @default("member")
+  showBaodaozai                   Boolean               @default(true)
+  essayQuestionCount              Int?                  @default(3)
   createdAt                       DateTime?             @default(now())
   updatedAt                       DateTime?             @updatedAt
   from_PostChoiceAnswer_member    PostChoiceAnswer[]    @relation("PostChoiceAnswer_member")


### PR DESCRIPTION
### Summary
- Add Baodaozai toggles and essayQuestionCount to CMS schema for Post and Member.
- Update generated GraphQL/Prisma schema and add corresponding Prisma migration.


### Reference
https://www.notion.so/twreporter/CMS-2798dbdca93280cd91e6f10d96c4679e
