### PR TITLE
fix: enhance error handling and logging for category metadata fetching

### DIFF
--- a/packages/frontend/src/app/(sticky-header)/category/[[...path]]/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/category/[[...path]]/page.tsx
@@ -1,5 +1,7 @@
 import { Metadata } from 'next'
 import { notFound, redirect } from 'next/navigation'
+// @ts-ignore `@twreporter/errors` does not have tyepscript definition file yet
+import errors from '@twreporter/errors'
 import PostList from '@/app/components/post-list'
 import Navigator from './navigator'
 import Pagination from '@/app/components/pagination'
@@ -40,50 +42,73 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const categorySlug = params.path?.[0]
   const subcategorySlug = params.path?.[1] ?? ''
-
-  const res = await sendGQLRequest({
-    query,
-    variables: {
-      categoryWhere: {
-        slug: categorySlug,
-      },
-      subcategoryWhere: {
-        slug: {
-          equals: subcategorySlug,
-        },
-      },
-    },
-  })
-
-  const category = res?.data?.data?.category
-
-  if (!category) {
-    log(
-      LogLevel.INFO,
-      `Category metadata not found. URL path is: /${params.path.join('/')}`
-    )
+  if (!categorySlug) {
+    log(LogLevel.WARNING, `Incorrect category path! ${params.path}`)
     return {}
   }
+  try {
+    const res = await sendGQLRequest({
+      query,
+      variables: {
+        categoryWhere: {
+          slug: categorySlug,
+        },
+        subcategoryWhere: {
+          slug: {
+            equals: subcategorySlug,
+          },
+        },
+      },
+    })
 
-  const title =
-    category?.subcategories?.[0]?.ogTitle ||
-    category?.ogTitle ||
-    '分類: 少年報導者 The Reporter for Kids'
-  const description =
-    category?.subcategories?.[0]?.ogDescription ||
-    category?.ogDescription ||
-    GENERAL_DESCRIPTION
+    const category = res?.data?.data?.category
 
-  return {
-    title,
-    description,
-    openGraph: {
+    if (!category) {
+      log(
+        LogLevel.INFO,
+        `Category metadata not found. URL path is: /${params.path.join('/')}`
+      )
+      return {}
+    }
+
+    const title =
+      category?.subcategories?.[0]?.ogTitle ||
+      category?.ogTitle ||
+      '分類: 少年報導者 The Reporter for Kids'
+    const description =
+      category?.subcategories?.[0]?.ogDescription ||
+      category?.ogDescription ||
+      GENERAL_DESCRIPTION
+
+    return {
       title,
       description,
-      images:
-        category?.subcategories?.[0]?.ogImage?.resized?.medium ??
-        category?.ogImage?.resized?.medium,
-    },
+      openGraph: {
+        title,
+        description,
+        images:
+          category?.subcategories?.[0]?.ogImage?.resized?.medium ??
+          category?.ogImage?.resized?.medium,
+      },
+    }
+  } catch (err) {
+    const annotatedErr = errors.helpers.wrap(
+      err,
+      'CategoryMetadataError',
+      'Error fetching category metadata'
+    )
+    console.log(
+      JSON.stringify({
+        severity: 'ERROR',
+        message: errors.helpers.printAll(
+          annotatedErr,
+          { withStack: true, withPayload: true },
+          0,
+          0
+        ),
+      })
+    )
+    return {}
   }
 }
 


### PR DESCRIPTION
## Summary

This PR addresses the missing error handling in the category page's `generateMetadata` function. Previously, when the GraphQL API returned error status codes (e.g., 403 Forbidden), the function would throw unhandled errors, causing the entire page to fail rendering. This fix adds comprehensive error handling with proper logging and fallback behavior.

## Changes

- Added early return check for `categorySlug` to prevent unnecessary API requests when the category path is invalid
- Wrapped GraphQL API request in `try-catch` block to handle errors gracefully
- Integrated `@twreporter/errors` for structured error logging with stack traces and payload information
- Added fallback behavior that returns empty metadata object (`{}`) when errors occur, ensuring pages can still render even if metadata is incomplete
- Improved error logging with severity levels and detailed error information for better debugging

## Additional Notes

This fix ensures that:
- Pages remain renderable even when metadata fetching fails
- Errors are properly logged for debugging and monitoring
- Unnecessary API requests are avoided when category paths are invalid
- The user experience is not disrupted by metadata fetch failures

The error handling follows the existing pattern used in other parts of the codebase and uses `@twreporter/errors` for consistent error reporting.

## Screenshot(s)

## Reference(s)

- [GitHub Issue #865](https://github.com/kids-reporter/kids-reporter-monorepo/issues/865)