### PR TITLE
fix(frontend): improve reading settings UI consistency and interaction states

### DIFF
--- a/packages/frontend/src/components/checkbox.tsx
+++ b/packages/frontend/src/components/checkbox.tsx
@@ -1,3 +1,5 @@
+import { cn } from '@kids-reporter/routing-ui'
+
 type CheckboxProps = {
   checked: boolean
   onChange: (value: string) => void
@@ -7,7 +9,7 @@ type CheckboxProps = {
 
 function Checkbox({ checked, onChange, label, value }: CheckboxProps) {
   return (
-    <label className="flex cursor-pointer items-center gap-2">
+    <label className="group flex cursor-pointer items-center gap-2">
       <input
         type="radio"
         value={value}
@@ -17,11 +19,12 @@ function Checkbox({ checked, onChange, label, value }: CheckboxProps) {
         className="hidden"
       />
       <div
-        className={`flex h-4 w-4 items-center justify-center rounded-[2px] border-2 transition-colors ${
+        className={cn(
+          'flex h-4 w-4 items-center justify-center rounded-[2px] border-2 transition-colors',
           checked
-            ? 'border-red-400 bg-red-400'
-            : 'border-neutral-700 bg-transparent'
-        }`}
+            ? 'border-red-400 bg-red-400 group-hover:border-red-500 group-hover:bg-red-500'
+            : 'border-neutral-700 bg-transparent group-hover:border-neutral-900'
+        )}
       >
         {checked && (
           <svg
@@ -41,7 +44,9 @@ function Checkbox({ checked, onChange, label, value }: CheckboxProps) {
           </svg>
         )}
       </div>
-      <span className="prose-p1 text-neutral-700">{label}</span>
+      <span className="prose-p1 text-neutral-700 group-hover:text-neutral-900">
+        {label}
+      </span>
     </label>
   )
 }

--- a/packages/frontend/src/components/switch.tsx
+++ b/packages/frontend/src/components/switch.tsx
@@ -12,16 +12,19 @@ function Switch({ checked, onChange, label }: SwitchProps) {
       onClick={() => onChange(!checked)}
       className={cn(
         'relative flex h-5 w-10 cursor-pointer items-center rounded-full p-0.5 transition-colors duration-100 ease-in-out',
-        checked ? 'bg-red-400' : 'bg-neutral-300'
+        checked
+          ? 'bg-red-400 hover:bg-red-500'
+          : 'bg-neutral-600 hover:bg-neutral-700'
       )}
       role="switch"
       aria-checked={checked}
       aria-label={label ?? 'Switch'}
     >
       <span
-        className={`h-4 w-4 rounded-full bg-white shadow-[0px_0px_24px_0px_rgba(0,0,0,0.1)] transition-transform duration-200 ease-in-out ${
+        className={cn(
+          'h-4 w-4 rounded-full bg-white shadow-[0px_0px_24px_0px_rgba(0,0,0,0.1)] transition-transform duration-200 ease-in-out',
           checked ? 'translate-x-5' : 'translate-x-0'
-        }`}
+        )}
       />
     </button>
   )

