### PR TITLE
refactor(frontend): route most graphql calls through rest gateway

### DIFF
--- a/packages/api-gateway/src/graphql/operations/answers.ts
+++ b/packages/api-gateway/src/graphql/operations/answers.ts
@@ -90,7 +90,7 @@ export const operations: Record<string, Operation> = {
     operationName: 'GetAllPostEssayAnswers',
     document: `
       query GetAllPostEssayAnswers(
-        $orderBy: [PostEssayAnswerOrderByInput!]
+        $orderBy: [PostEssayAnswerOrderByInput!]!
         $take: Int
   ) {
     postEssayAnswers(orderBy: $orderBy, take: $take) {

--- a/packages/api-gateway/src/graphql/operations/members.ts
+++ b/packages/api-gateway/src/graphql/operations/members.ts
@@ -60,12 +60,10 @@ export const operations: Record<string, Operation> = {
     operationName: 'GetMemberPostsWithAnswers',
     document: `
       query GetMemberPostsWithAnswers(
-        $memberId: ID!
         $take: Int
         $nextCursor: String
       ) {
         getMemberPostsWithAnswers(
-          memberId: $memberId
           take: $take
           cursor: $nextCursor
         )
@@ -73,12 +71,7 @@ export const operations: Record<string, Operation> = {
     `,
     buildVariables: (req) => {
       const input = ensureRecord(parseVars(req), 'Missing variables')
-      const memberId = input.memberId
-      if (typeof memberId !== 'string') {
-        throw new Error('Missing memberId')
-      }
       return {
-        memberId,
         take: toInt(input.take),
         nextCursor:
           typeof input.nextCursor === 'string' ? input.nextCursor : undefined,

--- a/packages/draft-editor/src/block-renderers/image.tsx
+++ b/packages/draft-editor/src/block-renderers/image.tsx
@@ -34,7 +34,7 @@ export function EditableImage(props: AtomicBlockProps<EntityData>) {
   const entityKey = block.getEntityAt(0)
   const entity = contentState.getEntity(entityKey)
   const data = entity.getData() || {}
-  const { alignment: _alignment, ...imageWithMeta } = data // eslint-disable-line
+  const { alignment: _alignment, ...imageWithMeta } = data
 
   const onChange: ImageSelectorOnChangeFn = (selectedImages, alignment) => {
     // close `ImageSelector`

--- a/packages/frontend/src/api/call-baodaozai-intro.ts
+++ b/packages/frontend/src/api/call-baodaozai-intro.ts
@@ -3,15 +3,14 @@ import {
   GetCallBaodaozaiIntroQueryVariables,
 } from '__generated__/operations/call-baodaozai-intro.generated'
 
-import { sendGQLRequest } from '@/utils/send-gql-request'
-
-import { GET_CALL_BAODAOZAI_INTRO_GQL } from './graphql/call-baodaozai-intro'
+import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
 export async function getCallBaodaozaiIntroContent(
   variables: GetCallBaodaozaiIntroQueryVariables
 ): Promise<string | undefined> {
-  const data = await sendGQLRequest<GetCallBaodaozaiIntroQuery>({
-    query: GET_CALL_BAODAOZAI_INTRO_GQL,
+  const data = await sendRestGqlRequest<GetCallBaodaozaiIntroQuery>({
+    operation: 'call-baodaozai-intro',
+    method: 'GET',
     variables,
   })
 

--- a/packages/frontend/src/api/category.ts
+++ b/packages/frontend/src/api/category.ts
@@ -7,19 +7,14 @@ import {
   GetCategorySubcategoriesAndThemeColorQueryVariables,
 } from '__generated__/operations/category.generated'
 
-import { sendGQLRequest } from '@/utils'
-
-import {
-  GET_CATEGORY_METADATA_GQL,
-  GET_CATEGORY_POSTS_GQL,
-  GET_CATEGORY_SUBCATEGORIES_AND_THEME_COLOR_GQL,
-} from './graphql/category'
+import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
 export const getCategoryPosts = async (
   variables: GetCategoryPostsQueryVariables
 ) => {
-  const response = await sendGQLRequest<GetCategoryPostsQuery>({
-    query: GET_CATEGORY_POSTS_GQL,
+  const response = await sendRestGqlRequest<GetCategoryPostsQuery>({
+    operation: 'category-posts',
+    method: 'GET',
     variables,
   })
   return response?.data?.data?.category
@@ -28,8 +23,9 @@ export const getCategoryPosts = async (
 export const getCategoryMetadata = async (
   variables: GetCategoryMetadataQueryVariables
 ) => {
-  const response = await sendGQLRequest<GetCategoryMetadataQuery>({
-    query: GET_CATEGORY_METADATA_GQL,
+  const response = await sendRestGqlRequest<GetCategoryMetadataQuery>({
+    operation: 'category-metadata',
+    method: 'GET',
     variables,
   })
   return response?.data?.data?.category
@@ -39,8 +35,9 @@ export const getCategorySubcategoriesAndThemeColor = async (
   variables: GetCategorySubcategoriesAndThemeColorQueryVariables
 ) => {
   const response =
-    await sendGQLRequest<GetCategorySubcategoriesAndThemeColorQuery>({
-      query: GET_CATEGORY_SUBCATEGORIES_AND_THEME_COLOR_GQL,
+    await sendRestGqlRequest<GetCategorySubcategoriesAndThemeColorQuery>({
+      operation: 'category-subcategories-and-theme-color',
+      method: 'GET',
       variables,
     })
   return response?.data?.data?.category

--- a/packages/frontend/src/api/editor-picks-settings.ts
+++ b/packages/frontend/src/api/editor-picks-settings.ts
@@ -3,15 +3,14 @@ import {
   GetEditorPicksSettingsQueryVariables,
 } from '__generated__/operations/editor-picks-settings.generated'
 
-import { sendGQLRequest } from '@/utils'
-
-import { GET_EDITOR_PICKS_SETTINGS_GQL } from './graphql/editor-picks-settings'
+import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
 export const getEditorPicksSettings = async (
   variables: GetEditorPicksSettingsQueryVariables
 ) => {
-  const response = await sendGQLRequest<GetEditorPicksSettingsQuery>({
-    query: GET_EDITOR_PICKS_SETTINGS_GQL,
+  const response = await sendRestGqlRequest<GetEditorPicksSettingsQuery>({
+    operation: 'editor-picks-settings',
+    method: 'GET',
     variables,
   })
   return response?.data?.data?.editorPicksSettings

--- a/packages/frontend/src/api/extended.ts
+++ b/packages/frontend/src/api/extended.ts
@@ -5,11 +5,9 @@ import {
 } from '__generated__/operations/extended.generated'
 
 import { sendGQLRequest } from '@/utils/send-gql-request'
+import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
-import {
-  GET_MEMBER_ESSAY_ANSWERS_HAS_LIKED_GQL,
-  GET_MEMBER_POSTS_WITH_ANSWERS_GQL,
-} from './graphql/extended'
+import { GET_MEMBER_ESSAY_ANSWERS_HAS_LIKED_GQL } from './graphql/extended'
 
 export type GetMemberPostsWithAnswersQuerySchema = {
   getMemberPostsWithAnswers: {
@@ -58,15 +56,14 @@ export type GetMemberPostsWithAnswersQuerySchema = {
 export const getMemberPostsWithAnswers = async (
   variables: GetMemberPostsWithAnswersQueryVariables & { accessToken: string }
 ) => {
-  const response = await sendGQLRequest<GetMemberPostsWithAnswersQuerySchema>(
-    {
-      query: GET_MEMBER_POSTS_WITH_ANSWERS_GQL,
-      variables,
-    },
-    {
-      authToken: variables.accessToken,
-    }
-  )
+  const { accessToken, ...restVariables } = variables
+  const response =
+    await sendRestGqlRequest<GetMemberPostsWithAnswersQuerySchema>({
+      operation: 'member-posts-with-answers',
+      method: 'GET',
+      variables: restVariables,
+      authToken: accessToken,
+    })
   return response?.data?.data?.getMemberPostsWithAnswers
 }
 

--- a/packages/frontend/src/api/member-avatar.ts
+++ b/packages/frontend/src/api/member-avatar.ts
@@ -7,12 +7,9 @@ import { print } from 'graphql/language/printer'
 
 import { API_URL, INTERNAL_API_URL } from '@/constants'
 import envVars from '@/environment-variables'
-import { sendGQLRequest } from '@/utils'
+import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
-import {
-  CREATE_MEMBER_AVATAR_MUTATION,
-  DELETE_MEMBER_AVATAR_MUTATION,
-} from './graphql/member-avatar'
+import { CREATE_MEMBER_AVATAR_MUTATION } from './graphql/member-avatar'
 
 export const uploadMemberAvatar = async (
   file: File,
@@ -68,17 +65,14 @@ export const deleteMemberAvatar = async (
   avatarId: string,
   accessToken: string
 ) => {
-  const response = await sendGQLRequest<DeleteMemberAvatarMutation>(
-    {
-      query: DELETE_MEMBER_AVATAR_MUTATION,
-      variables: {
-        where: { id: avatarId },
-      },
+  const response = await sendRestGqlRequest<DeleteMemberAvatarMutation>({
+    operation: 'delete-member-avatar',
+    method: 'POST',
+    variables: {
+      where: { id: avatarId },
     },
-    {
-      authToken: accessToken,
-    }
-  )
+    authToken: accessToken,
+  })
 
   return response?.data?.data?.deleteMemberAvatar
 }

--- a/packages/frontend/src/api/member.ts
+++ b/packages/frontend/src/api/member.ts
@@ -5,12 +5,7 @@ import {
   UpdateMemberProfileMutationVariables,
 } from '__generated__/operations/member.generated'
 
-import { sendGQLRequest } from '@/utils'
-
-import {
-  GET_MEMBER_PROFILE_GQL,
-  UPDATE_MEMBER_PROFILE_GQL,
-} from './graphql/member'
+import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
 export const getMemberProfileByTwreporterUserId = async ({
   twreporterUserId,
@@ -25,15 +20,12 @@ export const getMemberProfileByTwreporterUserId = async ({
     },
   }
 
-  const response = await sendGQLRequest<GetMemberProfileQuery>(
-    {
-      query: GET_MEMBER_PROFILE_GQL,
-      variables,
-    },
-    {
-      authToken: accessToken,
-    }
-  )
+  const response = await sendRestGqlRequest<GetMemberProfileQuery>({
+    operation: 'member-profile',
+    method: 'GET',
+    variables,
+    authToken: accessToken,
+  })
 
   return response?.data?.data?.member
 }
@@ -53,16 +45,13 @@ export const getMemberProfileByMemberId = async ({
     },
   }
 
-  const response = await sendGQLRequest<GetMemberProfileQuery>(
-    {
-      query: GET_MEMBER_PROFILE_GQL,
-      variables,
-    },
-    {
-      authToken: accessToken,
-      signal: abortSignal,
-    }
-  )
+  const response = await sendRestGqlRequest<GetMemberProfileQuery>({
+    operation: 'member-profile',
+    method: 'GET',
+    variables,
+    authToken: accessToken,
+    signal: abortSignal,
+  })
 
   return response?.data?.data?.member
 }
@@ -76,18 +65,15 @@ export const updateMemberProfile = async ({
   accessToken: string
   data: UpdateMemberProfileMutationVariables['data']
 }) => {
-  const response = await sendGQLRequest<UpdateMemberProfileMutation>(
-    {
-      query: UPDATE_MEMBER_PROFILE_GQL,
-      variables: {
-        where: { id: memberId },
-        data,
-      },
+  const response = await sendRestGqlRequest<UpdateMemberProfileMutation>({
+    operation: 'update-member-profile',
+    method: 'POST',
+    variables: {
+      where: { id: memberId },
+      data,
     },
-    {
-      authToken: accessToken,
-    }
-  )
+    authToken: accessToken,
+  })
 
   return response?.data?.data
 }

--- a/packages/frontend/src/api/post-choice-answer.ts
+++ b/packages/frontend/src/api/post-choice-answer.ts
@@ -7,13 +7,7 @@ import {
   UpdatePostChoiceAnswerMutationVariables,
 } from '__generated__/operations/post-choice-answer.generated'
 
-import { sendGQLRequest } from '@/utils/send-gql-request'
-
-import {
-  CREATE_POST_CHOICE_ANSWER_MUTATION,
-  GET_POST_CHOICE_ANSWER_QUERY,
-  UPDATE_POST_CHOICE_ANSWER_MUTATION,
-} from './graphql/post-choice-answer'
+import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
 export const getPostChoiceAnswersByMemberId = async (
   memberId: string,
@@ -27,30 +21,24 @@ export const getPostChoiceAnswersByMemberId = async (
     },
   }
 
-  const response = await sendGQLRequest<GetPostChoiceAnswersQuery>(
-    {
-      query: GET_POST_CHOICE_ANSWER_QUERY,
-      variables,
-    },
-    {
-      authToken: accessToken,
-    }
-  )
+  const response = await sendRestGqlRequest<GetPostChoiceAnswersQuery>({
+    operation: 'post-choice-answers',
+    method: 'GET',
+    variables,
+    authToken: accessToken,
+  })
   return response?.data?.data?.postChoiceAnswers ?? []
 }
 export const createPostChoiceAnswer = async (
   variables: CreatePostChoiceAnswerMutationVariables,
   accessToken: string
 ) => {
-  const response = await sendGQLRequest<CreatePostChoiceAnswerMutation>(
-    {
-      query: CREATE_POST_CHOICE_ANSWER_MUTATION,
-      variables,
-    },
-    {
-      authToken: accessToken,
-    }
-  )
+  const response = await sendRestGqlRequest<CreatePostChoiceAnswerMutation>({
+    operation: 'create-post-choice-answer',
+    method: 'POST',
+    variables,
+    authToken: accessToken,
+  })
   return response?.data?.data?.createPostChoiceAnswer
 }
 
@@ -58,14 +46,11 @@ export const updatePostChoiceAnswer = async (
   variables: UpdatePostChoiceAnswerMutationVariables,
   accessToken: string
 ) => {
-  const response = await sendGQLRequest<UpdatePostChoiceAnswerMutation>(
-    {
-      query: UPDATE_POST_CHOICE_ANSWER_MUTATION,
-      variables,
-    },
-    {
-      authToken: accessToken,
-    }
-  )
+  const response = await sendRestGqlRequest<UpdatePostChoiceAnswerMutation>({
+    operation: 'update-post-choice-answer',
+    method: 'POST',
+    variables,
+    authToken: accessToken,
+  })
   return response?.data?.data?.updatePostChoiceAnswer
 }

--- a/packages/frontend/src/api/post-essay-answer.ts
+++ b/packages/frontend/src/api/post-essay-answer.ts
@@ -10,14 +10,7 @@ import {
 } from '__generated__/operations/post-essay-answer.generated'
 import { PostEssayAnswerOrderByInput } from '__generated__/types'
 
-import { sendGQLRequest } from '@/utils/send-gql-request'
-
-import {
-  CREATE_POST_ESSAY_ANSWER_MUTATION,
-  GET_ALL_POST_ESSAY_ANSWERS_QUERY,
-  GET_POST_ESSAY_ANSWER_QUERY,
-  UPDATE_POST_ESSAY_ANSWER_MUTATION,
-} from './graphql/post-essay-answer'
+import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
 export const getPostEssayAnswersByMemberId = async (
   memberId: string,
@@ -30,15 +23,12 @@ export const getPostEssayAnswersByMemberId = async (
       ...(postSlug && { question: { post: { slug: { equals: postSlug } } } }),
     },
   }
-  const response = await sendGQLRequest<GetPostEssayAnswersQuery>(
-    {
-      query: GET_POST_ESSAY_ANSWER_QUERY,
-      variables,
-    },
-    {
-      authToken: accessToken,
-    }
-  )
+  const response = await sendRestGqlRequest<GetPostEssayAnswersQuery>({
+    operation: 'post-essay-answers',
+    method: 'GET',
+    variables,
+    authToken: accessToken,
+  })
   return response?.data?.data?.postEssayAnswers ?? []
 }
 
@@ -50,8 +40,9 @@ export const getAllPostEssayAnswers = async (
     orderBy: orderBy ?? [],
     take: take ?? 10,
   }
-  const response = await sendGQLRequest<GetAllPostEssayAnswersQuery>({
-    query: GET_ALL_POST_ESSAY_ANSWERS_QUERY,
+  const response = await sendRestGqlRequest<GetAllPostEssayAnswersQuery>({
+    operation: 'all-post-essay-answers',
+    method: 'GET',
     variables,
   })
   return response?.data?.data?.postEssayAnswers ?? []
@@ -61,15 +52,12 @@ export const createPostEssayAnswer = async (
   variables: CreatePostEssayAnswerMutationVariables,
   accessToken: string
 ) => {
-  const response = await sendGQLRequest<CreatePostEssayAnswerMutation>(
-    {
-      query: CREATE_POST_ESSAY_ANSWER_MUTATION,
-      variables,
-    },
-    {
-      authToken: accessToken,
-    }
-  )
+  const response = await sendRestGqlRequest<CreatePostEssayAnswerMutation>({
+    operation: 'create-post-essay-answer',
+    method: 'POST',
+    variables,
+    authToken: accessToken,
+  })
   return response?.data?.data?.createPostEssayAnswer
 }
 
@@ -77,15 +65,12 @@ export const updatePostEssayAnswer = async (
   variables: UpdatePostEssayAnswerMutationVariables,
   accessToken: string
 ) => {
-  const response = await sendGQLRequest<UpdatePostEssayAnswerMutation>(
-    {
-      query: UPDATE_POST_ESSAY_ANSWER_MUTATION,
-      variables,
-    },
-    {
-      authToken: accessToken,
-    }
-  )
+  const response = await sendRestGqlRequest<UpdatePostEssayAnswerMutation>({
+    operation: 'update-post-essay-answer',
+    method: 'POST',
+    variables,
+    authToken: accessToken,
+  })
 
   return response?.data?.data?.updatePostEssayAnswer
 }

--- a/packages/frontend/src/api/post.ts
+++ b/packages/frontend/src/api/post.ts
@@ -11,28 +11,28 @@ import {
 } from '__generated__/operations/post.generated'
 
 import { sendGQLRequest } from '@/utils'
+import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
 import {
-  GET_LATEST_POSTS_GQL,
   GET_POST_ESSAY_QUESTIONS_GQL,
-  GET_POST_GQL,
-  GET_POST_META_GQL,
   GET_POSTS_ESSAY_ANSWERS_WITH_LIKES_GQL,
 } from './graphql/post'
 
 export const getLatestPosts = async (
   variables: GetLatestPostsQueryVariables
 ) => {
-  const response = await sendGQLRequest<GetLatestPostsQuery>({
-    query: GET_LATEST_POSTS_GQL,
+  const response = await sendRestGqlRequest<GetLatestPostsQuery>({
+    operation: 'latest-posts',
+    method: 'GET',
     variables,
   })
   return response?.data?.data?.posts
 }
 
 export const getPost = async (variables: GetPostQueryVariables) => {
-  const response = await sendGQLRequest<GetPostQuery>({
-    query: GET_POST_GQL,
+  const response = await sendRestGqlRequest<GetPostQuery>({
+    operation: 'post-detail',
+    method: 'GET',
     variables,
   })
   return response?.data?.data?.post
@@ -41,8 +41,9 @@ export const getPost = async (variables: GetPostQueryVariables) => {
 export const getPostMeta = async (
   variables: GetPostMetaQueryVariables
 ): Promise<GetPostMetaQuery['post']> => {
-  const response = await sendGQLRequest<GetPostMetaQuery>({
-    query: GET_POST_META_GQL,
+  const response = await sendRestGqlRequest<GetPostMetaQuery>({
+    operation: 'post-meta',
+    method: 'GET',
     variables,
   })
   return response?.data?.data?.post

--- a/packages/frontend/src/api/project.ts
+++ b/packages/frontend/src/api/project.ts
@@ -3,15 +3,14 @@ import {
   GetTopicProjectsQueryVariables,
 } from '__generated__/operations/project.generated'
 
-import { sendGQLRequest } from '@/utils'
-
-import { GET_TOPIC_PROJECTS_GQL } from './graphql/project'
+import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
 export const getTopicProjects = async (
   variables: GetTopicProjectsQueryVariables
 ) => {
-  const response = await sendGQLRequest<GetTopicProjectsQuery>({
-    query: GET_TOPIC_PROJECTS_GQL,
+  const response = await sendRestGqlRequest<GetTopicProjectsQuery>({
+    operation: 'topic-projects',
+    method: 'GET',
     variables,
   })
 

--- a/packages/frontend/src/api/sub-subcategory.ts
+++ b/packages/frontend/src/api/sub-subcategory.ts
@@ -3,15 +3,14 @@ import {
   GetSubSubcategoryPostsQueryVariables,
 } from '__generated__/operations/sub-subcategory.generated'
 
-import { sendGQLRequest } from '@/utils'
-
-import { GET_SUB_SUBCATEGORY_POSTS_GQL } from './graphql/sub-subcategory'
+import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
 export const getSubSubcategoryPosts = async (
   variables: GetSubSubcategoryPostsQueryVariables
 ) => {
-  const response = await sendGQLRequest<GetSubSubcategoryPostsQuery>({
-    query: GET_SUB_SUBCATEGORY_POSTS_GQL,
+  const response = await sendRestGqlRequest<GetSubSubcategoryPostsQuery>({
+    operation: 'sub-subcategory-posts',
+    method: 'GET',
     variables,
   })
   return response?.data?.data?.subSubcategory

--- a/packages/frontend/src/api/subcategory.ts
+++ b/packages/frontend/src/api/subcategory.ts
@@ -3,15 +3,14 @@ import {
   GetSubcategoryPostsQueryVariables,
 } from '__generated__/operations/subcategory.generated'
 
-import { sendGQLRequest } from '@/utils'
-
-import { GET_SUBCATEGORY_POSTS_GQL } from './graphql/subcategory'
+import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
 export const getSubcategoryPosts = async (
   variables: GetSubcategoryPostsQueryVariables
 ) => {
-  const response = await sendGQLRequest<GetSubcategoryPostsQuery>({
-    query: GET_SUBCATEGORY_POSTS_GQL,
+  const response = await sendRestGqlRequest<GetSubcategoryPostsQuery>({
+    operation: 'subcategory-posts',
+    method: 'GET',
     variables,
   })
   return response?.data?.data?.subcategory

--- a/packages/frontend/src/constants/index.tsx
+++ b/packages/frontend/src/constants/index.tsx
@@ -6,6 +6,7 @@ import { CategorySlug } from '@/types'
 export const INTERNAL_API_URL = envVars.internalGqlEndpoint
 export const API_URL = envVars.gqlEndpoint
 export const ACCESS_TOKEN_ENDPOINT = `${envVars.apiGatewayEndpoint}/auth/access-token`
+export const REST_GQL_ENDPOINT = `${envVars.apiGatewayEndpoint}/api/rest`
 export const LOGOUT_ENDPOINT = '/api/logout'
 
 export const KIDS_URL_ORIGIN = 'https://kids.twreporter.org'

--- a/packages/frontend/src/utils/send-rest-gql.ts
+++ b/packages/frontend/src/utils/send-rest-gql.ts
@@ -1,0 +1,85 @@
+import errors from '@twreporter/errors'
+import axios, { AxiosResponse } from 'axios'
+
+import { REST_GQL_ENDPOINT } from '@/constants'
+
+import { log, LogLevel } from './log'
+import { AXIOS_TIMEOUT } from './send-gql-request'
+
+type GraphQLResponse<TData = Record<string, unknown>> = {
+  data?: TData
+  errors?: Array<{ message: string }>
+}
+
+export async function sendRestGqlRequest<TData = Record<string, unknown>>({
+  operation,
+  method,
+  variables,
+  authToken,
+  signal,
+}: {
+  operation: string
+  method: 'GET' | 'POST'
+  variables?: Record<string, unknown>
+  authToken?: string
+  signal?: AbortSignal
+}) {
+  const url = `${REST_GQL_ENDPOINT}/${operation}`
+
+  let response: AxiosResponse<GraphQLResponse<TData>> | undefined
+  try {
+    const config = {
+      headers: {
+        ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+      },
+      timeout: AXIOS_TIMEOUT,
+      withCredentials: true,
+      signal,
+    }
+
+    if (method === 'GET') {
+      response = await axios.get<GraphQLResponse<TData>>(url, {
+        ...config,
+        params: {
+          variables: JSON.stringify(variables ?? {}),
+        },
+      })
+    } else {
+      response = await axios.post<GraphQLResponse<TData>>(
+        url,
+        { variables },
+        config
+      )
+    }
+  } catch (err) {
+    const annotatedErr = errors.helpers.annotateAxiosError(err)
+    log(
+      LogLevel.ERROR,
+      errors.helpers.printAll(annotatedErr, {
+        withStack: true,
+        withPayload: true,
+      })
+    )
+  }
+
+  const gqlErrors = response?.data?.errors
+  if (gqlErrors) {
+    const annotatedErr = errors.helpers.wrap(
+      new Error(
+        `Errors occurred while executing REST GQL operation: ${operation}`
+      ),
+      'GraphQLError',
+      'Errors occurred after axios request',
+      { errors: gqlErrors }
+    )
+    log(
+      LogLevel.ERROR,
+      errors.helpers.printAll(annotatedErr, {
+        withStack: true,
+        withPayload: true,
+      })
+    )
+  }
+
+  return response
+}


### PR DESCRIPTION
## Summary
Route most frontend GraphQL traffic through REST gateway operations for consistency with backend rollout.

## Changes
- add sendRestGqlRequest helper for REST_GQL_ENDPOINT with GET/POST, auth headers, shared timeout, and error logging
- move most frontend API calls to REST gateway operations (category, member, post detail/meta, project, answers, editor picks, intro); leave a few direct GraphQL calls to migrate later
- expose REST_GQL_ENDPOINT in constants for reuse
- adjust REST gateway ops: require orderBy for all-post-essay-answers and drop memberId from member-posts-with-answers variables
- remove unnecessary eslint-disable in draft-editor image renderer

## Additional Notes
This PR bases on PR https://github.com/kids-reporter/kids-reporter-monorepo/pull/856, #856 needs to be merged before this PR merged.