### PR TITLE
fix(cms): only omit copyPostContent update and create

### DIFF
--- a/packages/cms/lists/post.ts
+++ b/packages/cms/lists/post.ts
@@ -561,7 +561,11 @@ const listConfigurations: ListConfig<any> = list({
         listView: { fieldMode: 'hidden' },
       },
       graphql: {
-        omit: true,
+        omit: {
+          read: false,
+          update: true,
+          create: true,
+        },
       },
     }),
   },

--- a/packages/cms/schema.graphql
+++ b/packages/cms/schema.graphql
@@ -216,6 +216,7 @@ type Post {
   listPreview: String
   onlineUsers: JSON
   generateQuestions: JSON
+  copyPostContent: JSON
 }
 
 input PostWhereUniqueInput {


### PR DESCRIPTION
- Since omitting all will let it disappear on the admin page, modify to only omit create/update