### PR TITLE
feat(frontend): add login iframe route

### DIFF
--- a/packages/frontend/.env.dev.public
+++ b/packages/frontend/.env.dev.public
@@ -1,1 +1,12 @@
 NEXT_PUBLIC_GQL_ENDPOINT=https://dev-kids-api.twreporter.org/api/graphql
+NEXT_PUBLIC_API_GATEWAY_ENDPOINT=https://dev-kids.twreporter.org/api-gateway
+NEXT_PUBLIC_BASE_URL=https://dev-kids.twreporter.org
+
+# Release Env
+NEXT_PUBLIC_RELEASE_ENV=dev
+
+# Login Url
+NEXT_PUBLIC_LOGIN_URL=/login
+
+# Login Widget Url
+NEXT_PUBLIC_LOGIN_WIDGET_URL=https://staging-accounts.twreporter.org/signin-widget

--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -16,4 +16,7 @@ SEARCH_API_KEY=search-api-key
 SEARCH_ENGINE_ID=search-engine-id
 
 # Login Url
-NEXT_PUBLIC_LOGIN_URL=https://staging-accounts.twreporter.org
+NEXT_PUBLIC_LOGIN_URL=/login
+
+# Login Widget Url
+NEXT_PUBLIC_LOGIN_WIDGET_URL=https://accounts.twreporter.org/signin-widget

--- a/packages/frontend/.env.ndx.public
+++ b/packages/frontend/.env.ndx.public
@@ -1,4 +1,12 @@
 NEXT_PUBLIC_GQL_ENDPOINT=https://ndx-kids.twreporter.org/api-gateway/api/graphql
 NEXT_PUBLIC_API_GATEWAY_ENDPOINT=https://ndx-kids.twreporter.org/api-gateway
 NEXT_PUBLIC_BASE_URL=https://ndx-kids.twreporter.org
-NEXT_PUBLIC_LOGIN_URL=https://staging-accounts.twreporter.org
+
+# Release Env
+NEXT_PUBLIC_RELEASE_ENV=ndx
+
+# Login Url
+NEXT_PUBLIC_LOGIN_URL=/login
+
+# Login Widget Url
+NEXT_PUBLIC_LOGIN_WIDGET_URL=https://staging-accounts.twreporter.org/signin-widget

--- a/packages/frontend/.env.prod.public
+++ b/packages/frontend/.env.prod.public
@@ -1,2 +1,12 @@
 NEXT_PUBLIC_GQL_ENDPOINT=https://kids-api.twreporter.org/api/graphql
+NEXT_PUBLIC_API_GATEWAY_ENDPOINT=https://kids-api.twreporter.org
+NEXT_PUBLIC_BASE_URL=https://kids.twreporter.org
+
+# Release Env
 NEXT_PUBLIC_RELEASE_ENV=prod
+
+# Login Url
+NEXT_PUBLIC_LOGIN_URL=/login
+
+# Login Widget Url
+NEXT_PUBLIC_LOGIN_WIDGET_URL=https://accounts.twreporter.org/signin-widget

--- a/packages/frontend/.env.staging.public
+++ b/packages/frontend/.env.staging.public
@@ -1,1 +1,12 @@
 NEXT_PUBLIC_GQL_ENDPOINT=https://staging-kids-api.twreporter.org/api/graphql
+NEXT_PUBLIC_API_GATEWAY_ENDPOINT=https://staging-kids.twreporter.org/api-gateway
+NEXT_PUBLIC_BASE_URL=https://staging-kids.twreporter.org
+
+# Release Env
+NEXT_PUBLIC_RELEASE_ENV=staging
+
+# Login Url
+NEXT_PUBLIC_LOGIN_URL=/login
+
+# Login Widget Url
+NEXT_PUBLIC_LOGIN_WIDGET_URL=https://staging-accounts.twreporter.org/signin-widget

--- a/packages/frontend/src/app/(sticky-header)/login/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/login/page.tsx
@@ -1,0 +1,24 @@
+import envVars from '@/environment-variables'
+
+export default async function Login({
+  searchParams,
+}: {
+  searchParams: {
+    destination?: string
+  }
+}) {
+  const destination = searchParams.destination
+    ? searchParams.destination
+    : 'https://kids.twreporter.org'
+
+  const iframeSrc = `${envVars.loginWidgetUrl}?destination=${encodeURIComponent(destination)}`
+
+  return (
+    <iframe
+      className="h-screen w-full"
+      src={iframeSrc}
+      title="Login widget"
+      allow="clipboard-read; clipboard-write"
+    />
+  )
+}

