### PR TITLE
fix(frontend): remove underline in email subscription description

### DIFF
--- a/packages/frontend/src/modules/membership/email-subscription/index.tsx
+++ b/packages/frontend/src/modules/membership/email-subscription/index.tsx
@@ -44,8 +44,7 @@ function EmailSubscription() {
                   </span>
                 </div>
                 <p className="prose-p1 text-neutral-700">
-                  兒少新聞平台<span className="underline">《少年報導者》</span>
-                  的最新專題和活動消息，就讓可愛的報導仔來告訴你！
+                  兒少新聞平台《少年報導者》的最新專題和活動消息，就讓可愛的報導仔來告訴你！
                 </p>
               </div>
             </div>


### PR DESCRIPTION
- as title

## Related Document(s)
- [Notion Page](https://www.notion.so/twreporter/defect-UI-2bc8dbdca932801cb966f08a628dd9a6?v=1588dbdca93281dfa43c000c8415265e&source=copy_link)