### PR TITLE
feat(auth): bootstrap shared token exchange flow across gateway and frontend

### DIFF
--- a/packages/api-gateway/package.json
+++ b/packages/api-gateway/package.json
@@ -15,11 +15,13 @@
   "dependencies": {
     "@twreporter/errors": "^1.1.2",
     "axios": "^1.4.0",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "http-proxy-middleware": "^2.0.6"
   },
   "devDependencies": {
+    "@types/cookie-parser": "^1.4.6",
     "@types/cors": "^2.8.15",
     "@types/express": "^4.17.20",
     "nodemon": "^2.0.20",

--- a/packages/api-gateway/src/app.ts
+++ b/packages/api-gateway/src/app.ts
@@ -1,5 +1,6 @@
 // @ts-ignore `@twreporter/errors` does not have tyepscript definition file yet
 import _errors from '@twreporter/errors'
+import cookieParser from 'cookie-parser'
 import cors from 'cors'
 import express from 'express'
 
@@ -39,12 +40,18 @@ export function createApp({
 
   const corsOpts = {
     origin: corsAllowOrigin,
+    credentials: true,
   }
 
   // common middlewares for every request
   // 1. log requests
   // 2. handle cors requests
-  app.use(middlewareCreator.createLoggerMw(gcpProjectId), cors(corsOpts))
+  // 3. parse header cookie
+  app.use(
+    middlewareCreator.createLoggerMw(gcpProjectId),
+    cors(corsOpts),
+    cookieParser()
+  )
 
   // mini app: GraphQL API
   app.use(createGraphQLProxy(gql))

--- a/packages/api-gateway/src/auth-mini-app.ts
+++ b/packages/api-gateway/src/auth-mini-app.ts
@@ -1,7 +1,7 @@
 // @ts-ignore `@twreporter/errors` does not have tyepscript definition file yet
 import _errors from '@twreporter/errors'
+import axios from 'axios'
 import express from 'express'
-import { createProxyMiddleware } from 'http-proxy-middleware'
 
 import consts from './constants.js'
 import envVar from './environment-variables.js'
@@ -12,14 +12,76 @@ const errors = _errors.default
 const statusCodes = consts.statusCodes
 
 const apiOrigin = envVar.apis.goApi.origin
+const upstreamTokenEndpoint = `${apiOrigin}/v2/auth/token`
+
+function decodeJwtPayload(jwtToken: string): {
+  user_id?: string
+  exp?: number
+} {
+  const segments = jwtToken.split('.')
+  if (segments.length < 2) {
+    throw new Error('Invalid JWT: payload segment is missing')
+  }
+
+  const payload = segments[1]
+  let decodedString
+
+  try {
+    const buffer = Buffer.from(payload, 'base64')
+    decodedString = buffer.toString('utf8')
+  } catch (_err) {
+    throw errors.helpers.wrap(
+      _err,
+      'DecodeJwtPayloadError',
+      'Invalid JWT: failed to decode base64 payload',
+      {
+        decodedString: decodedString,
+      }
+    )
+  }
+
+  try {
+    return JSON.parse(decodedString)
+  } catch (_err) {
+    throw errors.headers.wrap(
+      _err,
+      'DecodeJwtPayloadError',
+      'Invalid JWT: failed to parse payload as JSON',
+      {
+        decodedString: decodedString,
+      }
+    )
+  }
+}
+
+const ensureIdTokenCookie: express.RequestHandler = (req, res, next) => {
+  const idToken = req.cookies?.['id_token']
+  if (!idToken) {
+    console.log(
+      JSON.stringify({
+        severity: 'INFO',
+        message: 'Skip handling /auth/access-token, id_token cookie is missing',
+        ...res?.locals?.globalLogFields,
+      })
+    )
+    res.status(statusCodes.badRequest).send({
+      status: 'fail',
+      data: {
+        reason: 'id_token cookie is required',
+      },
+    })
+    return
+  }
+
+  next()
+}
 
 /**
  * Creates an Auth mini app.
  *
  * This mini app exposes the `/auth/access-token` endpoint,
- * which proxies requests to the Go API (`/v2/auth/token`)
- * and returns an `access_token` for authenticated twreporter
- * and kids-reporter users.
+ * which exchanges the go-api-issued `id_token` cookie for an
+ * access token by calling the go-api (`/v2/auth/token`).
  */
 export function createAuthMiniApp() {
   // Create an Express router
@@ -28,42 +90,117 @@ export function createAuthMiniApp() {
   // Enable preflight requests (CORS OPTIONS)
   router.options('/auth/access-token')
 
-  router.post(
-    '/auth/access-token',
-    // proxy request to go-api endpoint
-    createProxyMiddleware({
-      target: apiOrigin,
-      changeOrigin: true,
-      logLevel: 'debug',
-      pathRewrite: {
-        '/auth/access-token': '/v2/auth/token',
-      },
-      onError: (err, req, res) => {
-        const annotatedErr = errors.helpers.wrap(
-          err,
-          'GoApiProxyError',
-          `Error occurs while proxying request to API origin server: ${apiOrigin} ` +
-            err.message
-        )
+  router.post('/auth/access-token', ensureIdTokenCookie, async (req, res) => {
+    const idToken = req.cookies?.['id_token']
+    const requestStartTime = Date.now()
 
-        console.log(
-          JSON.stringify({
-            severity: 'ERROR',
-            message: errors.helpers.printAll(annotatedErr, {
-              withStack: true,
-              withPayload: true,
-            }),
-            ...res?.locals?.globalLogFields,
-          })
-        )
+    console.log(
+      JSON.stringify({
+        severity: 'DEBUG',
+        message: 'Calling upstream token endpoint.',
+        context: {
+          upstreamTokenEndpoint,
+        },
+        ...res?.locals?.globalLogFields,
+      })
+    )
 
-        res.status(statusCodes.internalServerError).send({
-          status: 'error',
-          error: annotatedErr.message,
+    try {
+      const upstreamResponse = await axios.post(
+        upstreamTokenEndpoint,
+        undefined,
+        {
+          headers: {
+            cookie: `id_token=${idToken}`,
+            'content-type': 'application/json',
+          },
+        }
+      )
+
+      const accessToken = upstreamResponse.data?.data?.jwt
+      const decodedPayload = decodeJwtPayload(accessToken)
+      const twreporterUserId = decodedPayload?.user_id?.toString()
+      const expiresAt =
+        typeof decodedPayload?.exp === 'number'
+          ? decodedPayload?.exp
+          : Math.round(Date.now() / 1000) + 3600
+      const ttlSeconds = expiresAt - Math.round(Date.now() / 1000)
+      const durationMs = Date.now() - requestStartTime
+
+      console.log(
+        JSON.stringify({
+          severity: 'INFO',
+          message: 'Issued access token.',
+          context: {
+            statusCode: statusCodes.ok,
+            upstreamStatus: upstreamResponse.status,
+            durationMs,
+            twreporterUserId,
+            expiresAt,
+            ttlSeconds,
+          },
+          ...res?.locals?.globalLogFields,
         })
-      },
-    })
-  )
+      )
+      res.status(statusCodes.ok).json({
+        status: 'success',
+        data: {
+          accessToken,
+          twreporterUserId,
+          expiresAt,
+        },
+      })
+    } catch (_err) {
+      let err = _err instanceof Error ? _err : new Error(String(_err))
+
+      if (axios.isAxiosError(err)) {
+        const statusCode = err.response?.status || err.status
+        if (
+          statusCode === statusCodes.badRequest ||
+          statusCode === statusCodes.unauthorized
+        ) {
+          console.log(
+            JSON.stringify({
+              severity: 'INFO',
+              message: 'Invalid id_token cookie.',
+              ...res?.locals?.globalLogFields,
+            })
+          )
+          res.status(statusCodes.unauthorized).send({
+            status: 'fail',
+            data: {
+              reason: 'Invalid id_token cookie.',
+            },
+          })
+          return
+        }
+      }
+
+      console.log(
+        JSON.stringify({
+          severity: 'ERROR',
+          message:
+            'Error to issue access token.' +
+            errors.helpers.printAll(
+              err,
+              {
+                withStack: true,
+                withPayload: true,
+              },
+              0,
+              0
+            ),
+          ...res?.locals?.globalLogFields,
+        })
+      )
+
+      res.status(statusCodes.internalServerError).send({
+        status: 'error',
+        error: err.message,
+      })
+      return
+    }
+  })
 
   return router
 }

--- a/packages/api-gateway/src/constants.ts
+++ b/packages/api-gateway/src/constants.ts
@@ -1,5 +1,6 @@
 const statusCodes = {
   ok: 200,
+  badRequest: 400,
   unauthorized: 401,
   internalServerError: 500,
 }

--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -2,6 +2,12 @@
 INTERNAL_GQL_ENDPOINT=http://localhost:3000/api/graphql
 NEXT_PUBLIC_GQL_ENDPOINT=http://localhost:3000/api/graphql
 
+# API Gateway Endpoint
+NEXT_PUBLIC_API_GATEWAY_ENDPOINT=http://localhost:3000
+
+# Mock id_token
+MOCK_ID_TOKEN=
+
 # Release Env
 NEXT_PUBLIC_RELEASE_ENV=
 

--- a/packages/frontend/codegen.ts
+++ b/packages/frontend/codegen.ts
@@ -5,6 +5,8 @@ const schemaPath =
     ? 'schema.graphql'
     : '../../packages/cms/schema.graphql'
 
+// Generated artifacts are written to packages/frontend/__generated__ so that
+// imports can use the "__generated__/" alias configured in tsconfig.json.
 const config: CodegenConfig = {
   overwrite: true,
   schema: schemaPath,

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -45,7 +45,8 @@
     "swiper": "^10.1.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.14",
-    "typescript": "5.9.2"
+    "typescript": "5.9.2",
+    "zustand": "^4.5.5"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^6.0.0",

--- a/packages/frontend/src/api/graphql/member.ts
+++ b/packages/frontend/src/api/graphql/member.ts
@@ -1,0 +1,14 @@
+import gql from 'graphql-tag'
+
+export const GET_MEMBER_PROFILE_GQL = gql`
+  query GetMemberProfile($where: MemberWhereUniqueInput!) {
+    member(where: $where) {
+      id
+      name
+      email
+      twreporter_user_id
+      showBaodaozai
+      essayQuestionCount
+    }
+  }
+`

--- a/packages/frontend/src/api/member.ts
+++ b/packages/frontend/src/api/member.ts
@@ -1,0 +1,60 @@
+import {
+  GetMemberProfileQuery,
+  GetMemberProfileQueryVariables,
+} from '__generated__/operations/member.generated'
+
+import { sendGQLRequest } from '@/utils'
+
+import { GET_MEMBER_PROFILE_GQL } from './graphql/member'
+
+export const getMemberProfileByTwreporterUserId = async ({
+  twreporterUserId,
+  accessToken,
+}: {
+  twreporterUserId: string
+  accessToken: string
+}) => {
+  const variables: GetMemberProfileQueryVariables = {
+    where: {
+      twreporter_user_id: twreporterUserId,
+    },
+  }
+
+  const response = await sendGQLRequest<GetMemberProfileQuery>(
+    {
+      query: GET_MEMBER_PROFILE_GQL,
+      variables,
+    },
+    {
+      authToken: accessToken,
+    }
+  )
+
+  return response?.data?.data?.member
+}
+
+export const getMemberProfileByMemberId = async ({
+  memberId,
+  accessToken,
+}: {
+  memberId: string
+  accessToken: string
+}) => {
+  const variables: GetMemberProfileQueryVariables = {
+    where: {
+      id: memberId,
+    },
+  }
+
+  const response = await sendGQLRequest<GetMemberProfileQuery>(
+    {
+      query: GET_MEMBER_PROFILE_GQL,
+      variables,
+    },
+    {
+      authToken: accessToken,
+    }
+  )
+
+  return response?.data?.data?.member
+}

--- a/packages/frontend/src/app/layout.tsx
+++ b/packages/frontend/src/app/layout.tsx
@@ -12,6 +12,7 @@ import {
   PRIVACY_POLICY,
   SOCIAL_MEDIA_ITEMS,
 } from '@/constants'
+import { AuthProvider } from '@/services/auth/auth-provider'
 
 const GTM_ID = 'GTM-T37WZJ44'
 
@@ -35,13 +36,15 @@ export default async function RootLayout({
       <StyledComponentsRegistry>
         <HeaderProvider keywords={keywords}>
           <body>
-            {children}
-            <Footer
-              socialMediaHrefs={SOCIAL_MEDIA_ITEMS.map((item) => item.href)}
-              additionalMenuItems={ADDITIONAL_MENU_ITEMS}
-              donateUrl={DONATE_URL}
-              privacyPolicyUrl={PRIVACY_POLICY}
-            />
+            <AuthProvider>
+              {children}
+              <Footer
+                socialMediaHrefs={SOCIAL_MEDIA_ITEMS.map((item) => item.href)}
+                additionalMenuItems={ADDITIONAL_MENU_ITEMS}
+                donateUrl={DONATE_URL}
+                privacyPolicyUrl={PRIVACY_POLICY}
+              />
+            </AuthProvider>
             <noscript
               dangerouslySetInnerHTML={{
                 __html: `<iframe src="https://www.googletagmanager.com/ns.html?id=${GTM_ID}" height="0" width="0" style="display: none; visibility: hidden;"></iframe>`,

--- a/packages/frontend/src/app/login/route.ts
+++ b/packages/frontend/src/app/login/route.ts
@@ -14,7 +14,7 @@ export async function GET() {
     status: 302,
   })
 
-  // 設定 cookie
+  // Set cookie
   response.cookies.set('id_token', envVars.mockIdToken, {
     httpOnly: true,
     domain:

--- a/packages/frontend/src/app/login/route.ts
+++ b/packages/frontend/src/app/login/route.ts
@@ -1,0 +1,29 @@
+// WARNING:
+//
+// THIS FILE IS ONLY FOR DEVELOPMENT.
+// After login implementation is done, this route `/login` should be DELETED.
+
+import { NextResponse } from 'next/server'
+
+import envVars from '@/environment-variables'
+
+export async function GET() {
+  const redirectUrl = new URL('/', process.env.NEXT_PUBLIC_BASE_URL)
+
+  const response = NextResponse.redirect(redirectUrl, {
+    status: 302,
+  })
+
+  // 設定 cookie
+  response.cookies.set('id_token', envVars.mockIdToken, {
+    httpOnly: true,
+    domain:
+      process.env.NODE_ENV === 'production' ? '.twreporter.org' : 'localhost',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    sameSite: 'lax',
+    maxAge: 60 * 60 * 24, // 1 day
+  })
+
+  return response
+}

--- a/packages/frontend/src/constants/index.tsx
+++ b/packages/frontend/src/constants/index.tsx
@@ -1,9 +1,12 @@
 import { MenuItem, SettingsIconSmall } from '@kids-reporter/routing-ui'
 
+export { STATUS_CODES } from './status-codes'
+
 import envVars from '@/environment-variables'
 
 export const INTERNAL_API_URL = envVars.internalGqlEndpoint
 export const API_URL = envVars.gqlEndpoint
+export const ACCESS_TOKEN_ENDPOINT = `${envVars.apiGatewayEndpoint}/auth/access-token`
 
 export const KIDS_URL_ORIGIN = 'https://kids.twreporter.org'
 export const SUBSCRIBE_URL = 'https://solink.soundon.fm/kidstwreporter'

--- a/packages/frontend/src/constants/status-codes.ts
+++ b/packages/frontend/src/constants/status-codes.ts
@@ -1,0 +1,5 @@
+export const STATUS_CODES = {
+  OK: 200,
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+}

--- a/packages/frontend/src/environment-variables.ts
+++ b/packages/frontend/src/environment-variables.ts
@@ -7,12 +7,15 @@ const isProduction = process.env.NEXT_PUBLIC_RELEASE_ENV === 'prod'
 const searchAPIKey = process.env.SEARCH_API_KEY || ''
 const searchEngineID = process.env.SEARCH_ENGINE_ID || ''
 
+const mockIdToken = process.env.MOCK_ID_TOKEN || ''
+
 const environmentVariables = {
   internalGqlEndpoint,
   gqlEndpoint,
   isProduction,
   searchAPIKey,
   searchEngineID,
+  mockIdToken,
 }
 
 export default environmentVariables

--- a/packages/frontend/src/environment-variables.ts
+++ b/packages/frontend/src/environment-variables.ts
@@ -2,6 +2,8 @@ const internalGqlEndpoint =
   process.env.INTERNAL_GQL_ENDPOINT || 'http://localhost:3001/api/graphql'
 const gqlEndpoint =
   process.env.NEXT_PUBLIC_GQL_ENDPOINT || 'http://localhost:3001/api/graphql'
+const apiGatewayEndpoint =
+  process.env.NEXT_PUBLIC_API_GATEWAY_ENDPOINT || 'http://localhost:3000'
 const isProduction = process.env.NEXT_PUBLIC_RELEASE_ENV === 'prod'
 
 const searchAPIKey = process.env.SEARCH_API_KEY || ''
@@ -12,6 +14,7 @@ const mockIdToken = process.env.MOCK_ID_TOKEN || ''
 const environmentVariables = {
   internalGqlEndpoint,
   gqlEndpoint,
+  apiGatewayEndpoint,
   isProduction,
   searchAPIKey,
   searchEngineID,

--- a/packages/frontend/src/services/auth/auth-provider.tsx
+++ b/packages/frontend/src/services/auth/auth-provider.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useEffect } from 'react'
+
+import { useHydratedAuthStore } from '@/services/auth/use-hydrated-auth-store'
+
+const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const { hydrated, tokens, status, exchangeTokenAndPopulateMember } =
+    useHydratedAuthStore()
+
+  const expiresAtMs = tokens?.expiresAt
+
+  useEffect(() => {
+    if (!hydrated) {
+      // wait for sessionStorage hydration
+      return
+    }
+
+    if (status === 'loading') {
+      return
+    }
+
+    if (
+      status === 'idle' ||
+      (expiresAtMs && expiresAtMs <= Math.round(Date.now() / 1000))
+    ) {
+      exchangeTokenAndPopulateMember()
+    }
+  }, [exchangeTokenAndPopulateMember, expiresAtMs, status, hydrated])
+
+  return <>{children}</>
+}
+
+export { AuthProvider }

--- a/packages/frontend/src/services/auth/auth-store.ts
+++ b/packages/frontend/src/services/auth/auth-store.ts
@@ -1,0 +1,227 @@
+'use client'
+
+import errors from '@twreporter/errors'
+import axios from 'axios'
+import { create } from 'zustand'
+import {
+  createJSONStorage,
+  persist,
+  subscribeWithSelector,
+} from 'zustand/middleware'
+
+import {
+  getMemberProfileByMemberId,
+  getMemberProfileByTwreporterUserId,
+} from '@/api/member'
+import { ACCESS_TOKEN_ENDPOINT, STATUS_CODES } from '@/constants'
+import { AXIOS_TIMEOUT, log, LogLevel } from '@/utils'
+
+type MemberProfile = {
+  id: string
+  name?: string
+  email?: string
+  twreporter_user_id?: string
+  showBaodaozai?: boolean
+  essayQuestionCount?: number
+}
+
+type AuthTokens = {
+  accessToken: string
+  expiresAt?: number
+}
+
+type AuthStatus =
+  | 'idle'
+  | 'loading'
+  | 'unauthenticated'
+  | 'authenticated'
+  | 'error'
+
+type AuthState = {
+  member?: MemberProfile
+  tokens?: AuthTokens
+  status: AuthStatus
+  error?: string
+  exchangeTokenAndPopulateMember: () => Promise<void>
+  fetchMember: () => Promise<void>
+  setAuth: (payload: { member: MemberProfile; tokens: AuthTokens }) => void
+  clearAuth: () => void
+}
+
+type AccessTokenResponse = {
+  status: 'success' | 'fail' | 'error'
+  data: {
+    accessToken: string
+    expiresAt?: number
+    twreporterUserId: string
+  }
+}
+
+type PersistedAuthState = Partial<
+  Pick<AuthState, 'member' | 'tokens' | 'status'>
+>
+
+const noopStorage: Storage = {
+  length: 0,
+  clear() {},
+  getItem() {
+    return null
+  },
+  key() {
+    return null
+  },
+  removeItem() {},
+  setItem() {},
+}
+
+const sessionJSONStorage = createJSONStorage<PersistedAuthState>(() =>
+  typeof window === 'undefined' ? noopStorage : window.sessionStorage
+)
+
+export const useAuthStore = create<AuthState>()(
+  subscribeWithSelector(
+    persist(
+      (set, get) => ({
+        status: 'idle',
+        async exchangeTokenAndPopulateMember() {
+          set({ status: 'loading', error: undefined })
+
+          try {
+            let axiosRes
+
+            try {
+              axiosRes = await axios.post<AccessTokenResponse>(
+                ACCESS_TOKEN_ENDPOINT,
+                null,
+                { timeout: AXIOS_TIMEOUT, withCredentials: true }
+              )
+            } catch (err) {
+              if (axios.isAxiosError(err)) {
+                const statusCode = err.response?.status
+                if (
+                  statusCode === STATUS_CODES.BAD_REQUEST ||
+                  statusCode === STATUS_CODES.UNAUTHORIZED
+                ) {
+                  // Fail to get access token due to invalid id_token.
+                  set({
+                    status: 'unauthenticated',
+                    member: undefined,
+                    tokens: undefined,
+                    error: undefined,
+                  })
+                  return
+                }
+
+                throw errors.helpers.annotateAxiosError(err)
+              }
+
+              throw err
+            }
+
+            const payload = axiosRes.data?.data
+
+            if (!payload?.accessToken) {
+              throw new Error('Fail to exchange access token')
+            }
+
+            const expiresAt =
+              typeof payload.expiresAt === 'number'
+                ? payload.expiresAt
+                : Math.round(Date.now() / 1000) + 3600
+
+            const member = await getMemberProfileByTwreporterUserId({
+              twreporterUserId: payload.twreporterUserId,
+              accessToken: payload.accessToken,
+            })
+
+            if (!member) {
+              throw new Error('Fail to fetch member profile')
+            }
+
+            set({
+              member,
+              tokens: { accessToken: payload.accessToken, expiresAt },
+              status: 'authenticated',
+              error: undefined,
+            })
+          } catch (_err) {
+            const err = errors.helpers.wrap(
+              _err,
+              'AuthStoreError',
+              'Error to exchangeTokenAndPopulateMember'
+            )
+
+            const msg = errors.helpers.printAll(err, {
+              withStack: true,
+              withPayload: true,
+            })
+
+            log(LogLevel.ERROR, msg)
+
+            set({
+              status: 'error',
+              error: '登入失敗，請稍後再試。',
+            })
+          }
+        },
+        async fetchMember() {
+          const { tokens, member } = get()
+          if (!tokens?.accessToken || !member?.id) {
+            return
+          }
+
+          try {
+            const latest = await getMemberProfileByMemberId({
+              memberId: member.id,
+              accessToken: tokens.accessToken,
+            })
+
+            if (latest) {
+              set({
+                member: latest,
+                status: 'authenticated',
+                error: undefined,
+              })
+            }
+          } catch (_err) {
+            const err = _err instanceof Error ? _err : new Error(String(_err))
+            log(
+              LogLevel.ERROR,
+              '[auth-store] fetchMember failed: ' + err.message
+            )
+          }
+        },
+        setAuth({ member, tokens }) {
+          set({
+            member,
+            tokens,
+            status: 'authenticated',
+            error: undefined,
+          })
+        },
+        clearAuth() {
+          set({
+            member: undefined,
+            tokens: undefined,
+            status: 'idle',
+            error: undefined,
+          })
+        },
+      }),
+      {
+        name: 'kids-auth',
+        storage: sessionJSONStorage,
+        partialize: (state) => {
+          if (state.status === 'authenticated') {
+            return {
+              member: state.member,
+              tokens: state.tokens,
+              status: state.status,
+            }
+          }
+          return {}
+        },
+      }
+    )
+  )
+)

--- a/packages/frontend/src/services/auth/use-hydrated-auth-store.tsx
+++ b/packages/frontend/src/services/auth/use-hydrated-auth-store.tsx
@@ -1,0 +1,25 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+import { useAuthStore } from '@/services/auth/auth-store'
+
+export const useHydratedAuthStore = () => {
+  const [hydrated, setHydrated] = useState(false)
+
+  useEffect(() => {
+    const unsub = useAuthStore.persist.onFinishHydration(() => {
+      setHydrated(true)
+    })
+
+    // store might be already hydrated
+    if (useAuthStore.persist.hasHydrated()) {
+      setHydrated(true)
+    }
+    return unsub
+  }, [])
+
+  return {
+    hydrated,
+    ...useAuthStore(),
+  }
+}

--- a/packages/frontend/src/utils/send-gql-request.ts
+++ b/packages/frontend/src/utils/send-gql-request.ts
@@ -35,7 +35,9 @@ export const sendGQLRequest = async <
   >,
 >(
   data: TRequestData,
-  config?: AxiosRequestConfig<TRequestData> | undefined
+  config?:
+    | (AxiosRequestConfig<TRequestData> & { authToken?: string })
+    | undefined
 ) => {
   let url
   if (typeof window === 'undefined' && !envVars.isProduction) {
@@ -46,6 +48,12 @@ export const sendGQLRequest = async <
 
   let response
   try {
+    const { authToken, headers, ...axiosConfig } = config ?? {}
+    const mergedHeaders = {
+      ...(headers ?? {}),
+      ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+    }
+
     response = await axios.post(
       url,
       {
@@ -54,7 +62,8 @@ export const sendGQLRequest = async <
       },
       {
         timeout: AXIOS_TIMEOUT,
-        ...config,
+        ...axiosConfig,
+        headers: mergedHeaders,
       }
     )
   } catch (err) {

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -20,7 +20,8 @@
     "composite": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "__generated__/*": ["./__generated__/*"]
     },
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6445,6 +6445,7 @@ __metadata:
     tailwind-merge: "npm:^3.3.1"
     tailwindcss: "npm:^4.1.14"
     typescript: "npm:5.9.2"
+    zustand: "npm:^4.5.5"
   languageName: unknown
   linkType: soft
 
@@ -19757,6 +19758,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"use-sync-external-store@npm:^1.2.2":
+  version: 1.6.0
+  resolution: "use-sync-external-store@npm:1.6.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/35e1179f872a53227bdf8a827f7911da4c37c0f4091c29b76b1e32473d1670ebe7bcd880b808b7549ba9a5605c233350f800ffab963ee4a4ee346ee983b6019b
+  languageName: node
+  linkType: hard
+
 "util-deprecate@npm:^1.0.1, util-deprecate@npm:~1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
@@ -20471,5 +20481,25 @@ __metadata:
   version: 1.0.5
   resolution: "zlib@npm:1.0.5"
   checksum: 10c0/34bd33f4fdcda34f57a1ab628ceb423bdf8ef07290f46cd944eedd9a66458cc24ccf3c770da73dc0f8d28016607d861290ac5c53d49113177f7c321838df2913
+  languageName: node
+  linkType: hard
+
+"zustand@npm:^4.5.5":
+  version: 4.5.7
+  resolution: "zustand@npm:4.5.7"
+  dependencies:
+    use-sync-external-store: "npm:^1.2.2"
+  peerDependencies:
+    "@types/react": ">=16.8"
+    immer: ">=9.0.6"
+    react: ">=16.8"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    immer:
+      optional: true
+    react:
+      optional: true
+  checksum: 10c0/55559e37a82f0c06cadc61cb08f08314c0fe05d6a93815e41e3376130c13db22a5017cbb0cd1f018c82f2dad0051afe3592561d40f980bd4082e32005e8a950c
   languageName: node
   linkType: hard


### PR DESCRIPTION
### Summary
- API gateway: 
  - replace the /auth/access-token proxy with an axios call to Go API /v2/auth/token, parse the returned JWT for user_id/exp, and `return { accessToken, twreporterUserId, expiresAt }`
  - add cookie-parser middleware, CORS credentials support, richer structured logs, and explicit handling for missing/invalid id_token cookies.
- Frontend auth utilities: 
  - introduce sendGQLRequest support for an optional authToken header
  - generated GraphQL operations plus helpers for fetching members by ID or twreporter user id
  - a persisted Zustand store that exchanges cookies for access tokens, caches member data, refreshes it, and exposes exchangeToken/fetchMember APIs.
- Hydration + provider: 
  - add AuthProvider (now hydration-aware via useHydratedAuthStore) to wrap the app layout, skip token refresh until session storage is ready, and keep member data in sync
  - expose a dev-only /login route that plants MOCK_ID_TOKEN, and capture that env var in environment-variables.ts.
- Tooling: add a __generated__ TypeScript path alias, ensure codegen notes the output location, and pull in the zustand dependency required by the auth store.

### Validation Ideas
1. Set MOCK_ID_TOKEN locally, visit /login, and confirm cookies + redirect.
2. /login will redirect to homepage, click browser network tab, and check there is /auth/token POST request to exchange access token.
3. After exchange, reload the page to ensure persisted auth hydrates before re-fetching.
4. Use expired/malformed cookies to confirm 400/401 handling and cleanup.

### Reference
https://www.notion.so/twreporter/aae99de42daf43bc8be6f7843f426887