### PR TITLE
fix(frontend): parallel login page

### DIFF
--- a/packages/frontend/src/app/(sticky-header)/login/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/login/page.tsx
@@ -1,7 +1,6 @@
 import { Metadata } from 'next'
-import { notFound } from 'next/navigation'
+import { notFound, redirect } from 'next/navigation'
 
-import { LoginComponent } from '@/components/login'
 import { GENERAL_DESCRIPTION, IS_LOGIN_ENABLED } from '@/constants'
 
 export const metadata: Metadata = {
@@ -14,9 +13,6 @@ export default async function Login() {
     notFound()
   }
 
-  return (
-    <main className="my-24 flex flex-col items-center justify-center">
-      <LoginComponent />
-    </main>
-  )
+  // Redirect to the API route handler that sets the cookie and redirects
+  redirect('/api/login_test')
 }

--- a/packages/frontend/src/app/api/login_test/route.ts
+++ b/packages/frontend/src/app/api/login_test/route.ts
@@ -1,7 +1,7 @@
 // WARNING:
 //
 // THIS FILE IS ONLY FOR DEVELOPMENT.
-// After login implementation is done, this route `/login` should be DELETED.
+// After login implementation is done, this route `/login_test` should be DELETED.
 
 import { NextResponse } from 'next/server'
 


### PR DESCRIPTION
## Summary

This PR refactors the login page implementation to handle authentication via an API route handler instead of directly rendering the login component. The login route handler has been moved from `/app/login/route.ts` to `/app/api/login_test/route.ts`, and the login page now redirects to this API endpoint for authentication processing.

## Changes

- **Moved login route handler**: Renamed and relocated `packages/frontend/src/app/login/route.ts` to `packages/frontend/src/app/api/login_test/route.ts` to prevent build error

## Screenshot(s)

N/A

## Reference(s)

- [build error](https://console.cloud.google.com/cloud-build/builds;region=asia-east1/3a09e344-8033-4ff1-8a6d-d6c8a23b3afc;step=1?authuser=0&project=kids-reporter)

