### PR TITLE
chore(ci): add GitHub Actions for type check, format, and lint

### DIFF
--- a/.github/actions/setup-and-install/action.yml
+++ b/.github/actions/setup-and-install/action.yml
@@ -1,0 +1,53 @@
+name: 'Setup and Install Dependencies'
+description: 'Setup Node.js, Yarn, cache dependencies and build artifacts, then install dependencies'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Enable Corepack
+      run: corepack enable
+      shell: bash
+
+    - name: Setup Yarn
+      run: corepack prepare yarn@4.9.4 --activate
+      shell: bash
+
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Cache dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          node_modules
+          **/node_modules
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    - name: Cache build artifacts
+      uses: actions/cache@v4
+      with:
+        path: |
+          packages/**/lib
+          packages/**/dist
+          packages/**/__generated__
+          packages/**/*.tsbuildinfo
+          **/*.tsbuildinfo
+        key: ${{ runner.os }}-build-${{ hashFiles('packages/cms/schema.graphql', 'packages/frontend/codegen.ts', 'packages/frontend/src/api/graphql/**/*.ts', 'packages/routing-ui/scripts/build.sh', 'packages/routing-ui/src/**/*', 'packages/core/src/**/*', 'packages/core/tsconfig.json', 'packages/draft-editor/src/**/*', 'packages/draft-editor/tsconfig.json', 'packages/draft-renderer/src/**/*', 'packages/draft-renderer/tsconfig.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-
+
+    - name: Install dependencies
+      run: yarn install --immutable
+      env:
+        SKIP_PATCH_PACKAGE: 'true'
+      shell: bash

--- a/.github/actions/setup-and-install/action.yml
+++ b/.github/actions/setup-and-install/action.yml
@@ -42,7 +42,7 @@ runs:
           packages/**/__generated__
           packages/**/*.tsbuildinfo
           **/*.tsbuildinfo
-        key: ${{ runner.os }}-build-${{ hashFiles('packages/cms/schema.graphql', 'packages/frontend/codegen.ts', 'packages/frontend/src/api/graphql/**/*.ts', 'packages/routing-ui/scripts/build.sh', 'packages/routing-ui/src/**/*', 'packages/core/src/**/*', 'packages/core/tsconfig.json', 'packages/draft-editor/src/**/*', 'packages/draft-editor/tsconfig.json', 'packages/draft-renderer/src/**/*', 'packages/draft-renderer/tsconfig.json') }}
+        key: ${{ runner.os }}-build-${{ hashFiles('packages/*/package.json','packages/*/tsconfig.json','packages/cms/schema.graphql','packages/frontend/codegen.ts','packages/frontend/src/api/graphql/**/*.ts','packages/routing-ui/scripts/build.sh','packages/routing-ui/src/index.ts','packages/core/src/index.ts','packages/draft-editor/src/index.ts','packages/draft-renderer/src/index.ts') }}
         restore-keys: |
           ${{ runner.os }}-build-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
   pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   type-check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  type-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup and install
+        uses: ./.github/actions/setup-and-install
+
+      - name: Type check
+        run: yarn type-check
+
+  format-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup and install
+        uses: ./.github/actions/setup-and-install
+
+      - name: Format check
+        run: yarn format:check
+
+  lint-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup and install
+        uses: ./.github/actions/setup-and-install
+
+      - name: Lint check
+        run: yarn lint:check

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,7 @@ node_modules/
 # IDE
 .vscode/
 .cursor/
+
+# generated files
+schema.graphql
+schema.prisma

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # kids-reporter-monorepo
 
 ### Monorepo setup
+
 This is a monorepo containing sub-packages:
+
 - [@kids-reporter/api-gateway](./packages/api-gateway): see `packages/api-gateway`
 - [@kids-reporter/draft-renderer](./packages/draft-renderer): see `packages/draft-renderer`
 - [@kids-reporter/draft-editor](./packages/draft-editor): see `packages/draft-editor`
