### PR TITLE
fix(frontend): add 'logged_out' status handling in auth components

### DIFF
--- a/packages/frontend/src/modules/membership/components/auth-route-guard.tsx
+++ b/packages/frontend/src/modules/membership/components/auth-route-guard.tsx
@@ -14,14 +14,21 @@ function AuthRouteGuard({ children }: AuthRouteGuardProps) {
   const { hydrated, status, member } = useHydratedAuthStore()
   const router = useRouter()
 
-  const hasCheckedAuth = ['authenticated', 'unauthenticated', 'error'].includes(
-    status
-  )
+  const hasCheckedAuth = [
+    'authenticated',
+    'unauthenticated',
+    'error',
+    'logged_out',
+  ].includes(status)
 
   const isAuthenticating = !hydrated || !hasCheckedAuth
 
   useEffect(() => {
     if (isAuthenticating) {
+      return
+    }
+
+    if (status === 'logged_out') {
       return
     }
 
@@ -31,7 +38,11 @@ function AuthRouteGuard({ children }: AuthRouteGuardProps) {
     }
   }, [isAuthenticating, status, member, router])
 
-  if (isAuthenticating || status === 'unauthenticated') {
+  if (
+    isAuthenticating ||
+    status === 'unauthenticated' ||
+    status === 'logged_out'
+  ) {
     return (
       <div className="h-[calc(100dvh-var(--mobile-header-height))] w-full desktop:h-[calc(100dvh-var(--desktop-header-height))]"></div>
     )

--- a/packages/frontend/src/services/auth/auth-provider.tsx
+++ b/packages/frontend/src/services/auth/auth-provider.tsx
@@ -16,7 +16,7 @@ const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       return
     }
 
-    if (status === 'loading') {
+    if (status === 'loading' || status === 'logged_out') {
       return
     }
 

--- a/packages/frontend/src/services/auth/auth-store.ts
+++ b/packages/frontend/src/services/auth/auth-store.ts
@@ -47,6 +47,7 @@ type AuthStatus =
   | 'unauthenticated'
   | 'authenticated'
   | 'error'
+  | 'logged_out'
 
 type AuthState = {
   member?: MemberProfile
@@ -61,7 +62,7 @@ type AuthState = {
       tokens: AuthTokens
     }>
   ) => void
-  clearAuth: () => void
+  clearAuth: ({ nextStatus }: { nextStatus: AuthStatus }) => void
   logout: () => Promise<void>
 }
 
@@ -253,7 +254,7 @@ export const useAuthStore = create<AuthState>()(
             error: undefined,
           })
         },
-        clearAuth() {
+        clearAuth({ nextStatus = 'idle' }: { nextStatus: AuthStatus }) {
           // Abort any pending fetchMember request
           if (fetchMemberAbortController) {
             fetchMemberAbortController.abort()
@@ -262,7 +263,7 @@ export const useAuthStore = create<AuthState>()(
           set({
             member: undefined,
             tokens: undefined,
-            status: 'idle',
+            status: nextStatus,
             error: undefined,
           })
         },
@@ -273,7 +274,7 @@ export const useAuthStore = create<AuthState>()(
               timeout: AXIOS_TIMEOUT,
               withCredentials: true,
             })
-            get().clearAuth()
+            get().clearAuth({ nextStatus: 'logged_out' })
           } catch (_err) {
             const annotatedErr = errors.helpers.wrap(
               _err,


### PR DESCRIPTION
## Summary

This PR introduces a new `logged_out` authentication status and updates auth components to properly handle the logout state. Previously, after logout, the auth state would transition to `idle`, which could trigger unwanted redirects or re-authentication attempts. With this change, the system now explicitly tracks the logged-out state and prevents redirects or token exchanges during logout.

## Changes

- Added `logged_out` as a new `AuthStatus` type in `auth-store.ts`
- Modified `clearAuth` method to accept an optional `nextStatus` parameter, allowing callers to specify the desired status after clearing authentication
- Updated `logout` method to set status to `logged_out` after successful logout instead of defaulting to `idle`
- Updated `AuthRouteGuard` component to:
  - Include `logged_out` in the `hasCheckedAuth` check to prevent showing loading state
  - Add early return when status is `logged_out` to prevent redirects to login page
  - Show empty div (loading placeholder) when status is `logged_out` to maintain consistent UI
- Updated `AuthProvider` to prevent token exchange attempts when status is `logged_out`

## Additional Notes

This fix ensures a smoother logout experience by:
- Preventing unnecessary redirects to the login page immediately after logout
- Avoiding token exchange attempts when the user has explicitly logged out
- Maintaining consistent UI state during the logout transition

Potential considerations:
- The empty div shown during `logged_out` status maintains the same visual state as during authentication checks, which may be intentional to prevent layout shifts
- If there are other components that check auth status, they may need similar updates to handle the `logged_out` status appropriately

## Screenshot(s)

## Reference(s)

