### PR TITLE
fix(cms,frontend): improve member list view and fix avatar URL initialization

### DIFF
--- a/packages/cms/lists/member.ts
+++ b/packages/cms/lists/member.ts
@@ -33,7 +33,7 @@ export default list<ListType<'Member'>>({
       label: '聯絡信箱',
     }),
     twreporter_user_id: text({
-      label: 'membership_user.users.id',
+      label: 'TWReporter Membership ID',
       validation: { isRequired: true },
       isIndexed: 'unique',
       ui: {
@@ -44,7 +44,7 @@ export default list<ListType<'Member'>>({
           fieldMode: 'read',
         },
         listView: {
-          fieldMode: 'hidden',
+          fieldMode: 'read',
         },
       },
       access: {
@@ -115,7 +115,7 @@ export default list<ListType<'Member'>>({
   },
   ui: {
     listView: {
-      initialColumns: ['id', 'name', 'email'],
+      initialColumns: ['id', 'twreporter_user_id', 'name', 'email'],
     },
   },
   db: {

--- a/packages/frontend/src/modules/membership/account/index.tsx
+++ b/packages/frontend/src/modules/membership/account/index.tsx
@@ -41,7 +41,7 @@ function Account() {
       name: member?.name ?? '',
       nickname: member?.nickname ?? '',
       contactEmail: member?.contactEmail ?? '',
-      avatarUrl: member?.avatar?.url,
+      ...(member?.avatar?.url ? { avatarUrl: member.avatar.url } : {}),
     }
   }, [member])
 


### PR DESCRIPTION
## Summary

This PR improves the member management experience in the CMS by making the TWReporter Membership ID visible in the list view, and fixes a potential form initialization issue in the frontend account page where undefined avatar URLs could cause validation problems.

## Changes

- **CMS Member List** (`packages/cms/lists/member.ts`):
  - Changed `twreporter_user_id` label from translation key `'membership_user.users.id'` to readable label `'TWReporter Membership ID'`
  - Changed `twreporter_user_id` list view field mode from `'hidden'` to `'read'` to make it visible in the member list
  - Added `'twreporter_user_id'` to the `initialColumns` array in the list view configuration

- **Frontend Account Page** (`packages/frontend/src/modules/membership/account/index.tsx`):
  - Fixed avatar URL initialization in form default values to conditionally include `avatarUrl` only when `member?.avatar?.url` exists, preventing undefined values that could cause form validation issues

## Additional Notes

The changes improve the usability of the CMS member list by making the TWReporter Membership ID easily accessible for administrators. The frontend fix ensures that the account form initializes correctly even when a member doesn't have an avatar set.

## Screenshot(s)
gh pr create --base ndx --repo kids-reporter/kids-reporter-monorepo --head ericsen-tsai:fix/member-issue --title "fix(cms): improve member list view and fix avatar URL initialization" --body "## Summary

This PR improves the member management experience in the CMS by making the TWReporter Membership ID visible in the list view, and fixes a potential form initialization issue in the frontend account page where undefined avatar URLs could cause validation problems.

## Changes

- **CMS Member List** (\`packages/cms/lists/member.ts\`):
  - Changed \`twreporter_user_id\` label from translation key \`'membership_user.users.id'\` to readable label \`'TWReporter Membership ID'\`
  - Changed \`twreporter_user_id\` list view field mode from \`'hidden'\` to \`'read'\` to make it visible in the member list
  - Added \`'twreporter_user_id'\` to the \`initialColumns\` array in the list view configuration

- **Frontend Account Page** (\`packages/frontend/src/modules/membership/account/index.tsx\`):
  - Fixed avatar URL initialization in form default values to conditionally include \`avatarUrl\` only when \`member?.avatar?.url\` exists, preventing undefined values that could cause form validation issues

## Additional Notes

The changes improve the usability of the CMS member list by making the TWReporter Membership ID easily accessible for administrators. The frontend fix ensures that the account form initializes correctly even when a member doesn't have an avatar set.

## Screenshot(s)

<img width="1649" height="1009" alt="Screenshot 2025-11-26 at 11 47 15 AM" src="https://github.com/user-attachments/assets/530c4515-bafb-4ef6-b05a-d761a848dad7" />

https://github.com/user-attachments/assets/241187d9-e146-40f8-98ed-02f5aa38911f



## Reference(s)

