### PR TITLE
fix(cms): enforce member-owned access and harden auth mini-app timeout

### DIFF
--- a/packages/api-gateway/src/auth-mini-app.ts
+++ b/packages/api-gateway/src/auth-mini-app.ts
@@ -114,6 +114,7 @@ export function createAuthMiniApp() {
             cookie: `id_token=${idToken}`,
             'content-type': 'application/json',
           },
+          timeout: 10000, // 10 seconds
         }
       )
 

--- a/packages/cms/lists/post-choice-answer.ts
+++ b/packages/cms/lists/post-choice-answer.ts
@@ -8,6 +8,7 @@ import {
 } from '@keystone-6/core/fields'
 
 import type { ListType } from '../types/keystone-list-types'
+import { allowRoles, RoleEnum } from './utils/access-control-list'
 import {
   makeMemberOwnedFilter,
   memberOwnedOperationAccess,
@@ -34,6 +35,12 @@ export default list<ListType<'PostChoiceAnswer'>>({
       many: false,
       ui: {
         hideCreate: true,
+      },
+      graphql: {
+        omit: {
+          create: true,
+          update: true,
+        },
       },
     }),
     choiceIndex: integer({
@@ -118,8 +125,8 @@ export default list<ListType<'PostChoiceAnswer'>>({
   access: {
     operation: {
       query: operationAccessControl,
-      create: operationAccessControl,
-      update: operationAccessControl,
+      create: allowRoles([RoleEnum.Member]),
+      update: allowRoles([RoleEnum.Member]),
       delete: operationAccessControl,
     },
     filter: {
@@ -129,13 +136,34 @@ export default list<ListType<'PostChoiceAnswer'>>({
     },
   },
   hooks: {
-    resolveInput: async ({ resolvedData, item, context }) => {
+    resolveInput: async ({ resolvedData, item, context, operation }) => {
       const questionId = resolvedData.question?.connect?.id ?? item?.questionId
-      const memberId = resolvedData.member?.connect?.id ?? item?.memberId
+      const memberId = item?.memberId?.toString()
 
-      if (questionId && memberId) {
+      const sessionMemberId = context.session?.data?.memberId?.toString()
+
+      if (!sessionMemberId) {
+        throw new Error(
+          'You must be signed in as a member to submit an answer.'
+        )
+      }
+
+      if (operation === 'create') {
+        // connect the answer to the member
+        resolvedData.member = {
+          connect: {
+            id: sessionMemberId,
+          },
+        }
+      } else if (operation === 'update') {
+        if (sessionMemberId !== memberId) {
+          throw new Error('You cannot edit the answer for another member.')
+        }
+      }
+
+      if (questionId) {
         // Use relational question id + member id as uniqueness
-        resolvedData.compositeKey = `${questionId}:${memberId}`
+        resolvedData.compositeKey = `${questionId}:${sessionMemberId}`
       }
 
       const choiceIndex = resolvedData.choiceIndex

--- a/packages/cms/lists/post-essay-answer-like.ts
+++ b/packages/cms/lists/post-essay-answer-like.ts
@@ -2,10 +2,16 @@ import { list } from '@keystone-6/core'
 import { relationship, text, timestamp } from '@keystone-6/core/fields'
 
 import type { ListType } from '../types/keystone-list-types'
+import { allowRoles, RoleEnum } from './utils/access-control-list'
 import {
   makeMemberOwnedFilter,
   memberOwnedOperationAccess,
 } from './utils/member-owned-access'
+
+const memberFieldName = 'member'
+
+const operationAccessControl = memberOwnedOperationAccess
+const filterAccessControl = makeMemberOwnedFilter(memberFieldName)
 
 export default list<ListType<'PostEssayAnswerLike'>>({
   fields: {
@@ -20,6 +26,12 @@ export default list<ListType<'PostEssayAnswerLike'>>({
       ref: 'Member',
       many: false,
       ui: { hideCreate: true },
+      graphql: {
+        omit: {
+          create: true,
+          update: true,
+        },
+      },
     }),
     compositeKey: text({
       label: '唯一鍵',
@@ -77,24 +89,45 @@ export default list<ListType<'PostEssayAnswerLike'>>({
   db: { idField: { kind: 'autoincrement' } },
   access: {
     operation: {
-      query: memberOwnedOperationAccess,
-      create: memberOwnedOperationAccess,
-      update: memberOwnedOperationAccess,
-      delete: memberOwnedOperationAccess,
+      query: operationAccessControl,
+      create: allowRoles([RoleEnum.Member]),
+      update: allowRoles([RoleEnum.Member]),
+      delete: operationAccessControl,
     },
     filter: {
-      query: makeMemberOwnedFilter('member'),
-      update: makeMemberOwnedFilter('member'),
-      delete: makeMemberOwnedFilter('member'),
+      query: filterAccessControl,
+      update: filterAccessControl,
+      delete: filterAccessControl,
     },
   },
   hooks: {
-    resolveInput: async ({ resolvedData, item }) => {
+    resolveInput: async ({ resolvedData, item, context, operation }) => {
       const answerId = resolvedData.answer?.connect?.id ?? item?.answerId
-      const memberId = resolvedData.member?.connect?.id ?? item?.memberId
-      if (answerId && memberId) {
-        resolvedData.compositeKey = `${answerId}:${memberId}`
+      const memberId = item?.memberId?.toString()
+
+      const sessionMemberId = context.session?.data?.memberId?.toString()
+
+      if (!sessionMemberId) {
+        throw new Error('You must be signed in as a member to submit a like.')
       }
+
+      if (operation === 'create') {
+        // connect the answer to the member
+        resolvedData.member = {
+          connect: {
+            id: sessionMemberId,
+          },
+        }
+      } else if (operation === 'update') {
+        if (sessionMemberId !== memberId) {
+          throw new Error('You cannot edit the like for another member.')
+        }
+      }
+
+      if (answerId) {
+        resolvedData.compositeKey = `${answerId}:${sessionMemberId}`
+      }
+
       return resolvedData
     },
   },

--- a/packages/cms/lists/post-essay-answer.ts
+++ b/packages/cms/lists/post-essay-answer.ts
@@ -30,6 +30,12 @@ export default list<ListType<'PostEssayAnswer'>>({
       ui: {
         hideCreate: true,
       },
+      graphql: {
+        omit: {
+          create: true,
+          update: true,
+        },
+      },
     }),
     content: text({
       label: '內容',
@@ -118,8 +124,8 @@ export default list<ListType<'PostEssayAnswer'>>({
         // Frontend needs to list essay answers publicly (read-only).
         RoleEnum.FrontendHeadlessAccount,
       ]),
-      create: operationAccessControl,
-      update: operationAccessControl,
+      create: allowRoles([RoleEnum.Member]),
+      update: allowRoles([RoleEnum.Member]),
       delete: operationAccessControl,
     },
     filter: {
@@ -133,13 +139,34 @@ export default list<ListType<'PostEssayAnswer'>>({
     },
   },
   hooks: {
-    resolveInput: async ({ resolvedData, item }) => {
+    resolveInput: async ({ resolvedData, item, context, operation }) => {
       const questionId = resolvedData.question?.connect?.id ?? item?.questionId
-      const memberId = resolvedData.member?.connect?.id ?? item?.memberId
+      const memberId = item?.memberId?.toString()
 
-      if (questionId && memberId) {
+      const sessionMemberId = context.session?.data?.memberId?.toString()
+
+      if (!sessionMemberId) {
+        throw new Error(
+          'You must be signed in as a member to submit an answer.'
+        )
+      }
+
+      if (operation === 'create') {
+        // connect the answer to the member
+        resolvedData.member = {
+          connect: {
+            id: sessionMemberId,
+          },
+        }
+      } else if (operation === 'update') {
+        if (sessionMemberId !== memberId) {
+          throw new Error('You cannot edit the answer for another member.')
+        }
+      }
+
+      if (questionId) {
         // Use relational question id + member id as uniqueness
-        resolvedData.compositeKey = `${questionId}:${memberId}`
+        resolvedData.compositeKey = `${questionId}:${sessionMemberId}`
       }
 
       return resolvedData

--- a/packages/cms/schema.graphql
+++ b/packages/cms/schema.graphql
@@ -1876,7 +1876,6 @@ input PostChoiceAnswerOrderByInput {
 
 input PostChoiceAnswerUpdateInput {
   question: PostChoiceQuestionRelateToOneForUpdateInput
-  member: MemberRelateToOneForUpdateInput
   choiceIndex: Int
   createdAt: DateTime
   updatedAt: DateTime
@@ -1888,12 +1887,6 @@ input PostChoiceQuestionRelateToOneForUpdateInput {
   disconnect: Boolean
 }
 
-input MemberRelateToOneForUpdateInput {
-  create: MemberCreateInput
-  connect: MemberWhereUniqueInput
-  disconnect: Boolean
-}
-
 input PostChoiceAnswerUpdateArgs {
   where: PostChoiceAnswerWhereUniqueInput!
   data: PostChoiceAnswerUpdateInput!
@@ -1901,7 +1894,6 @@ input PostChoiceAnswerUpdateArgs {
 
 input PostChoiceAnswerCreateInput {
   question: PostChoiceQuestionRelateToOneForCreateInput
-  member: MemberRelateToOneForCreateInput
   choiceIndex: Int
   createdAt: DateTime
   updatedAt: DateTime
@@ -1910,11 +1902,6 @@ input PostChoiceAnswerCreateInput {
 input PostChoiceQuestionRelateToOneForCreateInput {
   create: PostChoiceQuestionCreateInput
   connect: PostChoiceQuestionWhereUniqueInput
-}
-
-input MemberRelateToOneForCreateInput {
-  create: MemberCreateInput
-  connect: MemberWhereUniqueInput
 }
 
 type PostChoiceQuestion {
@@ -2024,7 +2011,6 @@ input PostEssayAnswerOrderByInput {
 
 input PostEssayAnswerUpdateInput {
   question: PostEssayQuestionRelateToOneForUpdateInput
-  member: MemberRelateToOneForUpdateInput
   content: String
   createdAt: DateTime
   updatedAt: DateTime
@@ -2043,7 +2029,6 @@ input PostEssayAnswerUpdateArgs {
 
 input PostEssayAnswerCreateInput {
   question: PostEssayQuestionRelateToOneForCreateInput
-  member: MemberRelateToOneForCreateInput
   content: String
   createdAt: DateTime
   updatedAt: DateTime
@@ -2143,7 +2128,6 @@ input PostEssayAnswerLikeOrderByInput {
 
 input PostEssayAnswerLikeUpdateInput {
   answer: PostEssayAnswerRelateToOneForUpdateInput
-  member: MemberRelateToOneForUpdateInput
   createdAt: DateTime
   updatedAt: DateTime
 }
@@ -2161,7 +2145,6 @@ input PostEssayAnswerLikeUpdateArgs {
 
 input PostEssayAnswerLikeCreateInput {
   answer: PostEssayAnswerRelateToOneForCreateInput
-  member: MemberRelateToOneForCreateInput
   createdAt: DateTime
   updatedAt: DateTime
 }


### PR DESCRIPTION
## PR Description
- restrict choice, essay, and like mutations to the authenticated member, auto-connecting submissions to the session and normalizing composite keys
- align Keystone ACLs with the resolver guards to block cross-member edits while keeping admin read/delete
- add a 10s timeout to the auth mini-app axios client to prevent hanging requests when upstream services stall

### BREAKING CHANGE:
Keystone mutations for post answers and likes can no longer accept manual member connections; clients must rely on the session-bound member context