### PR TITLE
feat(api-gateway): add RESTful API

### DIFF
--- a/packages/api-gateway/src/app.ts
+++ b/packages/api-gateway/src/app.ts
@@ -1,4 +1,4 @@
-// @ts-ignore `@twreporter/errors` does not have tyepscript definition file yet
+// @ts-ignore `@twreporter/errors` does not have typescript definition file yet
 import _errors from '@twreporter/errors'
 import cookieParser from 'cookie-parser'
 import cors from 'cors'
@@ -8,6 +8,7 @@ import { createAuthMiniApp } from './auth-mini-app.js'
 import consts from './constants.js'
 import { createGraphQLProxy } from './gql-proxy-mini-app.js'
 import middlewareCreator from './middlewares/index.js'
+import { createGqlRestRouter } from './routes/gql-rest.js'
 
 // @twreporter/errors is a cjs module, therefore, we need to use its default property
 const errors = _errors.default
@@ -53,6 +54,8 @@ export function createApp({
     cookieParser()
   )
 
+  // RESTful GraphQL mini app
+  app.use(createGqlRestRouter(gql))
   // mini app: GraphQL API
   app.use(createGraphQLProxy(gql))
 

--- a/packages/api-gateway/src/constants.ts
+++ b/packages/api-gateway/src/constants.ts
@@ -2,6 +2,7 @@ const statusCodes = {
   ok: 200,
   badRequest: 400,
   unauthorized: 401,
+  methodNotAllowed: 405,
   internalServerError: 500,
 }
 export default {

--- a/packages/api-gateway/src/gql-proxy-mini-app.ts
+++ b/packages/api-gateway/src/gql-proxy-mini-app.ts
@@ -1,149 +1,15 @@
-// @ts-ignore `@twreporter/errors` does not have tyepscript definition file yet
+// @ts-ignore `@twreporter/errors` does not have typescript definition file yet
 import _errors from '@twreporter/errors'
-import axios from 'axios'
 import express from 'express'
 import { createProxyMiddleware } from 'http-proxy-middleware'
 
 import consts from './constants.js'
+import { isBearerAuth, TokenManager } from './graphql/auth.js'
 
 // @twreporter/errors is a cjs module, therefore, we need to use its default property
 const errors = _errors.default
 
 const statusCodes = consts.statusCodes
-
-class TokenManager {
-  // Singleton
-  static instance?: TokenManager
-  private email: string
-  private password: string
-  private apiEndpoint: string
-  private token: string
-  private expiredAt?: number // timestamp
-
-  constructor(
-    email: string,
-    password: string,
-    apiEndpoint = 'http://localhost:3000/api/graphql'
-  ) {
-    this.email = email
-    this.password = password
-    this.apiEndpoint = apiEndpoint
-    this.token = ''
-
-    if (TokenManager.instance) {
-      return TokenManager.instance
-    }
-
-    TokenManager.instance = this
-  }
-
-  /**
-   *  This function will return a cache token if token is existed and not expired.
-   */
-  async getToken() {
-    if (this.token && this.expiredAt && this.expiredAt >= Date.now()) {
-      return this.token
-    }
-
-    // fetch token
-    try {
-      const sessionToken = await this._fetchToken()
-      this.token = sessionToken
-
-      // @TODO expiry time should be returned by API
-      // So far, we set expiry time as one hour later
-      this.expiredAt = Date.now() + 3600 * 1000
-
-      return this.token
-    } catch (err) {
-      const annotatedErr = errors.helpers.wrap(
-        err,
-        'TokenManangerError',
-        'Fail to get session token',
-        {
-          accoutEmail: this.email,
-        }
-      )
-      throw annotatedErr
-    }
-  }
-
-  /**
-   *  This function will return a new token.
-   */
-  async renewToken() {
-    try {
-      const sessionToken = await this._fetchToken()
-      this.token = sessionToken
-
-      // @TODO expiry time should be returned by API
-      // So far, we set expiry time as one hour later
-      this.expiredAt = Date.now() + 3600 * 1000
-      return this.token
-    } catch (err) {
-      const annotatedErr = errors.helpers.wrap(
-        err,
-        'TokenManangerError',
-        'Fail to renew session token',
-        {
-          accoutEmail: this.email,
-        }
-      )
-      throw annotatedErr
-    }
-  }
-
-  async _fetchToken() {
-    const gqlQuery = `
-      mutation AuthenticateUserWithPassword($email: String!, $password: String!) {
-        authenticateUserWithPassword(email: $email, password: $password) {
-          ... on UserAuthenticationWithPasswordSuccess {
-            sessionToken
-          }
-          ... on UserAuthenticationWithPasswordFailure {
-            message
-          }
-        }
-      }
-    `
-
-    let axiosRes
-    // fetch token
-    try {
-      axiosRes = await axios.post(this.apiEndpoint, {
-        query: gqlQuery,
-        variables: {
-          email: this.email,
-          password: this.password,
-        },
-      })
-    } catch (err) {
-      throw errors.helpers.annotateAxiosError(err)
-    }
-
-    const authenticationResult =
-      axiosRes.data?.data?.authenticateUserWithPassword
-    const errorMessage = authenticationResult?.message
-    if (errorMessage) {
-      throw new Error(errorMessage)
-    }
-
-    const sessionToken = authenticationResult?.sessionToken
-    if (!sessionToken) {
-      throw new Error(
-        'Session token "' + sessionToken + '" is not a valid string'
-      )
-    }
-
-    return sessionToken
-  }
-}
-
-// helpers
-const isBearerAuth = (req: express.Request) => {
-  const auth = req.get('authorization') || ''
-  return auth.startsWith('Bearer ')
-}
 
 /**
  *  This function creates a `GraphQLProxy` mini app.

--- a/packages/api-gateway/src/graphql/auth.ts
+++ b/packages/api-gateway/src/graphql/auth.ts
@@ -1,0 +1,167 @@
+// @ts-ignore `@twreporter/errors` does not have typescript definition file yet
+import _errors from '@twreporter/errors'
+import axios from 'axios'
+import express from 'express'
+
+const TOKEN_EXPIRY_MS = 3600 * 1000 // 1 hour
+
+const errors = _errors.default
+
+export class TokenManager {
+  // Singleton
+  static instance?: TokenManager
+  private email: string
+  private password: string
+  private apiEndpoint: string
+  private token: string
+  private expiredAt?: number // timestamp
+  private renewPromise?: Promise<string>
+
+  constructor(
+    email: string,
+    password: string,
+    apiEndpoint = 'http://localhost:3000/api/graphql'
+  ) {
+    this.email = email
+    this.password = password
+    this.apiEndpoint = apiEndpoint
+    this.token = ''
+
+    if (TokenManager.instance) {
+      return TokenManager.instance
+    }
+
+    TokenManager.instance = this
+  }
+
+  /**
+   *  This function will return a cached token if a token exists and is not expired.
+   */
+  async getToken() {
+    if (this.token && this.expiredAt && this.expiredAt >= Date.now()) {
+      return this.token
+    }
+
+    return this.queueRenewal()
+  }
+
+  /**
+   *  This function will return a new token.
+   */
+  async renewToken() {
+    this.token = ''
+    this.expiredAt = undefined
+    return this.queueRenewal()
+  }
+
+  private async queueRenewal() {
+    if (!this.renewPromise) {
+      this.renewPromise = this.fetchToken().finally(() => {
+        this.renewPromise = undefined
+      })
+    }
+    return this.renewPromise
+  }
+
+  private async fetchToken() {
+    const gqlQuery = `
+      mutation AuthenticateUserWithPassword($email: String!, $password: String!) {
+        authenticateUserWithPassword(email: $email, password: $password) {
+          ... on UserAuthenticationWithPasswordSuccess {
+            sessionToken
+          }
+          ... on UserAuthenticationWithPasswordFailure {
+            message
+          }
+        }
+      }
+    `
+
+    let axiosRes
+    // fetch token
+    try {
+      axiosRes = await axios.post(this.apiEndpoint, {
+        query: gqlQuery,
+        variables: {
+          email: this.email,
+          password: this.password,
+        },
+      })
+    } catch (err) {
+      throw errors.helpers.annotateAxiosError(err)
+    }
+
+    const authenticationResult =
+      axiosRes.data?.data?.authenticateUserWithPassword
+    const errorMessage = authenticationResult?.message
+    if (errorMessage) {
+      throw new Error(errorMessage)
+    }
+
+    const sessionToken = authenticationResult?.sessionToken
+    if (!sessionToken) {
+      throw new Error('Session token is missing or invalid')
+    }
+
+    this.token = sessionToken
+    // @TODO expiry time should be returned by API
+    // So far, we set expiry time as one hour later
+    this.expiredAt = Date.now() + TOKEN_EXPIRY_MS
+    return this.token
+  }
+}
+
+export const isBearerAuth = (req: express.Request) => {
+  const auth = req.get('authorization') || ''
+  return auth.startsWith('Bearer ')
+}
+
+export async function buildAuthContext({
+  req,
+  apiOrigin,
+  headlessAccount,
+  auth,
+}: {
+  req: express.Request
+  apiOrigin: string
+  headlessAccount: { email: string; password: string }
+  auth: 'auth' | 'public'
+}): Promise<{
+  mode: 'jwt' | 'cookie'
+  headers: Record<string, string>
+  originalCookie?: string
+  tokenManager?: TokenManager
+}> {
+  if (auth === 'auth') {
+    const authorization = req.get('authorization') || ''
+    if (!authorization) {
+      throw new Error('Authorization header is required')
+    }
+    return {
+      mode: 'jwt',
+      headers: { Authorization: authorization },
+    }
+  }
+
+  const tokenManager = new TokenManager(
+    headlessAccount.email,
+    headlessAccount.password,
+    apiOrigin + '/api/graphql'
+  )
+  const token = await tokenManager.getToken()
+  const originalCookie = req.get('Cookie') || ''
+  // Preserve client cookies while adding/refreshing the headless session token
+  const cookie = appendSessionCookie(originalCookie, token)
+
+  return {
+    mode: 'cookie',
+    headers: { Cookie: cookie },
+    originalCookie,
+    tokenManager,
+  }
+}
+
+export const appendSessionCookie = (originalCookie: string, token: string) =>
+  originalCookie
+    ? `${originalCookie};keystonejs-session=${token}`
+    : `keystonejs-session=${token}`

--- a/packages/api-gateway/src/graphql/cms-client.ts
+++ b/packages/api-gateway/src/graphql/cms-client.ts
@@ -1,0 +1,65 @@
+// @ts-ignore `@twreporter/errors` does not have typescript definition file yet
+import _errors from '@twreporter/errors'
+import axios from 'axios'
+
+import { appendSessionCookie, TokenManager } from './auth.js'
+
+const errors = _errors.default
+const CMS_REQUEST_TIMEOUT_MS = 10000
+
+export async function callCmsGraphql({
+  apiOrigin,
+  document,
+  variables,
+  operationName,
+  headers,
+  originalCookie,
+  mode,
+  tokenManager,
+  timeoutMs = CMS_REQUEST_TIMEOUT_MS,
+}: {
+  apiOrigin: string
+  document: string
+  variables: Record<string, unknown>
+  operationName: string
+  headers: Record<string, string>
+  originalCookie?: string
+  mode: 'jwt' | 'cookie'
+  tokenManager?: TokenManager
+  timeoutMs?: number
+}) {
+  const endpoint = `${apiOrigin}/api/graphql`
+  const doCall = async (customHeaders = headers) =>
+    axios.post(
+      endpoint,
+      { query: document, variables, operationName },
+      {
+        headers: { ...customHeaders, 'content-type': 'application/json' },
+        timeout: timeoutMs,
+      }
+    )
+
+  try {
+    return await doCall()
+  } catch (err) {
+    if (
+      mode === 'cookie' &&
+      axios.isAxiosError(err) &&
+      err.response?.status === 401 &&
+      tokenManager
+    ) {
+      try {
+        const token = await tokenManager.renewToken()
+        // Retry with the refreshed headless token stitched back into the Cookie header
+        const refreshedHeaders = {
+          ...headers,
+          Cookie: appendSessionCookie(originalCookie || '', token),
+        }
+        return await doCall(refreshedHeaders)
+      } catch (retryErr) {
+        throw errors.helpers.annotateAxiosError(retryErr)
+      }
+    }
+    throw errors.helpers.annotateAxiosError(err)
+  }
+}

--- a/packages/api-gateway/src/graphql/operations.ts
+++ b/packages/api-gateway/src/graphql/operations.ts
@@ -1,0 +1,12 @@
+import {
+  answerOperations,
+  contentOperations,
+  memberOperations,
+} from './operations/index.js'
+import type { Operation } from './operations/shared.js'
+
+export const operations: Record<string, Operation> = {
+  ...contentOperations,
+  ...memberOperations,
+  ...answerOperations,
+}

--- a/packages/api-gateway/src/graphql/operations/answers.ts
+++ b/packages/api-gateway/src/graphql/operations/answers.ts
@@ -1,0 +1,161 @@
+import { ensureRecord, Operation, parseVars, toInt } from './shared.js'
+
+export const operations: Record<string, Operation> = {
+  'post-choice-answers': {
+    method: 'GET',
+    auth: 'auth',
+    operationName: 'GetPostChoiceAnswers',
+    document: `
+      query GetPostChoiceAnswers($where: PostChoiceAnswerWhereInput!) {
+        postChoiceAnswers(where: $where) {
+          id
+          question { id }
+          member { id }
+          choiceIndex
+          correct
+        }
+      }
+    `,
+    buildVariables: (req) => {
+      const input = ensureRecord(parseVars(req), 'Missing variables')
+      return { where: ensureRecord(input.where, 'Missing where') }
+    },
+  },
+  'create-post-choice-answer': {
+    method: 'POST',
+    auth: 'auth',
+    operationName: 'CreatePostChoiceAnswer',
+    document: `
+      mutation CreatePostChoiceAnswer($data: PostChoiceAnswerCreateInput!) {
+        createPostChoiceAnswer(data: $data) {
+          question { id }
+          choiceIndex
+          correct
+        }
+      }
+    `,
+    buildVariables: (req) => {
+      const input = ensureRecord(parseVars(req), 'Missing variables')
+      return { data: ensureRecord(input.data, 'Missing data') }
+    },
+  },
+  'update-post-choice-answer': {
+    method: 'POST',
+    auth: 'auth',
+    operationName: 'UpdatePostChoiceAnswer',
+    document: `
+      mutation UpdatePostChoiceAnswer(
+        $id: ID!
+        $data: PostChoiceAnswerUpdateInput!
+      ) {
+        updatePostChoiceAnswer(where: { id: $id }, data: $data) {
+          id
+          choiceIndex
+          correct
+        }
+      }
+    `,
+    buildVariables: (req) => {
+      const input = ensureRecord(parseVars(req), 'Missing variables')
+      const id = input.id
+      if (typeof id !== 'string') {
+        throw new Error('Missing id')
+      }
+      return { id, data: ensureRecord(input.data, 'Missing data') }
+    },
+  },
+  'post-essay-answers': {
+    method: 'GET',
+    auth: 'auth',
+    operationName: 'GetPostEssayAnswers',
+    document: `
+      query GetPostEssayAnswers($where: PostEssayAnswerWhereInput!) {
+        postEssayAnswers(where: $where) {
+          id
+          question { id }
+          member { id }
+          content
+        }
+      }
+    `,
+    buildVariables: (req) => {
+      const input = ensureRecord(parseVars(req), 'Missing variables')
+      return { where: ensureRecord(input.where, 'Missing where') }
+    },
+  },
+  'all-post-essay-answers': {
+    method: 'GET',
+    cacheTtl: 60,
+    auth: 'public',
+    operationName: 'GetAllPostEssayAnswers',
+    document: `
+      query GetAllPostEssayAnswers(
+        $orderBy: [PostEssayAnswerOrderByInput!]
+        $take: Int
+  ) {
+    postEssayAnswers(orderBy: $orderBy, take: $take) {
+      id
+      question { id }
+      member {
+            id
+            avatar { fileUrl }
+            nickname
+            name
+          }
+          content
+          likesCount
+        }
+      }
+    `,
+    buildVariables: (req) => {
+      const input = ensureRecord(parseVars(req), 'Missing variables')
+      return {
+        orderBy: Array.isArray(input.orderBy)
+          ? input.orderBy
+          : [{ createdAt: 'desc' }],
+        take: toInt(input.take),
+      }
+    },
+  },
+  'create-post-essay-answer': {
+    method: 'POST',
+    auth: 'auth',
+    operationName: 'CreatePostEssayAnswer',
+    document: `
+      mutation CreatePostEssayAnswer($data: PostEssayAnswerCreateInput!) {
+        createPostEssayAnswer(data: $data) {
+          question { id }
+          content
+        }
+      }
+    `,
+    buildVariables: (req) => {
+      const input = ensureRecord(parseVars(req), 'Missing variables')
+      return { data: ensureRecord(input.data, 'Missing data') }
+    },
+  },
+  'update-post-essay-answer': {
+    method: 'POST',
+    auth: 'auth',
+    operationName: 'UpdatePostEssayAnswer',
+    document: `
+      mutation UpdatePostEssayAnswer(
+        $id: ID!
+        $data: PostEssayAnswerUpdateInput!
+      ) {
+        updatePostEssayAnswer(where: { id: $id }, data: $data) {
+          id
+          content
+        }
+      }
+    `,
+    buildVariables: (req) => {
+      const input = ensureRecord(parseVars(req), 'Missing variables')
+      const id = input.id
+      if (typeof id !== 'string') {
+        throw new Error('Missing id')
+      }
+      return { id, data: ensureRecord(input.data, 'Missing data') }
+    },
+  },
+}

--- a/packages/api-gateway/src/graphql/operations/content.ts
+++ b/packages/api-gateway/src/graphql/operations/content.ts
@@ -1,0 +1,382 @@
+import {
+  ensureArray,
+  ensureRecord,
+  Operation,
+  parseVars,
+  postContentFragment,
+  toInt,
+} from './shared.js'
+
+export const operations: Record<string, Operation> = {
+  'latest-posts': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'GetLatestPosts',
+    document: `
+      ${postContentFragment}
+      query GetLatestPosts($orderBy: [PostOrderByInput!]!, $take: Int) {
+        posts(orderBy: $orderBy, take: $take) {
+          ...PostContent
+        }
+      }
+    `,
+    buildVariables: (req) => {
+      const input = ensureRecord(parseVars(req), 'Missing variables')
+      const take = toInt(input.take)
+      const orderBy = Array.isArray(input.orderBy)
+        ? input.orderBy
+        : [{ publishedDate: 'desc' }]
+      return { orderBy, take }
+    },
+  },
+  'editor-picks-settings': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'GetEditorPicksSettings',
+    document: `
+      ${postContentFragment}
+      query GetEditorPicksSettings($take: Int) {
+        editorPicksSettings(take: $take) {
+          id
+          editorPicksOfPostsOrdered {
+            ...PostContent
+          }
+          editorPicksOfTags { name slug }
+        }
+      }
+    `,
+    buildVariables: (req) => {
+      const input = ensureRecord(parseVars(req), 'Missing variables')
+      return { take: toInt(input.take) }
+    },
+  },
+  'call-baodaozai-intro': {
+    method: 'GET',
+    cacheTtl: 300,
+    auth: 'public',
+    operationName: 'GetCallBaodaozaiIntro',
+    document: `
+      query GetCallBaodaozaiIntro($where: CallBaodaozaiIntroWhereUniqueInput!) {
+        callBaodaozaiIntro(where: $where) {
+          id
+          page
+          content
+        }
+      }
+    `,
+    buildVariables: (req) => {
+      const input = ensureRecord(parseVars(req), 'Missing variables')
+      const where = ensureRecord(input.where, 'Missing where')
+      const page = where.page
+      if (typeof page !== 'string') {
+        throw new Error('Missing where.page')
+      }
+      return { where: { page } }
+    },
+  },
+  'category-posts': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'GetCategoryPosts',
+    document: `
+      ${postContentFragment}
+      query GetCategoryPosts(
+        $where: CategoryWhereUniqueInput!
+        $take: Int
+        $skip: Int
+      ) {
+        category(where: $where) {
+          relatedPosts(take: $take, skip: $skip) {
+            ...PostContent
+          }
+          relatedPostsCount
+        }
+      }
+    `,
+    buildVariables: (req) => {
+      const input = ensureRecord(parseVars(req), 'Missing variables')
+      return {
+        where: ensureRecord(input.where, 'Missing where'),
+        take: toInt(input.take),
+        skip: toInt(input.skip),
+      }
+    },
+  },
+  'category-metadata': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'GetCategoryMetadata',
+    document: `
+      query GetCategoryMetadata(
+        $categoryWhere: CategoryWhereUniqueInput!
+        $subcategoryWhere: SubcategoryWhereInput!
+      ) {
+        category(where: $categoryWhere) {
+          ogTitle
+          ogDescription
+          ogImage { resized { medium } }
+          subcategories(where: $subcategoryWhere) {
+            ogTitle
+            ogDescription
+            ogImage { resized { medium } }
+          }
+        }
+      }
+    `,
+    buildVariables: (req) => {
+      const input = ensureRecord(parseVars(req), 'Missing variables')
+      return {
+        categoryWhere: ensureRecord(
+          input.categoryWhere,
+          'Missing categoryWhere'
+        ),
+        subcategoryWhere: ensureRecord(
+          input.subcategoryWhere,
+          'Missing subcategoryWhere'
+        ),
+      }
+    },
+  },
+  'category-subcategories-and-theme-color': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'GetCategorySubcategoriesAndThemeColor',
+    document: `
+      query GetCategorySubcategoriesAndThemeColor(
+        $where: CategoryWhereUniqueInput!
+      ) {
+        category(where: $where) {
+          subcategories { name slug }
+          themeColor
+        }
+      }
+    `,
+    buildVariables: (req) => {
+      const input = ensureRecord(parseVars(req), 'Missing variables')
+      return { where: ensureRecord(input.where, 'Missing where') }
+    },
+  },
+  'subcategory-posts': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'GetSubcategoryPosts',
+    document: `
+      ${postContentFragment}
+      query GetSubcategoryPosts(
+        $where: SubcategoryWhereUniqueInput!
+        $take: Int
+        $skip: Int
+      ) {
+        subcategory(where: $where) {
+          relatedPosts(take: $take, skip: $skip) {
+            ...PostContent
+          }
+          relatedPostsCount
+          category { slug }
+        }
+      }
+    `,
+    buildVariables: (req) => {
+      const input = ensureRecord(parseVars(req), 'Missing variables')
+      return {
+        where: ensureRecord(input.where, 'Missing where'),
+        take: toInt(input.take),
+        skip: toInt(input.skip),
+      }
+    },
+  },
+  'sub-subcategory-posts': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'GetSubSubcategoryPosts',
+    document: `
+      ${postContentFragment}
+      query GetSubSubcategoryPosts(
+        $where: SubSubcategoryWhereUniqueInput!
+        $take: Int
+        $skip: Int
+        $orderBy: [PostOrderByInput!]!
+      ) {
+        subSubcategory(where: $where) {
+          relatedPosts(take: $take, skip: $skip, orderBy: $orderBy) {
+            ...PostContent
+          }
+          relatedPostsCount
+          subcategory {
+            slug
+            category { slug }
+          }
+        }
+      }
+    `,
+    buildVariables: (req) => {
+      const input = ensureRecord(parseVars(req), 'Missing variables')
+      return {
+        where: ensureRecord(input.where, 'Missing where'),
+        take: toInt(input.take),
+        skip: toInt(input.skip),
+        orderBy: ensureArray(input.orderBy, 'Missing orderBy'),
+      }
+    },
+  },
+  'topic-projects': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'GetTopicProjects',
+    document: `
+      query GetTopicProjects($orderBy: [ProjectOrderByInput!]!, $take: Int) {
+        projects(orderBy: $orderBy, take: $take) {
+          title
+          subtitle
+          slug
+          heroImage { resized { small } }
+        }
+      }
+    `,
+    buildVariables: (req) => {
+      const input = ensureRecord(parseVars(req), 'Missing variables')
+      return {
+        orderBy: ensureArray(input.orderBy, 'Missing orderBy'),
+        take: toInt(input.take),
+      }
+    },
+  },
+  'post-detail': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'GetPost',
+    document: `
+      ${postContentFragment}
+      query GetPost(
+        $where: PostWhereUniqueInput!
+        $orderBy: [NewsReadingGroupItemOrderByInput!]!
+        $take: Int
+        $relatedPostsWhere: PostWhereInput!
+        $postEssayQuestionsTake: Int
+        $postChoiceQuestionsTake: Int
+      ) {
+        post(where: $where) {
+          opening
+          title
+          showBaodaozai
+          newsReadingGroup { items(orderBy: $orderBy) { name embedCode } }
+          brief
+          content
+          publishedDate
+          heroImage {
+            imageFile { width height }
+            resized { small medium large }
+          }
+          heroCaption
+          authors {
+            avatar { resized { tiny } }
+            bio
+            id
+            name
+            slug
+          }
+          authorsJSON
+          tagsOrdered { name slug }
+          TWReporterRelatedPostsJSON
+          relatedPostsOrdered {
+            title
+            slug
+            publishedDate
+            heroImage { resized { small medium large } }
+            ogDescription
+            subSubcategoriesOrdered {
+              name
+              slug
+              subcategory {
+                name
+                slug
+                category { name slug themeColor }
+              }
+            }
+          }
+          subtitle
+          subSubcategoriesOrdered {
+            name
+            slug
+            subcategory {
+              name
+              slug
+              category { name slug themeColor }
+            }
+          }
+          mainProject { title slug }
+          projects {
+            title
+            slug
+            relatedPosts(take: $take, where: $relatedPostsWhere) {
+              ...PostContent
+            }
+          }
+          postEssayQuestions(take: $postEssayQuestionsTake) {
+            id
+            title
+            hint
+          }
+          postChoiceQuestions(take: $postChoiceQuestionsTake) {
+            id
+            title
+            options
+            reason
+          }
+        }
+      }
+    `,
+    buildVariables: (req) => {
+      const input = ensureRecord(parseVars(req), 'Missing variables')
+      return {
+        where: ensureRecord(input.where, 'Missing where'),
+        orderBy: ensureArray(input.orderBy, 'Missing orderBy'),
+        take: toInt(input.take),
+        relatedPostsWhere: ensureRecord(
+          input.relatedPostsWhere,
+          'Missing relatedPostsWhere'
+        ),
+        postEssayQuestionsTake: toInt(input.postEssayQuestionsTake),
+        postChoiceQuestionsTake: toInt(input.postChoiceQuestionsTake),
+      }
+    },
+  },
+  'post-meta': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'GetPostMeta',
+    document: `
+      query GetPostMeta($where: PostWhereUniqueInput!) {
+        post(where: $where) {
+          publishedDate
+          ogDescription
+          ogTitle
+          ogImage { resized { small } }
+          subSubcategoriesOrdered {
+            name
+            slug
+            subcategory {
+              name
+              slug
+              category { name slug themeColor }
+            }
+          }
+        }
+      }
+    `,
+    buildVariables: (req) => {
+      const input = ensureRecord(parseVars(req), 'Missing variables')
+      return { where: ensureRecord(input.where, 'Missing where') }
+    },
+  },
+}