--- a/packages/frontend/src/app/(sticky-header)/login/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/login/page.tsx
@@ -1,5 +1,33 @@
 import envVars from '@/environment-variables'
 
+const defaultDestination = 'https://kids.twreporter.org'
+const allowedDestinationOrigins = new Set([
+  'https://kids.twreporter.org',
+  'https://dev-kids.twreporter.org',
+  'https://ndx-kids.twreporter.org',
+  'https://staging-kids.twreporter.org',
+  ...(envVars.nodeEnv === 'development'
+    ? ['http://localhost:3000', 'http://localhost:3001']
+    : []),
+])
+
+function sanitizeDestination(rawDestination?: string) {
+  if (!rawDestination) {
+    return defaultDestination
+  }
+
+  try {
+    const parsed = new URL(rawDestination)
+    if (allowedDestinationOrigins.has(parsed.origin)) {
+      return parsed.toString()
+    }
+  } catch {
+    // fall through to default destination
+  }
+
+  return defaultDestination
+}
+
 export default async function Login({
   searchParams,
 }: {
@@ -7,10 +35,7 @@ export default async function Login({
     destination?: string
   }
 }) {
-  const destination = searchParams.destination
-    ? searchParams.destination
-    : 'https://kids.twreporter.org'
-
+  const destination = sanitizeDestination(searchParams.destination)
   const iframeSrc = `${envVars.loginWidgetUrl}?destination=${encodeURIComponent(destination)}`
 
   return (

--- a/packages/frontend/src/environment-variables.ts
+++ b/packages/frontend/src/environment-variables.ts
@@ -12,6 +12,9 @@ const searchEngineID = process.env.SEARCH_ENGINE_ID || ''
 const mockIdToken = process.env.MOCK_ID_TOKEN || ''
 
 const loginUrl = process.env.NEXT_PUBLIC_LOGIN_URL || '/login'
+const loginWidgetUrl =
+  process.env.NEXT_PUBLIC_LOGIN_WIDGET_URL ||
+  'https://accounts.twreporter.org/signin-widget'
 
 const environmentVariables = {
   internalGqlEndpoint,
@@ -22,6 +25,7 @@ const environmentVariables = {
   searchEngineID,
   mockIdToken,
   loginUrl,
+  loginWidgetUrl,
 }
 
 export default environmentVariables

--- a/packages/frontend/src/environment-variables.ts
+++ b/packages/frontend/src/environment-variables.ts
@@ -16,6 +16,8 @@ const loginWidgetUrl =
   process.env.NEXT_PUBLIC_LOGIN_WIDGET_URL ||
   'https://accounts.twreporter.org/signin-widget'
 
+const nodeEnv = process.env.NODE_ENV
+
 const environmentVariables = {
   internalGqlEndpoint,
   gqlEndpoint,
@@ -26,6 +28,7 @@ const environmentVariables = {
   mockIdToken,
   loginUrl,
   loginWidgetUrl,
+  nodeEnv,
 }
 
 export default environmentVariables


### PR DESCRIPTION
## Summary: 
Introduce a dedicated login route that renders the external signin widget inside an iframe while wiring through the environment configuration needed by the frontend.

## Changes:
- update .env.example with the new NEXT_PUBLIC_LOGIN_WIDGET_URL and align NEXT_PUBLIC_LOGIN_URL with the signin route.
- expose loginWidgetUrl via src/environment-variables.ts so code can reference the iframe target.
- add src/app/(sticky-header)/login/page.tsx, which renders the login widget iframe and preserves any destination query parameter.

## Additional Notes:
The iframe defaults to https://accounts.twreporter.org/signin-widget when the env var isn’t set, and the login route now defaults to /login.
 
## Related PR(s): 
Both this PR and twreporter/membership-fe#1162 add iframe-friendly signin flows. Our frontend exposes the widget URL + /login route while the membership repo adds the signinWidget/registerWidget routes and widget logic that strips layout and preserves destinations.

## Reference(s):
https://www.notion.so/twreporter/Accounts-2738dbdca93280bc9ed7e52043683701