### PR TITLE
refactor(cms): persist essay answer likes count

### DIFF
--- a/packages/cms/lists/post-essay-answer-like.ts
+++ b/packages/cms/lists/post-essay-answer-like.ts
@@ -1,5 +1,6 @@
 import { list } from '@keystone-6/core'
 import { relationship, text, timestamp } from '@keystone-6/core/fields'
+import { GraphQLError } from 'graphql'
 
 import type { ListType } from '../types/keystone-list-types'
 import { allowRoles, RoleEnum } from './utils/access-control-list'
@@ -129,6 +130,76 @@ export default list<ListType<'PostEssayAnswerLike'>>({
       }
 
       return resolvedData
+    },
+    afterOperation: async ({
+      operation,
+      item,
+      originalItem,
+      resolvedData,
+      context,
+    }) => {
+      const assertExecuteSucceeded = (result: unknown) => {
+        // NOTE: Keystone v6 wraps Prisma calls and can return a GraphQLError
+        // instead of throwing (see keystonejs/keystone#9250). Until v6 pulls in
+        // PR #9476, explicitly detect GraphQLError so the afterOperation surfaces
+        // an actionable exception.
+        if (result instanceof GraphQLError) {
+          const debugInfo = result.extensions?.debug as
+            | { message?: string }
+            | undefined
+          const errorMsg =
+            debugInfo?.message?.trim() ??
+            `Unknown error during likesCount update (op=${operation}, answerId=${item?.answerId ?? originalItem?.answerId ?? 'n/a'})`
+
+          // TODO: throw and also enqueue a PubSub message to retry computing likesCount.
+          throw new Error(
+            `Update PostEssayAnswer failed with the following errors: ${errorMsg}`
+          )
+        }
+      }
+
+      const incrementLikesCount = async (answerId?: number | string | null) => {
+        if (!answerId) return
+        // Atomic row update in Postgres to avoid race conditions on concurrent likes
+        const result = await context.prisma
+          .$executeRaw`UPDATE "PostEssayAnswer" SET "likesCount" = "likesCount" + 1 WHERE "id" = ${Number(answerId)}`
+        assertExecuteSucceeded(result)
+      }
+
+      const decrementLikesCount = async (answerId?: number | string | null) => {
+        if (!answerId) return
+        // Atomic row update in Postgres to avoid race conditions on concurrent unlikes
+        const result = await context.prisma
+          .$executeRaw`UPDATE "PostEssayAnswer" SET "likesCount" = "likesCount" - 1 WHERE "id" = ${Number(answerId)} AND "likesCount" > 0`
+        assertExecuteSucceeded(result)
+      }
+
+      if (operation === 'create') {
+        await incrementLikesCount(item?.answerId)
+        return
+      }
+
+      if (operation === 'delete') {
+        await decrementLikesCount(originalItem?.answerId)
+        return
+      }
+
+      if (operation === 'update') {
+        const answerConnectId = resolvedData.answer?.connect?.id
+        const disconnectValue = resolvedData.answer?.disconnect
+        const answerDisconnectId =
+          disconnectValue === true
+            ? (originalItem?.answerId ?? item?.answerId)
+            : undefined
+
+        // An update may both connect a new answer and disconnect the previous one;
+        // run increment/decrement in parallel without a transaction since each
+        // statement is atomic and Promise.all will surface any failure.
+        await Promise.all([
+          incrementLikesCount(answerConnectId),
+          decrementLikesCount(answerDisconnectId),
+        ])
+      }
     },
   },
 })

--- a/packages/cms/lists/post-essay-answer-like.ts
+++ b/packages/cms/lists/post-essay-answer-like.ts
@@ -30,7 +30,6 @@ export default list<ListType<'PostEssayAnswerLike'>>({
       graphql: {
         omit: {
           create: true,
-          update: true,
         },
       },
     }),