--- a/packages/api-gateway/src/graphql/operations/index.ts
+++ b/packages/api-gateway/src/graphql/operations/index.ts
@@ -1,0 +1,5 @@
+import { operations as answerOperations } from './answers.js'
+import { operations as contentOperations } from './content.js'
+import { operations as memberOperations } from './members.js'
+
+export { answerOperations, contentOperations, memberOperations }

--- a/packages/api-gateway/src/graphql/operations/members.ts
+++ b/packages/api-gateway/src/graphql/operations/members.ts
@@ -1,0 +1,104 @@
+import { ensureRecord, Operation, parseVars, toInt } from './shared.js'
+
+export const operations: Record<string, Operation> = {
+  'member-profile': {
+    method: 'GET',
+    auth: 'auth',
+    operationName: 'GetMemberProfile',
+    document: `
+      query GetMemberProfile($where: MemberWhereUniqueInput!) {
+        member(where: $where) {
+          id
+          name
+          email
+          nickname
+          contactEmail
+          twreporter_user_id
+          showBaodaozai
+          essayQuestionCount
+          avatar { id fileUrl }
+          createdAt
+        }
+      }
+    `,
+    buildVariables: (req) => {
+      const input = ensureRecord(parseVars(req), 'Missing variables')
+      return { where: ensureRecord(input.where, 'Missing where') }
+    },
+  },
+  'update-member-profile': {
+    method: 'POST',
+    auth: 'auth',
+    operationName: 'UpdateMemberProfile',
+    document: `
+      mutation UpdateMemberProfile(
+        $where: MemberWhereUniqueInput!
+        $data: MemberUpdateInput!
+      ) {
+        updateMember(where: $where, data: $data) {
+          id
+          name
+          nickname
+          contactEmail
+          showBaodaozai
+          essayQuestionCount
+          avatar { id }
+        }
+      }
+    `,
+    buildVariables: (req) => {
+      const input = ensureRecord(parseVars(req), 'Missing variables')
+      return {
+        where: ensureRecord(input.where, 'Missing where'),
+        data: ensureRecord(input.data, 'Missing data'),
+      }
+    },
+  },
+  'member-posts-with-answers': {
+    method: 'GET',
+    auth: 'auth',
+    operationName: 'GetMemberPostsWithAnswers',
+    document: `
+      query GetMemberPostsWithAnswers(
+        $memberId: ID!
+        $take: Int
+        $nextCursor: String
+      ) {
+        getMemberPostsWithAnswers(
+          memberId: $memberId
+          take: $take
+          cursor: $nextCursor
+        )
+      }
+    `,
+    buildVariables: (req) => {
+      const input = ensureRecord(parseVars(req), 'Missing variables')
+      const memberId = input.memberId
+      if (typeof memberId !== 'string') {
+        throw new Error('Missing memberId')
+      }
+      return {
+        memberId,
+        take: toInt(input.take),
+        nextCursor:
+          typeof input.nextCursor === 'string' ? input.nextCursor : undefined,
+      }
+    },
+  },
+  'delete-member-avatar': {
+    method: 'POST',
+    auth: 'auth',
+    operationName: 'DeleteMemberAvatar',
+    document: `
+      mutation DeleteMemberAvatar($where: MemberAvatarWhereUniqueInput!) {
+        deleteMemberAvatar(where: $where) {
+          id
+        }
+      }
+    `,
+    buildVariables: (req) => {
+      const input = ensureRecord(parseVars(req), 'Missing variables')
+      return { where: ensureRecord(input.where, 'Missing where') }
+    },
+  },
+}

