### PR TITLE
fix(frontend): open idea hub in new tab when clicking confirm button and adjust wording

### DIFF
--- a/packages/frontend/src/app/(sticky-header)/_components/article/article.tsx
+++ b/packages/frontend/src/app/(sticky-header)/_components/article/article.tsx
@@ -363,12 +363,16 @@ const Article = ({
         isOpen: true,
         content: isLogin
           ? `想知道其他讀者的答案嗎？
-      大家送出的思辨題答案都會顯示在這裡喔～`
+大家送出的思辨題答案都會顯示在「小讀者觀點大集合」頁面喔～`
           : '登入帳號完成閱讀設定，還可以挑戰更多隱藏版的思辨題唷！',
         cancelText: '跳過',
         confirmText: isLogin ? '完成閱讀設定' : '立即登入',
         confirmAction: () => {
-          router.push(isLogin ? '/idea-hub' : '/login')
+          if (isLogin) {
+            window.open('/idea-hub', '_blank')
+          } else {
+            router.push('/login')
+          }
         },
       })
     },


### PR DESCRIPTION
## Summary

This PR updates the dialog wording to clarify where readers' answers are displayed and changes the confirm button behavior to open the idea hub page in a new tab when users are logged in.

## Changes

- Updated dialog content wording from "大家送出的思辨題答案都會顯示在這裡喔～" to "大家送出的思辨題答案都會顯示在「小讀者觀點大集合」頁面喔～" to provide clearer information about where answers are displayed
- Modified confirm action to use `window.open('/idea-hub', '_blank')` instead of `router.push('/idea-hub')` when user is logged in, allowing users to view the idea hub in a new tab while keeping the current article page open
- Login flow remains unchanged (still uses `router.push('/login')`)

## Additional Notes

This change improves user experience by allowing logged-in users to explore the idea hub without losing their place in the current article.

## Screenshot(s)

## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/defect-2ab8dbdca93280c99aaded5267ada070?v=1588dbdca93281dfa43c000c8415265e&source=copy_link)