### PR TITLE
fix(frontend): refactor login URL handling and improve login prompt wording

### DIFF
--- a/packages/frontend/src/app/(sticky-header)/_components/article/article.tsx
+++ b/packages/frontend/src/app/(sticky-header)/_components/article/article.tsx
@@ -33,6 +33,7 @@ import {
   QAModalEvent,
 } from '@/services/call-baodaozai'
 import { getPostSummaries } from '@/utils'
+import getLoginUrl from '@/utils/get-login-url'
 
 import ArticleBaodaozaiEventTrigger from './article-baodaozai-event-trigger'
 import { ArticleContext } from './article-context'
@@ -366,12 +367,12 @@ const Article = ({
 大家送出的思辨題答案都會顯示在「小讀者觀點大集合」頁面喔～`
           : '登入帳號完成閱讀設定，還可以挑戰更多隱藏版的思辨題唷！',
         cancelText: '跳過',
-        confirmText: isLogin ? '完成閱讀設定' : '立即登入',
+        confirmText: isLogin ? '立即前往' : '立即登入',
         confirmAction: () => {
           if (isLogin) {
             window.open('/idea-hub', '_blank')
           } else {
-            router.push('/login')
+            router.push(getLoginUrl())
           }
         },
       })

--- a/packages/frontend/src/components/auth-header-logged-in-setter.tsx
+++ b/packages/frontend/src/components/auth-header-logged-in-setter.tsx
@@ -1,15 +1,16 @@
 'use client'
 
 import { HeaderIsLoggedInSetter } from '@kids-reporter/routing-ui'
+import { useMemo } from 'react'
 
-import envVars from '@/environment-variables'
 import { useHydratedAuthStore } from '@/services/auth/use-hydrated-auth-store'
+import getLoginUrl from '@/utils/get-login-url'
 
 function AuthHeaderLoggedInSetter() {
   const { member } = useHydratedAuthStore()
   const isLoggedIn = !!member
 
-  const loginUrl = `${envVars.loginUrl}?destination=${typeof window !== 'undefined' ? encodeURIComponent(window.location.href) : ''}`
+  const loginUrl = useMemo(() => getLoginUrl(), [])
 
   return <HeaderIsLoggedInSetter isLoggedIn={isLoggedIn} loginUrl={loginUrl} />
 }

--- a/packages/frontend/src/utils/get-login-url.ts
+++ b/packages/frontend/src/utils/get-login-url.ts
@@ -1,0 +1,7 @@
+import envVars from '@/environment-variables'
+
+const getLoginUrl = () => {
+  return `${envVars.loginUrl}?destination=${typeof window !== 'undefined' ? encodeURIComponent(window.location.href) : ''}`
+}
+
+export default getLoginUrl


### PR DESCRIPTION
## Summary

This PR refactors login URL handling by centralizing the logic into a reusable utility function. It ensures that the destination parameter is consistently included when redirecting users to the login page, allowing them to return to their original page after authentication. Additionally, it improves the wording of the login prompt button text for better user experience.

## Changes

- Created new utility function `get-login-url.ts` to centralize login URL generation with destination parameter
- Updated `article.tsx` to use the new `getLoginUrl()` utility function instead of hardcoded `/login` path
- Changed login prompt button text from "完成閱讀設定" to "立即前往" when user is already logged in
- Refactored `auth-header-logged-in-setter.tsx` to use the centralized `getLoginUrl()` utility function with `useMemo` for optimization
- Removed duplicate login URL construction logic from `auth-header-logged-in-setter.tsx`

## Additional Notes

This change ensures that users are properly redirected back to their original page (including the current article page) after completing the login process, improving the overall user experience when interacting with baodaozai questions.

## Screenshot(s)

## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/defect-2ab8dbdca93280c99aaded5267ada070?v=1588dbdca93281dfa43c000c8415265e&source=copy_link)