### PR TITLE
fix(frontend): send credentials with authenticated GQL calls

### DIFF
--- a/packages/frontend/src/utils/send-gql-request.ts
+++ b/packages/frontend/src/utils/send-gql-request.ts
@@ -64,6 +64,7 @@ export const sendGQLRequest = async <
         timeout: AXIOS_TIMEOUT,
         ...axiosConfig,
         headers: mergedHeaders,
+        withCredentials: true,
       }
     )
   } catch (err) {


### PR DESCRIPTION
### PR changes
- set Axios withCredentials flag so session cookies accompany authorized requests
- withCredentials: true is necessary if we enable Identity-Proxy Aware (IAP) before our API gateway.

### Bug 說明
因為 AuthStore 再 exchange access token 後，會需要拿取 member 的資料。
瀏覽器會執行 `fetchMember`， `fetchMember` 會呼叫 `sendGQLRequest`，`sendGQLRequest` 進而呼叫 `axios.post`；瀏覽器最後透過 axios 發送 POST method 到 api-gateway。

但因為 api-gateway 前面擋了 Identity-Proxy Aware (IAP)，如果 request 要過 IAP，需要帶上 IAP 認證的 cookie。
然而，axios 因為沒有設定 `withCredentials: true`，request 不會帶上瀏覽器上的 cookies，IAP 會因為沒有 cookie 而將 request block 住。

此 PR 修正 axios 的設定，將 `withCredentials` 設定成 `true`，要求 axios 發送的 request 帶上 IAP 需要的 cookie。