@@ -10,33 +12,39 @@ This is a monorepo containing sub-packages:
 - [@kids-reporter/frontend](./packages/frontend): see `packages/frontend`
 - [@kids-reporter/cronjob-rss-feed](./packages/cronjob-rss-feed): see `packages/cronjob-rss-feed`
 
-This monorepo adopts `husky`, `lint-staged` and `yarn workspaces`. 
-`husky` and `lint-staged` will 
+This monorepo adopts `husky`, `lint-staged` and `yarn workspaces`.
+`husky` and `lint-staged` will
+
 1. run eslint for needed sub-packages before `git commit`
 
 `yarn workspaces` will install dependencies of all the sub-packages wisely and effienciently.
 
 ### Development
-Before modifying sub-packages' source codes, make sure you install dependencies on root. 
+
+Before modifying sub-packages' source codes, make sure you install dependencies on root.
 We need `husky` and `lint-staged` installed first.
 
 ### Installation
+
 - Corepack (Yarn v4): ensure Node 20 and run `corepack enable` once on your machine.
 - Install deps: `yarn install` (Berry config enforces immutable installs by default).
 - CI/Docker: use `yarn install --immutable` to prevent lockfile drift.
 
 ### Yarn v4 (Berry) Notes
+
 - This repo uses Yarn v4 with node_modules (`.yarnrc.yml` sets `nodeLinker: node-modules`).
 - Yarn is pinned via `packageManager` in `package.json` and resolved by Corepack.
 - Subpackage Docker builds copy `.yarnrc.yml` and enable Corepack in the image.
 
 ### 如何在 workspaces 中新增 subpkg？
+
 新增 subpkg 的 convention 是在 `${root}/packages/` 底下新增資料夾和檔案，
 並且在 root 的 packages.json#workspaces 的 array 中新增 `"packages/${subpkg}"`。
 
 若在同一個 monorepo 中的 subpkgs 之間有相依性，例如：`@kids-reporter/cms` 依賴 `@kids-reporter/cms-core`，而 `@kids-reporter/core` 依賴 `@kids-reporter/draft-editor`，workspaces 能讓你在 local 端使用 soft link 的方式連結到其他的 subpkgs 去；但要注意你在 packages.json 的 dependencies 裡標示的 name 和 version 要正確。
 
 例如：
+
 ```
 // in packages/cms/package.json
 
@@ -55,7 +63,9 @@ We need `husky` and `lint-staged` installed first.
 如此一來，就可以在 local 端一次開發多個 subpkgs。
 
 ### 如何update subpkg version
+
 使用@changeset/cli來update版號, ex:
+
 ```
 yarn update
 
