### PR TITLE
feat(frontend): implement scroll-up trigger for Baodaozai event system

### DIFF
--- a/packages/frontend/src/app/(sticky-header)/_components/article/article-baodaozai-event-trigger.tsx
+++ b/packages/frontend/src/app/(sticky-header)/_components/article/article-baodaozai-event-trigger.tsx
@@ -1,0 +1,166 @@
+'use client'
+
+import { ComponentProps, useMemo } from 'react'
+
+import {
+  BaodaozaiActionSetter,
+  BaodaozaiEventTrigger,
+} from '@/services/call-baodaozai'
+
+type EventId =
+  | 'show-start-reading'
+  | 'hide-start-reading'
+  | 'change-start-reading'
+  | 'change-ask-questions'
+  | 'show-ask-questions'
+  | 'show-related-articles'
+  | 'scroll-up'
+
+type EventConfig = Pick<
+  ComponentProps<typeof BaodaozaiEventTrigger>,
+  'dialogState' | 'baodaozaiState'
+>
+
+type ArticleBaodaozaiEventTriggerProps = {
+  id: EventId
+  once?: boolean
+  disabled?: boolean
+  onAskQuestionsConfirm?: BaodaozaiActionSetter
+  startReadingContent?: string
+}
+
+function createBaodaozaiEventConfig({
+  onAskQuestionsConfirm,
+  startReadingContent,
+}: {
+  onAskQuestionsConfirm?: BaodaozaiActionSetter
+  startReadingContent?: string
+}): Record<EventId, EventConfig> {
+  return {
+    'show-start-reading': {
+      dialogState: {
+        isOpen: true,
+        confirmText: '開始閱讀',
+        hideCancelButton: true,
+        content: startReadingContent || '',
+        confirmAction: () => {},
+      },
+      baodaozaiState: {
+        isActive: true,
+        action: 'speak',
+      },
+    },
+    'hide-start-reading': {
+      dialogState: {
+        isOpen: false,
+        hideCancelButton: true,
+        confirmText: '開始閱讀',
+        content: startReadingContent || '',
+        confirmAction: () => {},
+      },
+      baodaozaiState: {
+        isActive: false,
+        action: 'none',
+      },
+    },
+    'change-start-reading': {
+      dialogState: {
+        isOpen: false,
+        hideCancelButton: true,
+        confirmText: '開始閱讀',
+        content: startReadingContent || '',
+        confirmAction: () => {},
+      },
+      baodaozaiState: {
+        isActive: false,
+        action: 'none',
+      },
+    },
+    'change-ask-questions': {
+      dialogState: {
+        isOpen: false,
+        content:
+          '你好棒！已經把文章讀完了！接下來讓我問問你幾個和文章有關的問題⋯⋯',
+        hideCancelButton: false,
+        confirmText: '好！出招吧',
+        confirmAction: onAskQuestionsConfirm,
+      },
+      baodaozaiState: {
+        isActive: false,
+        action: 'none',
+      },
+    },
+    'show-ask-questions': {
+      dialogState: {
+        isOpen: true,
+        content:
+          '你好棒！已經把文章讀完了！接下來讓我問問你幾個和文章有關的問題⋯⋯',
+        hideCancelButton: false,
+        confirmText: '好！出招吧',
+        confirmAction: onAskQuestionsConfirm,
+      },
+      baodaozaiState: {
+        isActive: true,
+        action: 'speak',
+      },
+    },
+    'show-related-articles': {
+      dialogState: {
+        isOpen: true,
+        content:
+          '現在點擊上方的 Tab，可以看到來自報導者的觀點了，一起來看看更多深度文章吧！',
+        hideCancelButton: true,
+        confirmText: '我知道了',
+        confirmAction: () => {},
+      },
+      baodaozaiState: {
+        isActive: true,
+        action: 'speak',
+      },
+    },
+    'scroll-up': {
+      dialogState: {
+        isOpen: false,
+      },
+      baodaozaiState: {
+        isActive: false,
+        action: 'none',
+      },
+    },
+  }
+}
+
+function ArticleBaodaozaiEventTrigger({
+  id,
+  once = true,
+  disabled = false,
+  onAskQuestionsConfirm,
+  startReadingContent: content,
+}: ArticleBaodaozaiEventTriggerProps) {
+  const eventConfig = useMemo(() => {
+    const config = createBaodaozaiEventConfig({
+      onAskQuestionsConfirm,
+      startReadingContent: content,
+    })
+    return config[id]
+  }, [id, onAskQuestionsConfirm, content])
+
+  if (!eventConfig) {
+    console.warn(
+      `No configuration found for baodaozai event trigger with id: ${id}`
+    )
+    return null
+  }
+
+  return (
+    <BaodaozaiEventTrigger
+      id={id}
+      once={once}
+      disabled={disabled}
+      dialogState={eventConfig.dialogState}
+      baodaozaiState={eventConfig.baodaozaiState}
+    />
+  )
+}
+
+export default ArticleBaodaozaiEventTrigger

