### PR TITLE
fix(frontend): improve UI layout and visual consistency in membership pages

### DIFF
--- a/packages/frontend/src/modules/membership/components/side-menu.tsx
+++ b/packages/frontend/src/modules/membership/components/side-menu.tsx
@@ -15,7 +15,7 @@ function MembershipSideMenu() {
     return pathname?.startsWith(href)
   }
   return (
-    <div className="flex w-full flex-col gap-4 tablet:max-w-40">
+    <div className="flex w-full flex-col gap-4">
       <div className="flex flex-col gap-0">
         {MEMBERSHIP_MENU_ITEMS.map((item) => {
           const active = isActive(item.href)
@@ -36,7 +36,7 @@ function MembershipSideMenu() {
         })}
       </div>
 
-      <div className="mx-auto h-px w-[calc(100%-48px)] bg-neutral-200 tablet:w-[calc(100%-64px)] desktop:w-[calc(100%-32px)]" />
+      <div className="mx-auto h-[2px] w-[calc(100%-48px)] bg-neutral-200 tablet:w-[calc(100%-64px)] desktop:w-full" />
 
       <Link
         href="/logout"

--- a/packages/frontend/src/modules/membership/member/index.tsx
+++ b/packages/frontend/src/modules/membership/member/index.tsx
@@ -21,7 +21,7 @@ function Member() {
 
   return (
     <div className="w-full bg-neutral-100 desktop:px-12">
-      <div className="mx-auto flex w-full max-w-300 flex-col items-center gap-8 pt-6 pb-40 tablet:items-start tablet:pt-8 desktop:pt-16 desktop:pb-50">
+      <div className="mx-auto flex w-full max-w-300 flex-col items-center gap-8 pt-6 pb-40 tablet:grid tablet:grid-cols-12 tablet:items-start tablet:pt-8 desktop:pt-16 desktop:pb-50">
         <div className="flex w-full flex-col items-center gap-4 tablet:hidden">
           <div className="h-[136px] w-[136px] overflow-hidden rounded-full">
             <Image
@@ -42,7 +42,9 @@ function Member() {
           </div>
         </div>
 
-        <MembershipSideMenu />
+        <div className="w-full tablet:col-span-2 tablet:min-w-[150px] desktop:pr-8">
+          <MembershipSideMenu />
+        </div>
       </div>
     </div>
   )

--- a/packages/frontend/src/modules/membership/my-reading/index.tsx
+++ b/packages/frontend/src/modules/membership/my-reading/index.tsx
@@ -51,13 +51,13 @@ function MyReading() {
 
   return (
     <div className="mx-auto w-full bg-neutral-100 pt-6 pb-40 tablet:pt-8 desktop:px-12 desktop:pt-16 desktop:pb-50">
-      <div className="mx-auto flex w-full max-w-300 gap-6 desktop:gap-3">
+      <div className="mx-auto w-full max-w-300 tablet:grid tablet:grid-cols-12">
         <HeaderMobileBackButtonHrefSetter href="/member" />
-        <div className="hidden tablet:block">
+        <div className="hidden tablet:col-span-2 tablet:block tablet:min-w-[150px] desktop:pr-8">
           <MembershipSideMenu />
         </div>
-        <div className="flex flex-1 flex-col px-6 tablet:pr-8 tablet:pl-0 desktop:px-0">
-          <h1 className="mb-6 prose-h4-large font-swei text-neutral-900 desktop:pl-5">
+        <div className="flex flex-1 flex-col px-6 tablet:col-span-9 tablet:px-8 desktop:col-span-8 desktop:px-0">
+          <h1 className="mb-6 prose-h4-large font-swei text-neutral-900">
             我的回答
           </h1>
           <PostQuestionAnswersList

--- a/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/essay-answer-item.tsx
+++ b/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/essay-answer-item.tsx
@@ -8,7 +8,7 @@ function EssayAnswerItem({ answer }: { answer: PostEssayAnswer }) {
   return (
     <div className="flex gap-4 rounded-xl bg-white px-5 py-4">
       <p className="prose-p1-medium text-neutral-900">{answer.content || ''}</p>
-      <div className="ml-auto w-px self-stretch bg-neutral-200" />
+      <div className="ml-auto w-[2px] self-stretch bg-neutral-200" />
       <div className="flex flex-col items-center gap-1">
         <div className="text-neutral-600">
           <ThumbUpIcon />

--- a/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/index.tsx
+++ b/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/index.tsx
@@ -51,54 +51,53 @@ function PostQuestionAnswersList({
   }
 
   return (
-    <>
-      <div className="mx-auto h-px w-full bg-neutral-200 desktop:w-[calc(100%-40px)]"></div>
-      <Accordion type="multiple" className="flex w-full flex-col gap-0">
-        {postQuestionAnswers.map((group) => {
-          return (
-            <AccordionItem
-              key={group.title}
-              value={group.title}
-              className="border-none"
+    <Accordion
+      type="multiple"
+      className="flex w-full flex-col gap-0 border-t-[2px] border-t-neutral-200"
+    >
+      {postQuestionAnswers.map((group) => {
+        return (
+          <AccordionItem
+            key={group.title}
+            value={group.title}
+            className="border-b-[2px] border-b-neutral-200 last:border-b"
+          >
+            <AccordionTrigger
+              className={cn(
+                'group flex cursor-pointer items-center gap-4 rounded-none py-5 transition-all duration-300 desktop:px-4',
+                'bg-transparent hover:bg-black/5 active:bg-black/10',
+                'focus-visible:outline-none'
+              )}
             >
-              <AccordionTrigger
-                className={cn(
-                  'group flex cursor-pointer items-center gap-4 rounded-none py-5 transition-all duration-300 desktop:px-5',
-                  'bg-transparent hover:bg-black/5 active:bg-black/10',
-                  'focus-visible:outline-none'
-                )}
-              >
-                <div className="flex flex-1 flex-col gap-1 text-left">
-                  <div className="flex items-center gap-2">
-                    <span className="prose-p2 text-neutral-500">
-                      {formatDate(group.lastAnsweredTime)}
-                    </span>
-                    <span
-                      className={cn(
-                        'rounded px-1.5 py-0.5 prose-p3-bold',
-                        'bg-neutral-200 text-neutral-600'
-                      )}
-                    >
-                      共作答 {group.answers.length} 題
-                    </span>
-                  </div>
-                  <h3 className="prose-p1-bold text-neutral-900">
-                    {group.title}
-                  </h3>
+              <div className="flex flex-1 flex-col gap-1 text-left">
+                <div className="flex items-center gap-2">
+                  <span className="prose-p2 text-neutral-500">
+                    {formatDate(group.lastAnsweredTime)}
+                  </span>
+                  <span
+                    className={cn(
+                      'rounded px-1.5 py-0.5 prose-p3-bold transition-all duration-300 group-hover:bg-neutral-300 group-active:bg-neutral-300',
+                      'bg-neutral-200 text-neutral-600'
+                    )}
+                  >
+                    共作答 {group.answers.length} 題
+                  </span>
                 </div>
-              </AccordionTrigger>
-              <AccordionContent className="pt-2 pb-10 desktop:px-5">
-                <QuestionAnswersListContent
-                  href={group.href}
-                  answers={group.answers}
-                />
-              </AccordionContent>
-              <div className="mx-auto h-px w-full bg-neutral-200 desktop:w-[calc(100%-40px)]"></div>
-            </AccordionItem>
-          )
-        })}
-      </Accordion>
-    </>
+                <h3 className="prose-h6-large text-neutral-900">
+                  {group.title}
+                </h3>
+              </div>
+            </AccordionTrigger>
+            <AccordionContent className="pt-2 pb-10">
+              <QuestionAnswersListContent
+                href={group.href}
+                answers={group.answers}
+              />
+            </AccordionContent>
+          </AccordionItem>
+        )
+      })}
+    </Accordion>
   )
 }
 

--- a/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/question-answers-list-content.tsx
+++ b/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/question-answers-list-content.tsx
@@ -35,7 +35,7 @@ function QuestionAnswersListContent({
             className="flex w-full flex-col gap-3 rounded-2xl bg-neutral-200 p-5"
           >
             <div className="flex items-center gap-2">
-              <div className="mt-1 flex h-6 w-6 shrink-0 items-center justify-center text-neutral-900">
+              <div className="mt-[5px] flex h-6 w-6 shrink-0 items-center justify-center text-neutral-900">
                 <LightbulbIcon />
               </div>
               <h3 className="flex-1 prose-p1-bold text-neutral-900">
@@ -58,7 +58,7 @@ function QuestionAnswersListContent({
           <ArticleShortcutIcon />
           <span>閱讀完整文章</span>
         </Link>
-        <div className="h-4 w-px bg-neutral-900"></div>
+        <div className="h-4 w-[2px] bg-neutral-900"></div>
         <Link
           href={href}
           className="flex items-center gap-1 text-neutral-900 hover:text-red-400 active:text-red-500"


### PR DESCRIPTION
## Summary

This PR fixes UI layout defects and improves visual consistency across the membership pages, specifically the member profile and my-reading pages. The changes include switching from flex to grid layout for better responsive design, increasing divider thickness for better visibility, and refining spacing and typography.

## Changes

- **Layout improvements**: Converted flex layouts to CSS Grid (`tablet:grid tablet:grid-cols-12`) in `member/index.tsx` and `my-reading/index.tsx` for better responsive alignment
- **Side menu adjustments**: 
  - Removed `tablet:max-w-40` constraint from side menu container
  - Wrapped side menu in grid column container with `tablet:col-span-2 tablet:min-w-[150px] desktop:pr-8`
  - Updated divider width to `desktop:w-full` for full-width on desktop
- **Visual consistency**: Increased all divider thickness from `h-px`/`w-px` to `h-[2px]`/`w-[2px]` across components for better visibility
- **Accordion refactoring**: 
  - Replaced separate divider divs with Tailwind border utilities (`border-t-[2px]` and `border-b-[2px]`)
  - Removed redundant padding classes from `AccordionContent`
  - Adjusted `AccordionTrigger` padding from `desktop:px-5` to `desktop:px-4`
- **Typography updates**: Changed accordion title from `prose-p1-bold` to `prose-h6-large` for better semantic hierarchy
- **Interactive enhancements**: Added hover/active states (`group-hover:bg-neutral-300 group-active:bg-neutral-300`) to answer count badges
- **Spacing refinements**: 
  - Adjusted icon margin from `mt-1` to `mt-[5px]` in question answers list
  - Removed unnecessary `desktop:pl-5` from page title
  - Updated content area grid spans (`tablet:col-span-9 desktop:col-span-8`)

## Additional Notes

These changes improve the visual consistency and responsive behavior of the membership section. The grid layout provides better control over column alignment and spacing across different screen sizes. The increased divider thickness improves visual hierarchy and makes separators more noticeable.

## Screenshot(s)

<img width="1212" height="866" alt="image" src="https://github.com/user-attachments/assets/0f64d6fa-6d86-4fea-ad7d-16e9981451c1" />


## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/defect-UI-7-2aa8dbdca932805a8709c024960fe66c?source=copy_link)