### PR TITLE
fix(frontend): enhance logout with cookie domain and error handling

### DIFF
--- a/packages/frontend/src/app/api/logout/route.ts
+++ b/packages/frontend/src/app/api/logout/route.ts
@@ -18,6 +18,8 @@ export async function POST() {
     maxAge: 0,
     expires: new Date(0),
     path: '/',
+    domain:
+      process.env.NODE_ENV === 'production' ? '.twreporter.org' : undefined,
   })
 
   return response

--- a/packages/frontend/src/services/auth/auth-store.ts
+++ b/packages/frontend/src/services/auth/auth-store.ts
@@ -267,11 +267,32 @@ export const useAuthStore = create<AuthState>()(
           })
         },
         async logout() {
-          await axios.post(LOGOUT_ENDPOINT, null, {
-            timeout: AXIOS_TIMEOUT,
-            withCredentials: true,
-          })
-          get().clearAuth()
+          set({ status: 'loading' })
+          try {
+            await axios.post(LOGOUT_ENDPOINT, null, {
+              timeout: AXIOS_TIMEOUT,
+              withCredentials: true,
+            })
+            get().clearAuth()
+          } catch (_err) {
+            const annotatedErr = errors.helpers.wrap(
+              _err,
+              'AuthStoreError',
+              'Error to logout'
+            )
+
+            const msg = errors.helpers.printAll(annotatedErr, {
+              withStack: true,
+              withPayload: true,
+            })
+
+            log(LogLevel.ERROR, msg)
+
+            set({
+              status: 'error',
+              error: '登出失敗，請稍後再試。',
+            })
+          }
         },
       }),
       {


### PR DESCRIPTION
## Summary

This PR enhances the logout functionality by fixing cookie domain handling in production and adding proper error handling with loading states. The changes ensure that logout works correctly across subdomains in production and provides better user feedback when logout operations fail.

## Changes

- **Cookie domain fix in logout route**: Added `domain` property to cookie settings in `packages/frontend/src/app/api/logout/route.ts`
  - Set domain to `.twreporter.org` in production environment
  - Set domain to `undefined` in development environment (to allow localhost testing)
- **Enhanced logout error handling**: Improved the `logout` function in `packages/frontend/src/services/auth/auth-store.ts`
  - Added loading state management (`status: 'loading'`) at the start of logout
  - Wrapped logout API call in try-catch block for error handling
  - Added error logging with full stack traces and payload information
  - Set error state with user-friendly error message (`登出失敗，請稍後再試。`) when logout fails

## Additional Notes

**Cookie Domain Issue**: When a cookie is set with a specific domain (e.g., `.twreporter.org`), it must also be cleared with the same domain. Without explicitly setting the domain when clearing the cookie, the browser may not properly remove it, leading to potential authentication state inconsistencies. This change ensures that logout properly clears the authentication cookie across all subdomains in production.

**Error Handling**: Previously, if the logout API call failed, the error would be silently ignored and the auth state might not be properly cleared. Now, errors are properly caught, logged for debugging purposes, and the user is informed with a clear error message. The loading state also provides better UX feedback during the logout process.

## Screenshot(s)

## Reference(s)

