### PR TITLE
fix(frontend,cms): improve My Reading page layout and pagination logic and essay count default value

### DIFF
--- a/packages/cms/lists/member.ts
+++ b/packages/cms/lists/member.ts
@@ -90,7 +90,7 @@ export default list<ListType<'Member'>>({
     }),
     essayQuestionCount: integer({
       label: '思辨題數量',
-      defaultValue: 3,
+      defaultValue: 1,
     }),
     createdAt: timestamp({
       defaultValue: { kind: 'now' },

--- a/packages/frontend/src/modules/membership/my-reading/index.tsx
+++ b/packages/frontend/src/modules/membership/my-reading/index.tsx
@@ -51,13 +51,13 @@ function MyReading() {
 
   return (
     <div className="mx-auto w-full bg-neutral-100 pt-6 pb-40 tablet:pt-8 desktop:px-12 desktop:pt-16 desktop:pb-50">
-      <div className="mx-auto flex w-full max-w-300 gap-8">
+      <div className="mx-auto flex w-full max-w-300 gap-6 desktop:gap-3">
         <HeaderMobileBackButtonHrefSetter href="/member" />
         <div className="hidden tablet:block">
           <MembershipSideMenu />
         </div>
-        <div className="flex flex-1 flex-col px-6 tablet:px-8 desktop:px-0">
-          <h1 className="mb-6 prose-h4-large font-swei text-neutral-900">
+        <div className="flex flex-1 flex-col px-6 tablet:pr-8 tablet:pl-0 desktop:px-0">
+          <h1 className="mb-6 prose-h4-large font-swei text-neutral-900 desktop:pl-5">
             我的回答
           </h1>
           <PostQuestionAnswersList
@@ -65,26 +65,27 @@ function MyReading() {
             isLoading={isGetMemberPostsWithAnswersLoading}
             key={currentPage}
           />
-          {!isGetMemberPostsWithAnswersLoading && (
-            <div className="mt-6 flex justify-center gap-4">
-              <Button
-                variant="secondary"
-                className="size-11 p-0"
-                disabled={isFirstPage}
-                onClick={() => setCurrentPage(currentPage - 1)}
-              >
-                <ArrowLeft />
-              </Button>
-              <Button
-                variant="secondary"
-                className="size-11 p-0"
-                disabled={isLastPage}
-                onClick={() => setCurrentPage(currentPage + 1)}
-              >
-                <ArrowRight />
-              </Button>
-            </div>
-          )}
+          {!isGetMemberPostsWithAnswersLoading &&
+            currentPostQuestionAnswers.length > 0 && (
+              <div className="mt-6 flex justify-center gap-4">
+                <Button
+                  variant="secondary"
+                  className="size-11 p-0"
+                  disabled={isFirstPage}
+                  onClick={() => setCurrentPage(currentPage - 1)}
+                >
+                  <ArrowLeft />
+                </Button>
+                <Button
+                  variant="secondary"
+                  className="size-11 p-0"
+                  disabled={isLastPage}
+                  onClick={() => setCurrentPage(currentPage + 1)}
+                >
+                  <ArrowRight />
+                </Button>
+              </div>
+            )}
         </div>
       </div>
     </div>

--- a/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/index.tsx
+++ b/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/index.tsx
@@ -51,53 +51,54 @@ function PostQuestionAnswersList({
   }
 
   return (
-    <Accordion
-      type="multiple"
-      className="flex w-full flex-col gap-0 border-t border-t-neutral-200"
-    >
-      {postQuestionAnswers.map((group) => {
-        return (
-          <AccordionItem
-            key={group.title}
-            value={group.title}
-            className="border-b border-b-neutral-200 last:border-b"
-          >
-            <AccordionTrigger
-              className={cn(
-                'group flex cursor-pointer items-center gap-4 rounded-none py-5 transition-all duration-300',
-                'bg-transparent hover:bg-black/5 active:bg-black/10',
-                'focus-visible:outline-none'
-              )}
+    <>
+      <div className="mx-auto h-px w-full bg-neutral-200 desktop:w-[calc(100%-40px)]"></div>
+      <Accordion type="multiple" className="flex w-full flex-col gap-0">
+        {postQuestionAnswers.map((group) => {
+          return (
+            <AccordionItem
+              key={group.title}
+              value={group.title}
+              className="border-none"
             >
-              <div className="flex flex-1 flex-col gap-1 text-left">
-                <div className="flex items-center gap-2">
-                  <span className="prose-p2 text-neutral-500">
-                    {formatDate(group.lastAnsweredTime)}
-                  </span>
-                  <span
-                    className={cn(
-                      'rounded px-1.5 py-0.5 prose-p3-bold',
-                      'bg-neutral-200 text-neutral-600'
-                    )}
-                  >
-                    共作答 {group.answers.length} 題
-                  </span>
+              <AccordionTrigger
+                className={cn(
+                  'group flex cursor-pointer items-center gap-4 rounded-none py-5 transition-all duration-300 desktop:px-5',
+                  'bg-transparent hover:bg-black/5 active:bg-black/10',
+                  'focus-visible:outline-none'
+                )}
+              >
+                <div className="flex flex-1 flex-col gap-1 text-left">
+                  <div className="flex items-center gap-2">
+                    <span className="prose-p2 text-neutral-500">
+                      {formatDate(group.lastAnsweredTime)}
+                    </span>
+                    <span
+                      className={cn(
+                        'rounded px-1.5 py-0.5 prose-p3-bold',
+                        'bg-neutral-200 text-neutral-600'
+                      )}
+                    >
+                      共作答 {group.answers.length} 題
+                    </span>
+                  </div>
+                  <h3 className="prose-p1-bold text-neutral-900">
+                    {group.title}
+                  </h3>
                 </div>
-                <h3 className="prose-p1-bold text-neutral-900">
-                  {group.title}
-                </h3>
-              </div>
-            </AccordionTrigger>
-            <AccordionContent className="pt-2 pb-10">
-              <QuestionAnswersListContent
-                href={group.href}
-                answers={group.answers}
-              />
-            </AccordionContent>
-          </AccordionItem>
-        )
-      })}
-    </Accordion>
+              </AccordionTrigger>
+              <AccordionContent className="pt-2 pb-10 desktop:px-5">
+                <QuestionAnswersListContent
+                  href={group.href}
+                  answers={group.answers}
+                />
+              </AccordionContent>
+              <div className="mx-auto h-px w-full bg-neutral-200 desktop:w-[calc(100%-40px)]"></div>
+            </AccordionItem>
+          )
+        })}
+      </Accordion>
+    </>
   )
 }
 


### PR DESCRIPTION
## Summary

This PR fixes UI defects in the My Reading page by improving responsive layout spacing, fixing pagination visibility logic, and refactoring accordion dividers for better visual consistency across different screen sizes. And it also adjust the default value of default essay question couont.

## Changes

- **Pagination visibility fix**: Added condition to only display pagination navigation buttons when `currentPostQuestionAnswers.length > 0`, preventing empty pagination controls from appearing
- **Accordion divider refactoring**: Replaced border-based styling with explicit divider elements:
  - Removed `border-t` and `border-b` classes from Accordion and AccordionItem components
  - Added top divider before the accordion and dividers between each accordion item
  - Implemented responsive divider widths: full width on mobile, `calc(100%-40px)` on desktop to match content padding
  - Added `desktop:px-5` padding to AccordionTrigger and AccordionContent for consistent desktop spacing
- **Essay question default count adjustment**: modified it from 3 to 1 

## Additional Notes

These changes improve the visual consistency and user experience of the My Reading page across different device sizes. The explicit divider approach provides better control over spacing and alignment compared to border-based styling.

## Screenshot(s)
<img width="1413" height="778" alt="Screenshot 2025-11-13 at 11 37 52 AM" src="https://github.com/user-attachments/assets/5a5afafc-7c21-4be7-a2b2-e6a981e712a5" />


<img width="1288" height="643" alt="image" src="https://github.com/user-attachments/assets/2f3a2ecc-176e-4c25-9f1d-a0f90353ed47" />




## Reference(s)