--- a/packages/api-gateway/src/graphql/operations/shared.ts
+++ b/packages/api-gateway/src/graphql/operations/shared.ts
@@ -1,0 +1,74 @@
+import express from 'express'
+
+export type Operation = {
+  method: 'GET' | 'POST'
+  cacheTtl?: number
+  auth: 'public' | 'auth'
+  operationName: string
+  document: string
+  buildVariables: (req: express.Request) => Record<string, unknown>
+}
+
+export const postContentFragment = `
+  fragment PostContent on Post {
+    title
+    slug
+    ogDescription
+    heroImage { resized { small } }
+    subSubcategoriesOrdered {
+      name
+      subcategory { name category { slug themeColor } }
+    }
+    publishedDate
+  }
+`
+
+const isRecord = (val: unknown): val is Record<string, unknown> =>
+  typeof val === 'object' && val !== null && !Array.isArray(val)
+
+export const ensureRecord = (
+  val: unknown,
+  errorMessage: string
+): Record<string, unknown> => {
+  if (!isRecord(val)) {
+    throw new Error(errorMessage)
+  }
+  return val
+}
+
+export const ensureArray = (val: unknown, errorMessage: string): unknown[] => {
+  if (!Array.isArray(val)) {
+    throw new Error(errorMessage)
+  }
+  return val
+}
+
+export const parseVars = (
+  req: express.Request
+): Record<string, unknown> | unknown[] => {
+  const source = req.method === 'GET' ? req.query : req.body
+  const raw = (isRecord(source) ? source.variables : source) ?? {}
+  if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw)
+      if (isRecord(parsed) || Array.isArray(parsed)) {
+        return parsed
+      }
+      throw new Error('Variables must be an object or array')
+    } catch (_err) {
+      throw new Error(
+        'Invalid JSON in variables: ' +
+          (_err instanceof Error ? _err.message : String(_err))
+      )
+    }
+  }
+  if (isRecord(raw) || Array.isArray(raw)) {
+    return raw
+  }
+  throw new Error('Variables must be an object or array')
+}
+
+export const toInt = (val: unknown): number | undefined => {
+  const n = Number(val)
+  return Number.isFinite(n) ? n : undefined
+}

