### PR TITLE
fix(frontend,cms): fix baodaozai animation fade out and update essay question count default

### DIFF
--- a/packages/cms/migrations/20251113071138_modify_essay_count_default_value_in_member_list/migration.sql
+++ b/packages/cms/migrations/20251113071138_modify_essay_count_default_value_in_member_list/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Member" ALTER COLUMN "essayQuestionCount" SET DEFAULT 1;

--- a/packages/cms/schema.prisma
+++ b/packages/cms/schema.prisma
@@ -351,7 +351,7 @@ model Member {
   twreporter_user_id              String                @unique @default("")
   role                            String                @default("member")
   showBaodaozai                   Boolean               @default(true)
-  essayQuestionCount              Int?                  @default(3)
+  essayQuestionCount              Int?                  @default(1)
   createdAt                       DateTime?             @default(now())
   updatedAt                       DateTime?             @updatedAt
   from_PostChoiceAnswer_member    PostChoiceAnswer[]    @relation("PostChoiceAnswer_member")

--- a/packages/frontend/src/services/call-baodaozai/components/baodaozai.tsx
+++ b/packages/frontend/src/services/call-baodaozai/components/baodaozai.tsx
@@ -72,8 +72,8 @@ function Baodaozai() {
   return (
     <div
       className={cn(
-        'fixed right-0 bottom-0 z-1000 w-full transition-opacity duration-1000 tablet:right-0 tablet:bottom-0',
-        hide ? 'opacity-0' : 'opacity-100'
+        'fixed right-0 bottom-0 z-1000 w-full tablet:right-0 tablet:bottom-0',
+        hide ? 'opacity-0' : 'opacity-100 transition-opacity duration-1000'
       )}
     >
       <div


### PR DESCRIPTION
## Summary

This PR fixes the baodaozai animation fade-out behavior and updates the default value for essay question count in the Member model. The animation now fades in smoothly but fades out instantly, providing a better user experience. Additionally, the default essay question count has been changed from 3 to 1.

## Changes

- **fix(frontend)**: Adjust baodaozai component animation transition logic
  - Move `transition-opacity duration-1000` class to only apply when showing (opacity-100)
  - When hiding (opacity-0), the transition is removed, causing instant fade-out
  - This provides smooth fade-in but instant fade-out behavior

- **fix(cms)**: Update default value of `essayQuestionCount` in Member model
  - Change default value from 3 to 1 in `schema.prisma`
  - Add database migration to update existing default value
  - Migration file: `20251113071138_modify_essay_count_default_value_in_member_list/migration.sql`

## Additional Notes

- The animation change ensures that when the baodaozai component is hidden, it disappears immediately rather than fading out over 1 second, which may improve perceived responsiveness
- The essay question count default change affects new members created without explicitly setting this value
- Existing members with explicitly set values are not affected by the default change

## Screenshot(s)

https://github.com/user-attachments/assets/87a6145a-0dfa-438c-a94b-1400d46aec27


## Reference(s)
- [Notion Page](https://www.notion.so/twreporter/defect-2a88dbdca9328074a39fc25135b00285?v=1588dbdca93281dfa43c000c8415265e&source=copy_link)
