### PR TITLE
fix(frontend,cms): handle invalid date parsing in search results

### DIFF
--- a/packages/cms/graphql/extend-schema.ts
+++ b/packages/cms/graphql/extend-schema.ts
@@ -315,8 +315,6 @@ export const extendGraphqlSchema = graphql.extend(() => {
               })
             }
 
-            console.log({ _err })
-
             console.log(
               JSON.stringify({
                 severity: 'ERROR',

--- a/packages/cms/graphql/extend-schema.ts
+++ b/packages/cms/graphql/extend-schema.ts
@@ -271,14 +271,17 @@ export const extendGraphqlSchema = graphql.extend(() => {
               )
               ?.map((item: any) => {
                 const metaTag = item?.pagemap?.metatags?.[0]
-                const publishedDate = new Date(
+                const publishedDateObj = new Date(
                   item?.snippet
                     ?.split('...')?.[0]
                     .trim()
                     .replace('年', '-')
                     .replace('月', '-')
                     .replace('日', '')
-                ).toISOString()
+                )
+                const publishedDate = isNaN(publishedDateObj.getTime())
+                  ? null
+                  : publishedDateObj.toISOString()
 
                 return {
                   src: item.link,
@@ -311,6 +314,8 @@ export const extendGraphqlSchema = graphql.extend(() => {
                 withPayload: true,
               })
             }
+
+            console.log({ _err })
 
             console.log(
               JSON.stringify({

--- a/packages/frontend/src/components/article-card.tsx
+++ b/packages/frontend/src/components/article-card.tsx
@@ -41,7 +41,7 @@ function ArticleCard({ article, showOverImageCover = false }: ArticleCardProp) {
           </div>
         </div>
 
-        <div className="flex min-w-0 flex-1 flex-col gap-2">
+        <div className="grid min-w-0 flex-1 grid-rows-1 gap-2">
           <div className="flex items-center justify-between gap-4">
             {hasCategoryOrSubcategory && (
               <span className="inline-flex items-center rounded-full bg-neutral-200 px-3 py-1 prose-p3-bold text-neutral-900">


### PR DESCRIPTION
## Summary

This PR fixes date parsing issues in the search functionality that were causing errors when invalid or unparseable date strings were encountered. The changes include validation logic in the CMS GraphQL schema to safely handle date parsing failures, and a frontend layout adjustment to gracefully handle empty published dates.

## Changes

- **packages/cms/graphql/extend-schema.ts**: Added validation to check if parsed date is valid before converting to ISO string. Returns `null` instead of throwing an error when date parsing fails, preventing the entire search operation from crashing.
- **packages/frontend/src/components/article-card.tsx**: Changed layout from `flex flex-col` to `grid grid-rows-1` to better handle cases where `publishedDate` is `null` or empty, preventing layout issues.

## Additional Notes

- The date parsing logic now safely handles cases where the snippet date format cannot be parsed (e.g., malformed date strings, missing date information).
- When a date cannot be parsed, `publishedDate` is set to `null`, which is then handled gracefully by the frontend's `getFormattedDate` utility function (returns empty string).
- A debug `console.log` was added in the error handler for troubleshooting purposes.

## Screenshot(s)

<img width="1177" height="495" alt="image" src="https://github.com/user-attachments/assets/50aef359-8539-46f8-9cba-0a01b1b0e291" />


## Reference(s)
- [Notion Page](https://www.notion.so/twreporter/Defect-CMS-2b58dbdca93280ce8f3fcce5b43a21f0?v=1588dbdca93281dfa43c000c8415265e&source=copy_link)