--- a/packages/api-gateway/src/routes/gql-rest.ts
+++ b/packages/api-gateway/src/routes/gql-rest.ts
@@ -1,0 +1,139 @@
+// @ts-ignore `@twreporter/errors` does not have typescript definition file yet
+import _errors from '@twreporter/errors'
+import express from 'express'
+
+import consts from '../constants.js'
+import { buildAuthContext } from '../graphql/auth.js'
+import { callCmsGraphql } from '../graphql/cms-client.js'
+import { operations } from '../graphql/operations.js'
+
+const errors = _errors.default
+const statusCodes = consts.statusCodes
+
+export function createGqlRestRouter({
+  apiOrigin,
+  headlessAccount,
+}: {
+  apiOrigin: string
+  headlessAccount: { email: string; password: string }
+}) {
+  const router = express.Router()
+  router.use(express.json({ limit: '1mb' }))
+
+  // Register method-specific handlers for each operation
+  Object.entries(operations).forEach(([operationName, op]) => {
+    const method = op.method.toLowerCase() as keyof express.Router
+    const methodFn = router[method]
+
+    if (typeof methodFn === 'function') {
+      ;(
+        methodFn as (
+          this: express.Router,
+          path: string,
+          handler: express.RequestHandler
+        ) => void
+      ).call(router, `/api/rest/${operationName}`, async (req, res) => {
+        let variables
+        try {
+          variables = op.buildVariables(req)
+        } catch (err) {
+          return res.status(statusCodes.badRequest).json({
+            status: 'fail',
+            data: {
+              message: 'buildVariables fails. ' + (err as Error).message,
+            },
+          })
+        }
+
+        let authContext
+        try {
+          authContext = await buildAuthContext({
+            req,
+            apiOrigin,
+            headlessAccount,
+            auth: op.auth,
+          })
+        } catch (err) {
+          return res.status(statusCodes.badRequest).json({
+            status: 'fail',
+            data: {
+              message: 'buildAuthContext fails. ' + (err as Error).message,
+            },
+          })
+        }
+
+        try {
+          const gqlRes = await callCmsGraphql({
+            apiOrigin,
+            document: op.document,
+            variables,
+            operationName: op.operationName,
+            headers: authContext.headers,
+            originalCookie: authContext.originalCookie,
+            mode: authContext.mode,
+            tokenManager: authContext.tokenManager,
+          })
+
+          if (op.auth === 'auth') {
+            res.set('Cache-Control', 'no-store')
+          } else if (op.cacheTtl && op.method === 'GET') {
+            res.set('Cache-Control', `public, max-age=${op.cacheTtl}`)
+          }
+
+          const gqlPayload = gqlRes?.data
+
+          if (gqlPayload?.errors?.length) {
+            return res.status(statusCodes.internalServerError).json({
+              status: 'error',
+              message: 'CMS GraphQL responded with errors',
+              errors: gqlPayload.errors,
+            })
+          }
+
+          return res.status(statusCodes.ok).json({
+            status: 'success',
+            data: gqlPayload?.data ?? {},
+          })
+        } catch (err) {
+          const annotatedErr = errors.helpers.wrap(
+            err,
+            'GraphQLRestError',
+            'Failed to call CMS GraphQL'
+          )
+          console.log(
+            JSON.stringify({
+              severity: 'ERROR',
+              message: errors.helpers.printAll(annotatedErr, {
+                withStack: true,
+                withPayload: true,
+              }),
+              ...res?.locals?.globalLogFields,
+            })
+          )
+          return res.status(statusCodes.internalServerError).json({
+            status: 'error',
+            message: 'Failed to process request',
+          })
+        }
+      })
+    }
+  })
+
+  router.all('/api/rest/:operation', (req, res) => {
+    const op = operations[req.params.operation]
+    if (!op) {
+      return res.status(statusCodes.badRequest).json({
+        status: 'fail',
+        data: {
+          message: `Unknown operation: '${req.params.operation}'. Available operations: [${Object.keys(operations).join(', ')}]`,
+        },
+      })
+    }
+    return res.status(statusCodes.methodNotAllowed).json({
+      status: 'fail',
+      data: { message: `Use ${op.method}` },
+    })
+  })
+
+  return router
+}