@@ -48,7 +47,6 @@ export default list<ListType<'PostEssayAnswerLike'>>({
       graphql: {
         omit: {
           create: true,
-          update: true,
         },
       },
       access: {
@@ -92,19 +90,22 @@ export default list<ListType<'PostEssayAnswerLike'>>({
     operation: {
       query: operationAccessControl,
       create: allowRoles([RoleEnum.Member]),
-      update: allowRoles([RoleEnum.Member]),
+      update: () => false,
       delete: operationAccessControl,
     },
     filter: {
       query: filterAccessControl,
-      update: filterAccessControl,
       delete: filterAccessControl,
+    },
+  },
+  graphql: {
+    omit: {
+      update: true,
     },
   },
   hooks: {
     resolveInput: async ({ resolvedData, item, context, operation }) => {
       const answerId = resolvedData.answer?.connect?.id ?? item?.answerId
-      const memberId = item?.memberId?.toString()
 
       const sessionMemberId = context.session?.data?.memberId?.toString()
 
@@ -119,10 +120,6 @@ export default list<ListType<'PostEssayAnswerLike'>>({
             id: sessionMemberId,
           },
         }
-      } else if (operation === 'update') {
-        if (sessionMemberId !== memberId) {
-          throw new Error('You cannot edit the like for another member.')
-        }
       }
 
       if (answerId) {
@@ -131,13 +128,7 @@ export default list<ListType<'PostEssayAnswerLike'>>({
 
       return resolvedData
     },
-    afterOperation: async ({
-      operation,
-      item,
-      originalItem,
-      resolvedData,
-      context,
-    }) => {
+    afterOperation: async ({ operation, item, originalItem, context }) => {
       const assertExecuteSucceeded = (result: unknown) => {
         // NOTE: Keystone v6 wraps Prisma calls and can return a GraphQLError
         // instead of throwing (see keystonejs/keystone#9250). Until v6 pulls in
@@ -182,23 +173,6 @@ export default list<ListType<'PostEssayAnswerLike'>>({
       if (operation === 'delete') {
         await decrementLikesCount(originalItem?.answerId)
         return
-      }
-
-      if (operation === 'update') {
-        const answerConnectId = resolvedData.answer?.connect?.id
-        const disconnectValue = resolvedData.answer?.disconnect
-        const answerDisconnectId =
-          disconnectValue === true
-            ? (originalItem?.answerId ?? item?.answerId)
-            : undefined
-
-        // An update may both connect a new answer and disconnect the previous one;
-        // run increment/decrement in parallel without a transaction since each
-        // statement is atomic and Promise.all will surface any failure.
-        await Promise.all([
-          incrementLikesCount(answerConnectId),
-          decrementLikesCount(answerDisconnectId),
-        ])
       }
     },
   },

--- a/packages/cms/lists/post-essay-answer.ts
+++ b/packages/cms/lists/post-essay-answer.ts
@@ -1,5 +1,5 @@
-import { graphql, list } from '@keystone-6/core'
-import { relationship, text, timestamp, virtual } from '@keystone-6/core/fields'
+import { list } from '@keystone-6/core'
+import { integer, relationship, text, timestamp } from '@keystone-6/core/fields'
 
 import type { ListType } from '../types/keystone-list-types'
 import { allowRoles, RoleEnum } from './utils/access-control-list'
@@ -41,24 +41,26 @@ export default list<ListType<'PostEssayAnswer'>>({
       label: '內容',
       validation: { isRequired: true },
     }),
-    likesCount: virtual({
-      field: graphql.field({
-        type: graphql.Int,
-        async resolve(item, args, context) {
-          const answerId = item.id
-
-          // Intentionally bypasses PostEssayAnswerLike list ACL via Prisma.
-          // Make sure this resolver already enforced authorization.
-          const count = await context.sudo().db.PostEssayAnswerLike.count({
-            where: { answer: { id: { equals: answerId.toString() } } },
-          })
-
-          return count ?? 0
-        },
-      }),
+    likesCount: integer({
+      label: '按讚數',
+      defaultValue: 0,
+      db: {
+        isNullable: false,
+      },
       ui: {
         itemView: { fieldMode: 'read' },
         listView: { fieldMode: 'read' },
+        createView: { fieldMode: 'hidden' },
+      },
+      graphql: {
+        omit: {
+          create: true,
+          update: true,
+        },
+      },
+      access: {
+        create: () => false,
+        update: () => false,
       },
     }),
     compositeKey: text({

--- a/packages/cms/migrations/20251201155420_add_likes_count_in_post_essay_answer/migration.sql
+++ b/packages/cms/migrations/20251201155420_add_likes_count_in_post_essay_answer/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "PostEssayAnswer" ADD COLUMN     "likesCount" INTEGER NOT NULL DEFAULT 0;

--- a/packages/cms/schema.graphql
+++ b/packages/cms/schema.graphql
@@ -2085,6 +2085,7 @@ input PostEssayAnswerWhereInput {
   question: PostEssayQuestionWhereInput
   member: MemberWhereInput
   content: StringFilter
+  likesCount: IntFilter
   compositeKey: StringNullableFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
@@ -2093,6 +2094,7 @@ input PostEssayAnswerWhereInput {
 input PostEssayAnswerOrderByInput {
   id: OrderDirection
   content: OrderDirection
+  likesCount: OrderDirection
   compositeKey: OrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection

--- a/packages/cms/schema.graphql
+++ b/packages/cms/schema.graphql
@@ -2217,23 +2217,6 @@ input PostEssayAnswerLikeOrderByInput {
   updatedAt: OrderDirection
 }
 
-input PostEssayAnswerLikeUpdateInput {
-  answer: PostEssayAnswerRelateToOneForUpdateInput
-  createdAt: DateTime
-  updatedAt: DateTime
-}
-
-input PostEssayAnswerRelateToOneForUpdateInput {
-  create: PostEssayAnswerCreateInput
-  connect: PostEssayAnswerWhereUniqueInput
-  disconnect: Boolean
-}
-
-input PostEssayAnswerLikeUpdateArgs {
-  where: PostEssayAnswerLikeWhereUniqueInput!
-  data: PostEssayAnswerLikeUpdateInput!
-}
-
 input PostEssayAnswerLikeCreateInput {
   answer: PostEssayAnswerRelateToOneForCreateInput
   createdAt: DateTime
@@ -2397,8 +2380,6 @@ type Mutation {
   deletePostEssayQuestions(where: [PostEssayQuestionWhereUniqueInput!]!): [PostEssayQuestion]
   createPostEssayAnswerLike(data: PostEssayAnswerLikeCreateInput!): PostEssayAnswerLike
   createPostEssayAnswerLikes(data: [PostEssayAnswerLikeCreateInput!]!): [PostEssayAnswerLike]
-  updatePostEssayAnswerLike(where: PostEssayAnswerLikeWhereUniqueInput!, data: PostEssayAnswerLikeUpdateInput!): PostEssayAnswerLike
-  updatePostEssayAnswerLikes(data: [PostEssayAnswerLikeUpdateArgs!]!): [PostEssayAnswerLike]
   deletePostEssayAnswerLike(where: PostEssayAnswerLikeWhereUniqueInput!): PostEssayAnswerLike
   deletePostEssayAnswerLikes(where: [PostEssayAnswerLikeWhereUniqueInput!]!): [PostEssayAnswerLike]
   endSession: Boolean!

--- a/packages/cms/schema.prisma
+++ b/packages/cms/schema.prisma
@@ -421,6 +421,7 @@ model PostEssayAnswer {
   member                          Member?               @relation("PostEssayAnswer_member", fields: [memberId], references: [id])
   memberId                        String?               @map("member")
   content                         String                @default("")
+  likesCount                      Int                   @default(0)
   compositeKey                    String?               @unique
   createdAt                       DateTime?             @default(now())
   updatedAt                       DateTime?             @updatedAt


### PR DESCRIPTION
## Summary
Persist likesCount as an integer field and sync counts through PostEssayAnswerLike hooks.

## Changes
- Replace virtual likesCount with an integer column and hide it from mutations
- Add afterOperation hook on PostEssayAnswerLike to atomically inc/dec counts via raw SQL with GraphQLError handling
- Add notes around atomic updates and transaction scope for to-one disconnect handling
- Prisma migration to add the likesCount column.

## Additional Notes
There is a TODO note in this PR. If the afterOperation hook fails to adjust counts, enqueue a PubSub message to recompute the latest likesCount so data stays in sync.