### PR TITLE
fix(frontend): adjust grid layout and typography in member and my-reading pages

### DIFF
--- a/packages/frontend/src/modules/membership/member/index.tsx
+++ b/packages/frontend/src/modules/membership/member/index.tsx
@@ -21,7 +21,7 @@ function Member() {
 
   return (
     <div className="w-full bg-neutral-100 desktop:px-12">
-      <div className="mx-auto flex w-full max-w-300 flex-col items-center gap-8 pt-6 pb-40 tablet:grid tablet:grid-cols-12 tablet:items-start tablet:pt-8 desktop:pt-16 desktop:pb-50">
+      <div className="mx-auto flex w-full max-w-300 flex-col items-center gap-8 pt-6 pb-40 tablet:grid tablet:grid-cols-12 tablet:items-start tablet:gap-6 tablet:pt-8 desktop:gap-8 desktop:pt-16 desktop:pb-50">
         <div className="flex w-full flex-col items-center gap-4 tablet:hidden">
           <div className="h-[136px] w-[136px] overflow-hidden rounded-full">
             <Image
@@ -42,7 +42,7 @@ function Member() {
           </div>
         </div>
 
-        <div className="w-full tablet:col-span-2 tablet:min-w-[150px] desktop:pr-8">
+        <div className="w-full tablet:col-span-2 tablet:min-w-[150px]">
           <MembershipSideMenu />
         </div>
       </div>

--- a/packages/frontend/src/modules/membership/my-reading/index.tsx
+++ b/packages/frontend/src/modules/membership/my-reading/index.tsx
@@ -51,12 +51,12 @@ function MyReading() {
 
   return (
     <div className="mx-auto w-full bg-neutral-100 pt-6 pb-40 tablet:pt-8 desktop:px-12 desktop:pt-16 desktop:pb-50">
-      <div className="mx-auto w-full max-w-300 tablet:grid tablet:grid-cols-12">
+      <div className="mx-auto w-full max-w-300 tablet:grid tablet:grid-cols-12 tablet:gap-6 desktop:gap-8">
         <HeaderMobileBackButtonHrefSetter href="/member" />
-        <div className="hidden tablet:col-span-2 tablet:block tablet:min-w-[150px] desktop:pr-8">
+        <div className="hidden tablet:col-span-2 tablet:block tablet:min-w-[150px]">
           <MembershipSideMenu />
         </div>
-        <div className="flex flex-1 flex-col px-6 tablet:col-span-9 tablet:px-8 desktop:col-span-8 desktop:px-0">
+        <div className="flex flex-1 flex-col px-6 tablet:col-span-10 tablet:px-8 desktop:col-span-8 desktop:px-0">
           <h1 className="mb-6 prose-h4-large font-swei text-neutral-900">
             我的回答
           </h1>

--- a/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/index.tsx
+++ b/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/index.tsx
@@ -83,7 +83,7 @@ function PostQuestionAnswersList({
                     共作答 {group.answers.length} 題
                   </span>
                 </div>
-                <h3 className="prose-h6-large text-neutral-900">
+                <h3 className="prose-p1-bold text-neutral-900 desktop:prose-h6-large">
                   {group.title}
                 </h3>
               </div>

--- a/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/question-answers-list-content.tsx
+++ b/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/question-answers-list-content.tsx
@@ -35,7 +35,7 @@ function QuestionAnswersListContent({
             className="flex w-full flex-col gap-3 rounded-2xl bg-neutral-200 p-5"
           >
             <div className="flex items-center gap-2">
-              <div className="mt-[5px] flex h-6 w-6 shrink-0 items-center justify-center text-neutral-900">
+              <div className="mt-px flex h-6 w-6 shrink-0 items-center justify-center text-neutral-900">
                 <LightbulbIcon />
               </div>
               <h3 className="flex-1 prose-p1-bold text-neutral-900">

--- a/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/question-answers-list-content.tsx
+++ b/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/question-answers-list-content.tsx
@@ -34,7 +34,7 @@ function QuestionAnswersListContent({
             key={answer.id}
             className="flex w-full flex-col gap-3 rounded-2xl bg-neutral-200 p-5"
           >
-            <div className="flex items-center gap-2">
+            <div className="flex items-start gap-2">
               <div className="mt-px flex h-6 w-6 shrink-0 items-center justify-center text-neutral-900">
                 <LightbulbIcon />
               </div>


### PR DESCRIPTION
## Summary

This PR fixes UI layout and typography issues in the membership section, specifically in the member and my-reading pages. The changes improve grid spacing, column distribution, and responsive typography to ensure better visual consistency across different screen sizes.

## Changes

- **Grid spacing**: Added proper gap spacing (`tablet:gap-6 desktop:gap-8`) to grid containers in both member and my-reading pages for consistent spacing between sidebar and content areas
- **Sidebar padding**: Removed unnecessary `desktop:pr-8` padding from sidebar containers in member and my-reading pages, as spacing is now handled by grid gaps
- **Column span adjustment**: Changed main content area from `tablet:col-span-9` to `tablet:col-span-10` in my-reading page to better utilize available space
- **Responsive typography**: Updated post title typography in post-question-answers-list to use `prose-p1-bold` on mobile/tablet and `desktop:prose-h6-large` on desktop for better readability
- **Icon alignment**: Adjusted icon margin from `mt-[5px]` to `mt-px` in question-answers-list-content for better vertical alignment

## Additional Notes

These changes ensure consistent spacing and typography across the membership section, improving the overall user experience and visual hierarchy.

## Screenshot(s)

<img width="685" height="624" alt="image" src="https://github.com/user-attachments/assets/d9ecc8bd-0d03-4a2e-beae-59e953f310a0" />

<img width="1152" height="842" alt="image" src="https://github.com/user-attachments/assets/cd115289-8afb-4a2d-887e-39e005ec97c3" />


## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/defect-UI-2aa8dbdca932805a8709c024960fe66c?v=1588dbdca93281dfa43c000c8415265e&source=copy_link)