### PR TITLE
fix(frontend): proxy ndx-kids-api traffic through frontend

### DIFF
--- a/packages/frontend/.env.ndx.public
+++ b/packages/frontend/.env.ndx.public
@@ -1,3 +1,3 @@
-NEXT_PUBLIC_GQL_ENDPOINT=https://ndx-kids-api.twreporter.org/api/graphql
-NEXT_PUBLIC_API_GATEWAY_ENDPOINT=https://ndx-kids-api.twreporter.org
+NEXT_PUBLIC_GQL_ENDPOINT=https://ndx-kids.twreporter.org/api-gateway/api/graphql
+NEXT_PUBLIC_API_GATEWAY_ENDPOINT=https://ndx-kids.twreporter.org/api-gateway
 NEXT_PUBLIC_BASE_URL=https://ndx-kids.twreporter.org


### PR DESCRIPTION
## Summary
- ndx-kids.twreporter.org/api-gateway now proxies to ndx-kids-api.twreporter.org/. This routing removes the cross-origin hop that was triggering IAP-blocked requests.

- Updated .env.ndx.public so the new proxy target is available in deployment configs

## Bug Description
IAP (Identity-Aware Proxy) needs user to open the protected URLs in the browser, so the browser will get and store the IAP issued cookies.
However, in our case, we send api requests to IAP via Ajax. Hence, users cannot get necessary cookies to pass the IAP authentications. The Ajax requests will receive 400 bad request response due to lacking of IAP cookies.

##  Implementation Details
In GCP [load balancer](https://console.cloud.google.com/net-services/loadbalancing/details/httpAdvanced/nonprod-external-lb?project=kids-reporter) routing rules, we add a rule to proxy `ndx-kids.twreporter.org/api-gateway/*` to ndx-kids-api cloud run. 
For exampe: `https://ndx-kids.twreporter.org/api-gateway/api/graphql` will be proxied to ndx-kids-api cloud run, and ndx-kids-api cloud run will receive a request with path `/api/graphql` (without `/api-gateway` prefix).

In this way, we don't have to change the source codes to pass the IAP authentications.

## Note
This proxy method is only used in non-prod (ndx, dev and staging) environments. In prod environment, we don't have IAP to protect our services.