--- a/packages/frontend/src/app/(sticky-header)/_components/article/article.tsx
+++ b/packages/frontend/src/app/(sticky-header)/_components/article/article.tsx
@@ -2,6 +2,7 @@
 import './article.css'
 
 import { GetPostQuery } from '__generated__/operations/post.generated'
+import { ScrollLevel, useScrollLevel } from '@kids-reporter/routing-ui'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useCallback, useMemo, useState } from 'react'
@@ -20,13 +21,13 @@ import {
 import {
   BaodaozaiActionSetter,
   BaodaozaiChoiceQuestion,
-  BaodaozaiEventTrigger,
   BaodaozaiQAModal,
   BaodaozaiQuestions,
+  QAModalEvent,
 } from '@/services/call-baodaozai'
-import { QAModalEvent } from '@/services/call-baodaozai/components/qa-modal'
 import { getPostSummaries } from '@/utils'
 
+import ArticleBaodaozaiEventTrigger from './article-baodaozai-event-trigger'
 import { ArticleContext } from './article-context'
 import Brief, { AuthorGroup } from './brief'
 import CallToAction from './call-to-action'
@@ -37,6 +38,9 @@ import { NewsReading } from './news-reading'
 import PostRenderer from './post-renderer'
 import PublishedDate from './published-date'
 import RelatedArticles from './related-articles'
+import ScrollUpBaodaozaiEventTrigger, {
+  ScrollUpBaodaozaiEventTriggerProps,
+} from './scroll-up-baodaozai-event-trigger'
 import { MobileSidebar, Sidebar } from './sidebar'
 import StartReadingBaodaozaiEventTrigger from './start-reading-baodaozai-event-trigger'
 import SubSubcategory from './subSubcategory'
@@ -236,7 +240,7 @@ const Article = ({ post }: { post: NonNullable<GetPostQuery['post']> }) => {
 
   const [isQAModalOpen, setIsQAModalOpen] = useState(false)
 
-  const handleBaodaozaiConfirmation = useCallback(
+  const handleBaodaozaiConfirm = useCallback(
     ({
       setHide,
       setIsActive,
@@ -250,9 +254,22 @@ const Article = ({ post }: { post: NonNullable<GetPostQuery['post']> }) => {
     []
   )
 
-  const router = useRouter()
+  const handleScrollUp = useCallback(
+    ({
+      setIsActive,
+      setAction,
+      onDialogPropsChange,
+    }: Parameters<ScrollUpBaodaozaiEventTriggerProps['onScrollUp']>[0]) => {
+      onDialogPropsChange({
+        isOpen: false,
+      })
+      setIsActive(false)
+      setAction('none')
+    },
+    []
+  )
 
-  const [isSubmitted, setIsSubmitted] = useState(false)
+  const router = useRouter()
 
   const handleQAModalSubmit = useCallback(
     (answers: Record<number, string>, events: QAModalEvent) => {
@@ -273,7 +290,6 @@ const Article = ({ post }: { post: NonNullable<GetPostQuery['post']> }) => {
           router.push(IS_LOGIN ? '/idea-hub' : '/login')
         },
       })
-      setIsSubmitted(true)
     },
     [router]
   )
@@ -324,8 +340,16 @@ const Article = ({ post }: { post: NonNullable<GetPostQuery['post']> }) => {
     return [questions[0], questions[1], questions[2]]
   }, [post.postChoiceQuestions])
 
+  const scrollingLevel = useScrollLevel({
+    scrollDownDistance: 150,
+    throttleThreshold: 50,
+  })
+
+  const isScrollingDown = scrollingLevel === ScrollLevel.DOWN_HIDDEN
+
   return (
     <>
+      <ScrollUpBaodaozaiEventTrigger onScrollUp={handleScrollUp} />
       <div className={`post${theme ? ` theme-${theme}` : ''}`}>
         <ArticleContext.Provider
           value={{
@@ -343,10 +367,7 @@ const Article = ({ post }: { post: NonNullable<GetPostQuery['post']> }) => {
             imgProps={imgProps}
             handleImgModalClose={handleImgModalClose}
           />
-          <StartReadingBaodaozaiEventTrigger
-            isSubmitted={isSubmitted}
-            content={post?.opening ?? ''}
-          />
+          <StartReadingBaodaozaiEventTrigger content={post?.opening ?? ''} />
           {post?.heroImage && post?.heroCaption && (
             <HeroImage
               image={post?.heroImage}
@@ -359,17 +380,10 @@ const Article = ({ post }: { post: NonNullable<GetPostQuery['post']> }) => {
             <NewsReading items={newsReadingGroupItems} />
           )}
 
-          <BaodaozaiEventTrigger
+          <ArticleBaodaozaiEventTrigger
             id="hide-start-reading"
-            dialogState={{
-              isOpen: false,
-              hideCancelButton: true,
-            }}
-            baodaozaiState={{
-              isActive: false,
-              action: 'none',
-            }}
-            disabled={isSubmitted}
+            disabled={!isScrollingDown}
+            startReadingContent={post?.opening ?? ''}
           />
           <Brief content={post?.brief} authors={authorsInBrief} theme={theme} />
           <Divider />
@@ -377,36 +391,29 @@ const Article = ({ post }: { post: NonNullable<GetPostQuery['post']> }) => {
             <PostRenderer post={post} theme={theme} />
             {/* middle of the article content enters 50% of the viewport*/}
             <div className="absolute top-[calc(50%+50vh)]">
-              <BaodaozaiEventTrigger
-                dialogState={{
-                  isOpen: false,
-                  content:
-                    '你好棒！已經把文章讀完了！接下來讓我問問你幾個和文章有關的問題⋯⋯',
-                  hideCancelButton: false,
-                  confirmText: '好！出招吧',
-                  confirmAction: handleBaodaozaiConfirmation,
-                }}
-                baodaozaiState={{
-                  isActive: false,
-                  action: 'none',
-                }}
-                disabled={isSubmitted}
-                id="change-to-ask-questions"
+              <ArticleBaodaozaiEventTrigger
+                id="change-ask-questions"
+                disabled={!isScrollingDown}
+                onAskQuestionsConfirm={handleBaodaozaiConfirm}
+              />
+              <ArticleBaodaozaiEventTrigger
+                id="change-start-reading"
+                disabled={isScrollingDown}
+                startReadingContent={post?.opening ?? ''}
               />
             </div>
           </div>
 
           {post?.tagsOrdered && <Tags title="常用關鍵字" tags={tags} />}
-          <BaodaozaiEventTrigger
-            dialogState={{
-              isOpen: true,
-            }}
-            baodaozaiState={{
-              isActive: true,
-              action: 'speak',
-            }}
-            disabled={isSubmitted}
+          <ArticleBaodaozaiEventTrigger
             id="show-ask-questions"
+            disabled={!isScrollingDown}
+            onAskQuestionsConfirm={handleBaodaozaiConfirm}
+          />
+          <ArticleBaodaozaiEventTrigger
+            id="change-ask-questions"
+            disabled={isScrollingDown}
+            onAskQuestionsConfirm={handleBaodaozaiConfirm}
           />
           <AuthorCard title="誰幫我們完成這篇文章" authors={orderedAuthors} />
         </ArticleContext.Provider>
@@ -415,15 +422,9 @@ const Article = ({ post }: { post: NonNullable<GetPostQuery['post']> }) => {
       <div className="relative w-full">
         {/* related posts enters 50% of the viewport*/}
         <div className="absolute top-[calc(50%+50vh)]">
-          <BaodaozaiEventTrigger
-            dialogState={{
-              content:
-                '現在點擊上方的 Tab，可以看到來自報導者的觀點了，一起來看看更多深度文章吧！',
-              hideCancelButton: true,
-              confirmText: '我知道了',
-              confirmAction: () => {},
-            }}
+          <ArticleBaodaozaiEventTrigger
             id="show-related-articles"
+            disabled={!isScrollingDown}
           />
         </div>
         <RelatedArticles

--- a/packages/frontend/src/app/(sticky-header)/_components/article/scroll-up-baodaozai-event-trigger.tsx
+++ b/packages/frontend/src/app/(sticky-header)/_components/article/scroll-up-baodaozai-event-trigger.tsx
@@ -1,0 +1,85 @@
+import throttle from 'lodash/throttle'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+
+import {
+  QAModalEvent as ScrollUpBaodaozaiEventTriggerEvent,
+  useCallBaodaozaiContext,
+} from '@/services/call-baodaozai'
+
+export type ScrollUpBaodaozaiEventTriggerProps = {
+  onScrollUp: (events: ScrollUpBaodaozaiEventTriggerEvent) => void
+}
+
+const SCROLL_UP_THRESHOLD = 100
+
+function ScrollUpBaodaozaiEventTrigger({
+  onScrollUp,
+}: ScrollUpBaodaozaiEventTriggerProps) {
+  const { onDialogPropsChange, baodaozaiProps } = useCallBaodaozaiContext()
+  const { setHide, setIsActive, setAction } = baodaozaiProps
+  const lastScrollY = useRef(0)
+  const scrollUpStartY = useRef(0)
+  const isScrollingUp = useRef(false)
+
+  const resetScrollTracking = useCallback(() => {
+    isScrollingUp.current = false
+    scrollUpStartY.current = lastScrollY.current
+  }, [])
+
+  const triggerScrollUpEvent = useCallback(() => {
+    onScrollUp({
+      setHide,
+      setIsActive,
+      setAction,
+      onDialogPropsChange,
+    })
+    resetScrollTracking()
+  }, [
+    onScrollUp,
+    setHide,
+    setIsActive,
+    setAction,
+    onDialogPropsChange,
+    resetScrollTracking,
+  ])
+
+  const throttledTriggerScrollUpEvent = useMemo(
+    () => throttle(triggerScrollUpEvent, 100),
+    [triggerScrollUpEvent]
+  )
+
+  const handleScroll = useCallback(() => {
+    const currentScrollY = window.scrollY
+    const scrollingUp = currentScrollY < lastScrollY.current
+
+    if (scrollingUp) {
+      if (!isScrollingUp.current) {
+        scrollUpStartY.current = lastScrollY.current
+        isScrollingUp.current = true
+      }
+
+      const scrollUpDistance = scrollUpStartY.current - currentScrollY
+      if (scrollUpDistance >= SCROLL_UP_THRESHOLD) {
+        throttledTriggerScrollUpEvent()
+      }
+    }
+
+    if (!scrollingUp) {
+      resetScrollTracking()
+    }
+
+    lastScrollY.current = currentScrollY
+  }, [throttledTriggerScrollUpEvent, resetScrollTracking])
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll, { passive: true })
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll)
+    }
+  }, [handleScroll])
+
+  return null
+}
+
+export default ScrollUpBaodaozaiEventTrigger

--- a/packages/frontend/src/app/(sticky-header)/_components/article/scroll-up-baodaozai-event-trigger.tsx
+++ b/packages/frontend/src/app/(sticky-header)/_components/article/scroll-up-baodaozai-event-trigger.tsx
@@ -1,3 +1,4 @@
+'use client'
 import throttle from 'lodash/throttle'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 

--- a/packages/frontend/src/app/(sticky-header)/_components/article/start-reading-baodaozai-event-trigger.tsx
+++ b/packages/frontend/src/app/(sticky-header)/_components/article/start-reading-baodaozai-event-trigger.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { useIsAtTop } from '@kids-reporter/routing-ui'
 import { useEffect, useState } from 'react'
 

--- a/packages/frontend/src/app/(sticky-header)/_components/article/start-reading-baodaozai-event-trigger.tsx
+++ b/packages/frontend/src/app/(sticky-header)/_components/article/start-reading-baodaozai-event-trigger.tsx
@@ -1,15 +1,13 @@
 import { useIsAtTop } from '@kids-reporter/routing-ui'
 import { useEffect, useState } from 'react'
 
-import { BaodaozaiEventTrigger } from '@/services/call-baodaozai'
+import ArticleBaodaozaiEventTrigger from './article-baodaozai-event-trigger'
 
 type StartReadingBaodaozaiEventTriggerProps = {
-  isSubmitted: boolean
   content: string
 }
 
 function StartReadingBaodaozaiEventTrigger({
-  isSubmitted,
   content,
 }: StartReadingBaodaozaiEventTriggerProps) {
   const isAtTop = useIsAtTop(35)
@@ -22,19 +20,10 @@ function StartReadingBaodaozaiEventTrigger({
   }, [isAtTop, isFirstRenderAtTop])
 
   return (
-    <BaodaozaiEventTrigger
+    <ArticleBaodaozaiEventTrigger
       id="show-start-reading"
-      dialogState={{
-        isOpen: true,
-        confirmText: '開始閱讀',
-        hideCancelButton: true,
-        content,
-      }}
-      baodaozaiState={{
-        isActive: true,
-        action: 'speak',
-      }}
-      disabled={!isFirstRenderAtTop || isSubmitted}
+      disabled={!isFirstRenderAtTop}
+      startReadingContent={content}
     />
   )
 }

--- a/packages/frontend/src/services/call-baodaozai/components/baodaozai-event-trigger.tsx
+++ b/packages/frontend/src/services/call-baodaozai/components/baodaozai-event-trigger.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { memo, useCallback, useEffect, useRef } from 'react'
+import { memo, useCallback, useEffect, useRef, useState } from 'react'
 
 import { useCallBaodaozaiContext } from '../context'
 import { BaodaozaiAction, BaodaozaiActionSetter } from '../types'
@@ -62,6 +62,14 @@ function BaodaozaiEventTrigger({
     setAction,
     triggerStep,
   ])
+  const [prevDisabled, setPrevDisabled] = useState(disabled)
+
+  useEffect(() => {
+    if (prevDisabled !== disabled) {
+      triggeredOnceRef.current = false
+      setPrevDisabled(disabled)
+    }
+  }, [disabled, prevDisabled])
 
   useEffect(() => {
     const element = containerRef.current

--- a/packages/frontend/src/services/call-baodaozai/components/index.tsx
+++ b/packages/frontend/src/services/call-baodaozai/components/index.tsx
@@ -1,3 +1,4 @@
 export { default as Baodaozai } from './baodaozai'
 export { default as BaodaozaiEventTrigger } from './baodaozai-event-trigger'
+export type { QAModalEvent } from './qa-modal'
 export { default as BaodaozaiQAModal } from './qa-modal'


### PR DESCRIPTION
## Summary

This PR implements a scroll-up trigger system for the Baodaozai event system, allowing baodaozai to respond to user scroll-up gestures during article reading. The implementation includes new event trigger components, refactored event handling, and improved scroll detection logic.

## Changes

- **New Components:**
  - `ArticleBaodaozaiEventTrigger`: Centralized event trigger component with predefined configurations for different Baodaozai events
  - `ScrollUpBaodaozaiEventTrigger`: Specialized component that detects scroll-up gestures and triggers appropriate events
  - Enhanced `StartReadingBaodaozaiEventTrigger` with simplified props

- **Event System Refactoring:**
  - Consolidated multiple `BaodaozaiEventTrigger` instances into reusable `ArticleBaodaozaiEventTrigger` components
  - Added scroll-based event triggering logic with throttling for performance
  - Implemented scroll direction detection with configurable thresholds

- **Article Component Updates:**
  - Integrated scroll level detection using `useScrollLevel` hook from routing-ui
  - Added scroll-up event handling with proper state management
  - Refactored event trigger placement throughout the article component
  - Removed redundant `isSubmitted` state management

## Additional Notes

The scroll-up trigger system enhances user interaction by allowing the Baodaozai to respond contextually to user behavior.

The implementation uses a 100px scroll-up threshold to trigger events, with throttling to ensure smooth performance.

## Screenshot(s)

## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/changespec-29b8dbdca93280119339e6b708ae42ec?source=copy_link)