### PR TITLE
chore(routing-ui): expose built files and remove postinstall script

### DIFF
--- a/packages/routing-ui/package.json
+++ b/packages/routing-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kids-reporter/routing-ui",
   "license": "MIT",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "description": "Routing UI for Kids Reporter",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -18,8 +18,7 @@
     "build": "./scripts/build.sh",
     "lint": "eslint . --config ./eslint.config.mjs",
     "lint:check": "eslint . --config ./eslint.config.mjs",
-    "type-check": "tsc --noEmit",
-    "postinstall": "yarn build"
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",
@@ -50,5 +49,8 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "tailwindcss": "^4.1.14"
-  }
+  },
+  "files": [
+    "dist"
+  ]
 }

--- a/packages/routing-ui/package.json
+++ b/packages/routing-ui/package.json
@@ -25,7 +25,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lodash": "^4.17.21",
-    "next": "^14.2.33",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6468,7 +6468,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/routing-ui@npm:0.1.0-alpha.5, @kids-reporter/routing-ui@workspace:packages/routing-ui":
+"@kids-reporter/routing-ui@npm:0.1.0-alpha.5":
+  version: 0.1.0-alpha.5
+  resolution: "@kids-reporter/routing-ui@npm:0.1.0-alpha.5"
+  dependencies:
+    "@radix-ui/react-slot": "npm:^1.2.3"
+    class-variance-authority: "npm:^0.7.1"
+    clsx: "npm:^2.1.1"
+    lodash: "npm:^4.17.21"
+    next: "npm:^14.2.33"
+    tailwind-merge: "npm:^3.3.1"
+  peerDependencies:
+    react: 18.3.1
+    react-dom: 18.3.1
+    tailwindcss: ^4.1.14
+  checksum: 10c0/26e9b616f96ccfdc3dc0d8a99cdeaf56eb59ac672eebcd78777a62950cc40de2b116a287612086cbb13901e29ae1d2dd57eb74544d84841270b113db8996a658
+  languageName: node
+  linkType: hard
+
+"@kids-reporter/routing-ui@workspace:packages/routing-ui":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/routing-ui@workspace:packages/routing-ui"
   dependencies:


### PR DESCRIPTION
## Details
- update packages/routing-ui/package.json to version 0.1.0-alpha.6
- remove the postinstall script now that the package ships compiled artifacts
- add a files field so only the prebuilt dist output is published

## Issue
Installing @kids-reporter/routing-ui@0.1.0-alpha.5 inside membership-fe fails because the postinstall hook invokes yarn build, which depends on dev-only Babel plugins missing from downstream projects.

```
yarn add @kids-reporter/routing-ui@0.1.0-alpha.5
…
[5/5] 🔨  Building fresh packages...
error …/node_modules/@kids-reporter/routing-ui: Command failed.
Command: yarn build
…
Error: Cannot find package '@babel/plugin-transform-runtime' imported from …/routing-ui/babel-virtual-resolve-base.js
```

By shipping only the compiled dist/ output and removing postinstall, consumers install the package without executing our build tooling or requiring our dev dependencies.