--- a/packages/frontend/src/modules/membership/account/index.tsx
+++ b/packages/frontend/src/modules/membership/account/index.tsx
@@ -173,7 +173,7 @@ function Account() {
           <div className="flex w-full gap-9 tablet:col-span-10 hd:gap-13">
             <div className="flex flex-1 flex-col px-6 tablet:px-8 desktop:px-0">
               <div className="mb-6 flex items-center justify-between desktop:mb-8">
-                <h1 className="prose-h4-large font-family-swei text-neutral-900">
+                <h1 className="prose-h4-small font-family-swei text-neutral-900 desktop:prose-h4-large">
                   個人資料
                 </h1>
                 {isEditMode ? (

--- a/packages/frontend/src/modules/membership/custom/index.tsx
+++ b/packages/frontend/src/modules/membership/custom/index.tsx
@@ -24,7 +24,7 @@ function Custom() {
           <MembershipSideMenu />
         </div>
         <div className="flex flex-1 flex-col px-6 tablet:col-span-10 tablet:px-8 desktop:col-span-8 desktop:px-0">
-          <h1 className="mb-6 prose-h4-large font-swei text-neutral-900 desktop:mb-8">
+          <h1 className="mb-6 prose-h4-small font-swei text-neutral-900 desktop:mb-8 desktop:prose-h4-large">
             閱讀設定
           </h1>
           <div className="flex w-full flex-col gap-6">

--- a/packages/frontend/src/modules/membership/custom/index.tsx
+++ b/packages/frontend/src/modules/membership/custom/index.tsx
@@ -2,6 +2,7 @@
 import { HeaderMobileBackButtonHrefSetter } from '@kids-reporter/routing-ui'
 
 import Checkbox from '@/components/checkbox'
+import Divider from '@/components/divider'
 import Switch from '@/components/switch'
 import { BAODAOZAI_DEFAULT_ESSAY_QUESTION_COUNT } from '@/constants/baodaozai-question-count'
 
@@ -49,7 +50,7 @@ function Custom() {
               </div>
             </div>
 
-            <div className="h-px w-full bg-neutral-200" />
+            <Divider />
 
             <div className="flex w-full flex-col gap-4">
               <div className="flex flex-col gap-1">

--- a/packages/frontend/src/modules/membership/email-subscription/index.tsx
+++ b/packages/frontend/src/modules/membership/email-subscription/index.tsx
@@ -20,7 +20,7 @@ function EmailSubscription() {
           <MembershipSideMenu />
         </div>
         <div className="flex flex-1 flex-col px-6 tablet:col-span-10 tablet:px-8 desktop:col-span-8 desktop:px-0">
-          <h1 className="mb-6 prose-h4-large font-swei text-neutral-900 desktop:mb-8">
+          <h1 className="mb-6 prose-h4-small font-swei text-neutral-900 desktop:mb-8 desktop:prose-h4-large">
             訂閱電子報
           </h1>
           <div className="flex flex-col gap-5 rounded-2xl bg-white p-6 tablet:gap-6 tablet:p-8 hd:flex-row hd:items-center">

--- a/packages/frontend/src/modules/membership/my-reading/index.tsx
+++ b/packages/frontend/src/modules/membership/my-reading/index.tsx
@@ -57,7 +57,7 @@ function MyReading() {
           <MembershipSideMenu />
         </div>
         <div className="flex flex-1 flex-col px-6 tablet:col-span-10 tablet:px-8 desktop:col-span-8 desktop:px-0">
-          <h1 className="mb-6 prose-h4-large font-swei text-neutral-900 desktop:mb-8">
+          <h1 className="mb-6 prose-h4-small font-swei text-neutral-900 desktop:mb-8 desktop:prose-h4-large">
             我的回答
           </h1>
           <PostQuestionAnswersList


### PR DESCRIPTION
## Summary

This PR fixes UI consistency issues in the reading settings module and enhances user interaction feedback. The changes include responsive heading font sizes across membership pages, improved hover states for interactive components, and code refactoring to use reusable components.

## Changes

- **Enhanced Checkbox component** (`packages/frontend/src/components/checkbox.tsx`):
  - Added `cn` utility import for better className management
  - Implemented hover states for both checked and unchecked states using `group` class
  - Added hover effects to checkbox border/background colors (red-400 → red-500 when checked, neutral-700 → neutral-900 when unchecked)
  - Added hover effect to label text (neutral-700 → neutral-900)

- **Enhanced Switch component** (`packages/frontend/src/components/switch.tsx`):
  - Added hover states for better user feedback
  - Hover effect when checked: red-400 → red-500
  - Hover effect when unchecked: neutral-600 → neutral-700

- **Fixed heading font sizes** across membership pages:
  - Changed from fixed `prose-h4-large` to responsive sizing: `prose-h4-small` with `desktop:prose-h4-large`
  - Updated in `packages/frontend/src/modules/membership/account/index.tsx`
  - Updated in `packages/frontend/src/modules/membership/custom/index.tsx`
  - Updated in `packages/frontend/src/modules/membership/email-subscription/index.tsx`
  - Updated in `packages/frontend/src/modules/membership/my-reading/index.tsx`

- **Code refactoring** (`packages/frontend/src/modules/membership/custom/index.tsx`):
  - Replaced hardcoded divider div with reusable `Divider` component for better maintainability

## Additional Notes

These changes improve the visual consistency of the membership pages, especially on mobile devices where the previous `prose-h4-large` heading size may have been too large. The hover state enhancements provide better visual feedback for interactive elements, improving the overall user experience.

**Potential considerations:**
- The hover states use Tailwind's `group` utility which requires the parent element to have the `group` class (already implemented in Checkbox)
- The responsive heading sizes ensure better readability across different screen sizes
- Using the `Divider` component instead of inline styles improves code maintainability and consistency

## Screenshot(s)
<img width="1061" height="453" alt="image" src="https://github.com/user-attachments/assets/ee4e2cf2-b423-4027-95bb-a6b701e13943" />
<img width="338" height="198" alt="image" src="https://github.com/user-attachments/assets/b6fb006b-a226-4a90-9c1e-7323c1b089e3" />
<img width="398" height="226" alt="image" src="https://github.com/user-attachments/assets/c19d61b4-11e9-414e-8130-81af53dd48cb" />

## Reference(s)
- [Notion Page](https://www.notion.so/twreporter/defect-UI-2bc8dbdca932801cb966f08a628dd9a6?source=copy_link)
