### PR TITLE
chore: upgrade next.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
   },
   "resolutions": {
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "next": "14.2.35"
   },
   "version": "0.0.0",
   "packageManager": "yarn@4.9.4"

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -39,7 +39,7 @@
     "encoding": "^0.1.13",
     "graphql-tag": "^2.12.6",
     "lodash": "^4.17.21",
-    "next": "^14.2.33",
+    "next": "^14.2.35",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-helmet": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6451,7 +6451,7 @@ __metadata:
     graphql: "npm:^16.8.1"
     graphql-tag: "npm:^2.12.6"
     lodash: "npm:^4.17.21"
-    next: "npm:^14.2.33"
+    next: "npm:^14.2.35"
     postcss: "npm:^8.4.38"
     prettier: "npm:^3.6.2"
     prettier-plugin-tailwindcss: "npm:^0.6.14"
@@ -6569,10 +6569,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:14.2.33":
-  version: 14.2.33
-  resolution: "@next/env@npm:14.2.33"
-  checksum: 10c0/e4901199326dadf2e49f44ddbc78b1fc9bc2e4d290c0c52b5cfd8b79e18250717557f297ad0e1c3dbf411bd4fca6e94382d9b53bc02fe845ee50b801a38fb7fb
+"@next/env@npm:14.2.35":
+  version: 14.2.35
+  resolution: "@next/env@npm:14.2.35"
+  checksum: 10c0/e042f1771f91d4f69b296aa7f633df216464df5844e5e1ea46105b76b2e519093dff4b25df9a24576916811b65a7e896202b2540649af5aa54bd7f8b19d7b6ab
   languageName: node
   linkType: hard
 
@@ -15968,11 +15968,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:^14.2.0, next@npm:^14.2.33":
-  version: 14.2.33
-  resolution: "next@npm:14.2.33"
+"next@npm:14.2.35":
+  version: 14.2.35
+  resolution: "next@npm:14.2.35"
   dependencies:
-    "@next/env": "npm:14.2.33"
+    "@next/env": "npm:14.2.35"
     "@next/swc-darwin-arm64": "npm:14.2.33"
     "@next/swc-darwin-x64": "npm:14.2.33"
     "@next/swc-linux-arm64-gnu": "npm:14.2.33"
@@ -16022,7 +16022,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 10c0/e1b457582a397b54052c984b99f9ad8e0f0d2ba0d5626bf5959a9c07b23ea6497fa4cde05e02af5d26c92d7f32533998f241e7fdac9ba6a20bbc003fc077d243
+  checksum: 10c0/5b1eadd554cd2cb1f030335d71a9363d16d86453f60a2331333887804c8b4b04a16fcb1ddb58229b792b6c365dbd0fafd9ccacd727c85134101a124bd6b4c06a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgrade to fix the vulnerability

https://react.dev/blog/2025/12/03/critical-security-vulnerability-in-react-server-components