### PR TITLE
fix(frontend): adjust related posts layout and baodaozai callback event trigger

### DIFF
--- a/packages/frontend/src/app/(sticky-header)/_components/article/article.tsx
+++ b/packages/frontend/src/app/(sticky-header)/_components/article/article.tsx
@@ -396,7 +396,7 @@ const Article = ({ post }: { post: NonNullable<GetPostQuery['post']> }) => {
             </div>
           </div>
 
-          {post?.tagsOrdered && <Tags title={'常用關鍵字'} tags={tags} />}
+          {post?.tagsOrdered && <Tags title="常用關鍵字" tags={tags} />}
           <BaodaozaiEventTrigger
             dialogState={{
               isOpen: true,
@@ -412,7 +412,7 @@ const Article = ({ post }: { post: NonNullable<GetPostQuery['post']> }) => {
         </ArticleContext.Provider>
       </div>
 
-      <div className="relative w-screen">
+      <div className="relative w-full">
         {/* related posts enters 50% of the viewport*/}
         <div className="absolute top-[calc(50%+50vh)]">
           <BaodaozaiEventTrigger
@@ -421,6 +421,7 @@ const Article = ({ post }: { post: NonNullable<GetPostQuery['post']> }) => {
                 '現在點擊上方的 Tab，可以看到來自報導者的觀點了，一起來看看更多深度文章吧！',
               hideCancelButton: true,
               confirmText: '我知道了',
+              confirmAction: () => {},
             }}
             id="show-related-articles"
           />

--- a/packages/frontend/src/app/(sticky-header)/_components/article/related-articles.tsx
+++ b/packages/frontend/src/app/(sticky-header)/_components/article/related-articles.tsx
@@ -48,7 +48,7 @@ function RelatedArticles({
   }, [visibleArticles, selectedSegment])
 
   return (
-    <div className="mx-auto flex w-full flex-col items-center justify-center px-6 py-10 tablet:px-8 tablet:py-12 desktop:px-12 desktop:py-18 hd:max-w-300 hd:px-16 hd:py-24">
+    <div className="mx-auto flex w-full max-w-300 flex-col items-center justify-center px-6 py-10 tablet:px-8 tablet:py-12 desktop:px-12 desktop:py-18 hd:px-16 hd:py-24">
       <div className="mb-6 flex w-full flex-col items-start justify-between gap-6 tablet:flex-row">
         <div className="flex items-center gap-2">
           <div className="flex size-11 items-center justify-center">

--- a/packages/frontend/src/app/(sticky-header)/article/[slug]/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/article/[slug]/page.tsx
@@ -105,7 +105,7 @@ export default async function PostPage({
   })
 
   return (
-    <main className="flex max-w-(--breakpoint-2xl) flex-col items-center">
+    <main className="mx-auto flex max-w-(--breakpoint-2xl) flex-col items-center">
       <HeaderPostTitleSetter postTitle={post?.title} />
       {tocIndexes.length > 0 && <TOC indexes={tocIndexes} />}
       {post && <Article post={post} />}

--- a/packages/frontend/src/app/(sticky-header)/layout.tsx
+++ b/packages/frontend/src/app/(sticky-header)/layout.tsx
@@ -22,7 +22,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
           subscribeUrl={SUBSCRIBE_URL}
           donateUrl={DONATE_URL}
         />
-        <div className="flex grow">{children}</div>
+        <div className="flex w-full grow">{children}</div>
         <Baodaozai />
       </CallBaodaozaiProvider>
     </>


### PR DESCRIPTION
## Summary

This PR fixes layout issues with related posts and improves the baodaozai event trigger functionality. The changes address width constraints, layout positioning, and ensure proper callback handling for the baodaozai dialog.

## Changes

- Fixed related articles container width by changing from `w-screen` to `w-full` to prevent horizontal overflow
- Updated related articles layout to use `max-w-300` class for consistent width constraints
- Added missing `confirmAction` callback to baodaozai event trigger for proper dialog handling
- Improved main container layout by adding `mx-auto` class for better centering
- Fixed quote consistency by changing single quotes to double quotes in Tags component
- Enhanced layout wrapper with `w-full` class for proper width handling

## Additional Notes

These changes ensure that the related posts section displays correctly without causing horizontal scroll issues and that the baodaozai dialog functions properly with all required callback handlers.

## Screenshot(s)


https://github.com/user-attachments/assets/b6ab4af8-8fa3-4dc8-b843-c48270c0e9a2



## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/defect-bug-29b8dbdca932804ca6c9e390a86e71d6?source=copy_link)

