### PR TITLE
fix(frontend): replace TWREPORTER_ID with SEARCH_ENGINE_ID

### DIFF
--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -7,4 +7,4 @@ NEXT_PUBLIC_RELEASE_ENV=
 
 # Google Search
 SEARCH_API_KEY=search-api-key
-TWREPORTER_ID=twreporter-id
+SEARCH_ENGINE_ID=search-engine-id

--- a/packages/frontend/src/app/(sticky-header)/search/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/search/page.tsx
@@ -3,6 +3,7 @@ import errors from '@twreporter/errors'
 import {
   defaultCount,
   getFilteredSearchResults,
+  SearchResult,
   transferItemsToCards,
 } from '@/app/api/search/utils'
 import { ContentType, EMAIL } from '@/constants'
@@ -29,13 +30,13 @@ export default async function SearchPage({
     return <SearchTitle>請輸入要搜尋的字串。</SearchTitle>
   }
 
-  let data
+  let data: SearchResult | undefined
 
   try {
     data = await getFilteredSearchResults({
       q: `${searchParams.q} ${filterParams}`,
       apiKey: envVars.searchAPIKey,
-      cx: envVars.twreporterID,
+      cx: envVars.searchEngineID,
       start: 1,
       count: defaultCount,
     })

--- a/packages/frontend/src/app/api/search/route.ts
+++ b/packages/frontend/src/app/api/search/route.ts
@@ -30,7 +30,7 @@ export async function GET(request: Request) {
 
   try {
     const searchResults = await getFilteredSearchResults({
-      cx: envVars.twreporterID,
+      cx: envVars.searchEngineID,
       apiKey: envVars.searchAPIKey,
       q,
       start,

--- a/packages/frontend/src/app/api/search/utils.ts
+++ b/packages/frontend/src/app/api/search/utils.ts
@@ -41,7 +41,7 @@ const client = customsearch('v1')
 export const defaultCount = 10
 export const defaultStart = 1
 
-type SearchResult = {
+export type SearchResult = {
   nextQuery?: {
     count?: number
     startIndex?: number
@@ -173,7 +173,6 @@ async function getSearchResults({
   }
 
   const nextPage = searchRes.data.queries?.nextPage?.[0]
-
   const nextQuery = nextPage
     ? {
         startIndex: nextPage.startIndex,

--- a/packages/frontend/src/environment-variables.ts
+++ b/packages/frontend/src/environment-variables.ts
@@ -5,14 +5,14 @@ const gqlEndpoint =
 const isProduction = process.env.NEXT_PUBLIC_RELEASE_ENV === 'prod'
 
 const searchAPIKey = process.env.SEARCH_API_KEY || ''
-const twreporterID = process.env.TWREPORTER_ID || ''
+const searchEngineID = process.env.SEARCH_ENGINE_ID || ''
 
 const environmentVariables = {
   internalGqlEndpoint,
   gqlEndpoint,
   isProduction,
   searchAPIKey,
-  twreporterID,
+  searchEngineID,
 }
 
 export default environmentVariables


### PR DESCRIPTION
## Summary

This PR updates the search functionality to use a more generic environment variable name for the Google Custom Search Engine ID, replacing mistaken `TWREPORTER_ID` with `SEARCH_ENGINE_ID`.

## Changes

- Updated environment variable from `TWREPORTER_ID` to `SEARCH_ENGINE_ID` in `.env.example`
- Modified `environment-variables.ts` to use `searchEngineID` instead of `twreporterID`
- Updated search page component to use the new environment variable name
- Updated search API route to use the new environment variable name
- Updated search utils to use the new environment variable name

## Additional Notes

This change fixed search mechanism with right env name.

## Screenshot(s)

N/A

## Reference(s)

N/A