--- a/packages/api-gateway/src/routes/gql-rest.ts
+++ b/packages/api-gateway/src/routes/gql-rest.ts
@@ -9,6 +9,53 @@ import { operations } from '../graphql/operations.js'
 
 const errors = _errors.default
 const statusCodes = consts.statusCodes
+const MAX_LOG_BODY_BYTES = 1024
+
+const logResponse = (
+  res: express.Response,
+  status: number,
+  payload: unknown
+) => {
+  let serialized = ''
+  let serializeError: string | undefined
+  try {
+    serialized = JSON.stringify(payload)
+  } catch (err) {
+    serialized = '"[unserializable payload]"'
+    serializeError = (err as Error).message
+  }
+
+  const byteLength = Buffer.byteLength(serialized, 'utf8')
+  const errorInfo = serializeError
+    ? { unserializable: true, serializeError }
+    : null
+  let bodyForLog: unknown = errorInfo
+  if (!bodyForLog) {
+    if (status === statusCodes.ok) {
+      bodyForLog = { byteLength }
+    } else if (byteLength > MAX_LOG_BODY_BYTES) {
+      bodyForLog = {
+        truncated: true,
+        byteLength,
+        preview: serialized.slice(0, MAX_LOG_BODY_BYTES),
+      }
+    } else {
+      bodyForLog = payload
+    }
+  }
+
+  console.log(
+    JSON.stringify({
+      severity: 'INFO',
+      message: 'GraphQL REST response',
+      status,
+      body: bodyForLog,
+      ...res?.locals?.globalLogFields,
+    })
+  )
+
+  return res.status(status).json(payload)
+}
 
 export function createGqlRestRouter({
   apiOrigin,
@@ -37,7 +84,7 @@ export function createGqlRestRouter({
         try {
           variables = op.buildVariables(req)
         } catch (err) {
-          return res.status(statusCodes.badRequest).json({
+          return logResponse(res, statusCodes.badRequest, {
             status: 'fail',
             data: {
               message: 'buildVariables fails. ' + (err as Error).message,
@@ -54,7 +101,7 @@ export function createGqlRestRouter({
             auth: op.auth,
           })
         } catch (err) {
-          return res.status(statusCodes.badRequest).json({
+          return logResponse(res, statusCodes.badRequest, {
             status: 'fail',
             data: {
               message: 'buildAuthContext fails. ' + (err as Error).message,
@@ -83,14 +130,14 @@ export function createGqlRestRouter({
           const gqlPayload = gqlRes?.data
 
           if (gqlPayload?.errors?.length) {
-            return res.status(statusCodes.internalServerError).json({
+            return logResponse(res, statusCodes.internalServerError, {
               status: 'error',
               message: 'CMS GraphQL responded with errors',
               errors: gqlPayload.errors,
             })
           }
 
-          return res.status(statusCodes.ok).json({
+          return logResponse(res, statusCodes.ok, {
             status: 'success',
             data: gqlPayload?.data ?? {},
           })
@@ -110,7 +157,7 @@ export function createGqlRestRouter({
               ...res?.locals?.globalLogFields,
             })
           )
-          return res.status(statusCodes.internalServerError).json({
+          return logResponse(res, statusCodes.internalServerError, {
             status: 'error',
             message: 'Failed to process request',
           })
@@ -122,14 +169,14 @@ export function createGqlRestRouter({
   router.all('/api/rest/:operation', (req, res) => {
     const op = operations[req.params.operation]
     if (!op) {
-      return res.status(statusCodes.badRequest).json({
+      return logResponse(res, statusCodes.badRequest, {
         status: 'fail',
         data: {
           message: `Unknown operation: '${req.params.operation}'. Available operations: [${Object.keys(operations).join(', ')}]`,
         },
       })
     }
-    return res.status(statusCodes.methodNotAllowed).json({
+    return logResponse(res, statusCodes.methodNotAllowed, {
       status: 'fail',
       data: { message: `Use ${op.method}` },
     })

--- a/packages/api-gateway/src/routes/gql-rest.ts
+++ b/packages/api-gateway/src/routes/gql-rest.ts
@@ -10,6 +10,10 @@ import { operations } from '../graphql/operations.js'
 const errors = _errors.default
 const statusCodes = consts.statusCodes
 const MAX_LOG_BODY_BYTES = 1024
+const CLIENT_GQL_ERROR_CODES = new Set([
+  'BAD_USER_INPUT',
+  'GRAPHQL_VALIDATION_FAILED',
+])
 
 const logResponse = (
   res: express.Response,
@@ -130,11 +134,21 @@ export function createGqlRestRouter({
           const gqlPayload = gqlRes?.data
 
           if (gqlPayload?.errors?.length) {
-            return logResponse(res, statusCodes.internalServerError, {
-              status: 'error',
-              message: 'CMS GraphQL responded with errors',
-              errors: gqlPayload.errors,
-            })
+            const hasClientError = gqlPayload.errors.some(
+              (error: { extensions?: { code?: string } }) =>
+                CLIENT_GQL_ERROR_CODES.has(error?.extensions?.code ?? '')
+            )
+            return logResponse(
+              res,
+              hasClientError
+                ? statusCodes.badRequest
+                : statusCodes.internalServerError,
+              {
+                status: 'error',
+                message: 'CMS GraphQL responded with errors',
+                errors: gqlPayload.errors,
+              }
+            )
           }
 
           return logResponse(res, statusCodes.ok, {


### PR DESCRIPTION
## Summary

Expose CMS GraphQL operations through a REST gateway with centralized auth and request handling, enabling CDN caching and reducing direct GraphQL surface area.

## Changes
- Add /api/rest/:operation router with operation dispatch, variable parsing, error handling, and Cache-Control behavior.
- Introduce CMS client/auth helpers to manage Keystone tokens, cookie stitching, and 401 retry on headless sessions.
- Define REST-exposed GraphQL operations covering category/subcategory flows, topic projects, post detail/meta, member profile read/update, member posts/answers, essay/choice answer CRUD, and avatar deletion.
- Wire the REST gateway alongside the existing GraphQL proxy.
- log gql-rest responses with size-aware output
  
## Additional Notes
- GQL requests are POST-only, so responses are not cached by CDN (e.g., Cloudflare). Essay-answer listing pages issue heavy GQL queries that could be offloaded via HTTP caching; RESTful endpoints enable CDN caching to reduce load on the GQL server and database.
- The api-gateway lacks a GQL parser and does not validate query/mutation content, so end users could send unexpected GQL operations to probe the GQL server. Restricting to RESTful endpoints limits exposed operations and mitigates this risk.