@@ -65,6 +75,7 @@ yarn changeset && yarn changeset version
 ```
 
 ### Troubleshootings
+
 #### Q1: 我在 root 資料夾底下跑 `yarn install` 時，在 `yarn postinstall` 階段發生錯誤。
 
 A1: 如果錯誤訊息與 `@kids-reporter/(draft-editor|draft-renderer|cms-core|)` 有關，可以嘗試先到 `packages/(draft-editor|draft-renderer|core)` 底下，執行 `yarn build`。

--- a/packages/api-gateway/README.md
+++ b/packages/api-gateway/README.md
@@ -49,7 +49,7 @@ $ yarn start
 **如何使用 `--override` flag：**
 
 若需讓 dotenv 覆寫現有的 shell 環境變數，可在執行 make 指令時加上 `DOTENV_FLAGS="--override"`，例如：
+
 ```
 $ DOTENV_FLAGS="--override" make dev
 ```
-

--- a/packages/cms/.prettierignore
+++ b/packages/cms/.prettierignore
@@ -6,4 +6,3 @@ dist/
 
 # Generated files
 .keystone/
-schema.graphql

--- a/packages/cms/Makefile
+++ b/packages/cms/Makefile
@@ -5,9 +5,19 @@ help:
 	@echo "$(p) make postinstall - run after dependencies installation"
 
 postinstall: build-deps
-	@yarn patch-package;
-	@yarn keystone postinstall --fix;
-	@yarn patch-package;
+	@if [ "$(SKIP_PATCH_PACKAGE)" = "true" ]; then \
+		echo "Patch package skipped."; \
+	else \
+		echo "$(P) patch package"; \
+		yarn patch-package; \
+	fi
+	@yarn keystone build --no-ui;
+	@if [ "$(SKIP_PATCH_PACKAGE)" = "true" ]; then \
+		echo "Patch package skipped."; \
+	else \
+		echo "$(P) patch package"; \
+		yarn patch-package; \
+	fi
 
 build-deps:
 	@if [ "$(SKIP_BUILD_DEPS)" = "true" ]; then \

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -8,7 +8,7 @@
     "db-migrate": "keystone prisma migrate deploy",
     "build": "keystone build",
     "lint:check": "eslint . --ext .ts,.tsx,.js,.jsx",
-    "postinstall": "bash -c 'SKIP_BUILD_DEPS=\"${SKIP_BUILD_DEPS:-}\" make postinstall'",
+    "postinstall": "bash -c 'SKIP_BUILD_DEPS=\"${SKIP_BUILD_DEPS:-}\" SKIP_PATCH_PACKAGE=\"${SKIP_PATCH_PACKAGE:-}\" make postinstall'",
     "type-check": "tsc --noEmit"
   },
   "repository": {

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -7,12 +7,4 @@ export default {
   trailingComma: 'es5',
   bracketSpacing: true,
   arrowParens: 'always',
-  overrides: [
-    {
-      files: '*.graphql',
-      options: {
-        tabWidth: 2,
-      },
-    },
-  ],
 }


### PR DESCRIPTION
## Summary

This PR introduces GitHub Actions CI workflow to automatically run type checking, format checking, and linting on every push and pull request. The implementation includes a reusable composite action for dependency setup and installation with intelligent caching to optimize CI build times.

## Changes

- **Added GitHub Actions CI workflow** (`.github/workflows/ci.yml`): Creates three parallel jobs that run on every push and PR:
  - `type-check`: Validates TypeScript types across all packages
  - `format-check`: Ensures code formatting consistency using Prettier
  - `lint-check`: Runs ESLint checks across all packages

- **Created reusable composite action** (`.github/actions/setup-and-install/action.yml`): A centralized action that:
  - Sets up Node.js 20 and Yarn 4.9.4 via Corepack
  - Implements intelligent caching for dependencies (`node_modules`, yarn cache) and build artifacts (`lib`, `dist`, `__generated__`, `*.tsbuildinfo`)
  - Installs dependencies with `yarn install --immutable` and `SKIP_PATCH_PACKAGE=true` to speed up CI builds

- **Updated CMS package configuration**:
  - Modified `packages/cms/Makefile` to support `SKIP_PATCH_PACKAGE` environment variable, allowing CI to skip patch-package steps
  - Changed `keystone postinstall --fix` to `keystone build --no-ui` for more explicit build control
  - Updated `packages/cms/package.json` to pass `SKIP_PATCH_PACKAGE` to the postinstall script

- **Consolidated Prettier ignore patterns**: Moved `schema.graphql` and `schema.prisma` to root `.prettierignore` and removed duplicate entry from `packages/cms/.prettierignore`

- **Improved README formatting**: Added blank lines for better readability in markdown sections

- **Minor formatting fix**: Fixed trailing newline in `packages/api-gateway/README.md`

## Additional Notes

- The CI workflow runs all three checks in parallel to minimize total execution time
- Build artifact caching is based on source file hashes to ensure cache invalidation when relevant files change
- The `SKIP_PATCH_PACKAGE` flag is used in CI to avoid unnecessary patch application during dependency installation
- All jobs use the same setup action, ensuring consistency across CI runs

## Screenshot(s)

- [Result](https://github.com/ericsen-tsai/kids-reporter-monorepo/actions/runs/19564462183)

<img width="1623" height="804" alt="image" src="https://github.com/user-attachments/assets/c09a62ce-3547-4b08-a762-bc86c9f95fcf" />

## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/Github-Actions-for-types-check-format-and-lint-2b28dbdca932803db1a2fa79dd2623a9)
- [Keystone Document](https://keystonejs.com/docs/guides/cli#fixing-validation-errors)