### PR TITLE
fix(frontend): adjust spacing and padding for better layout

### DIFF
--- a/packages/frontend/src/modules/idea-hub/all-answers/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/all-answers/index.tsx
@@ -101,7 +101,7 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
   const showLoading = isLoading || isFetchingNextPage
 
   return (
-    <div className="flex w-[calc(100%+48px)] flex-col gap-6 bg-neutral-100 pt-10 pb-14 tablet:w-[calc(100%+64px)] tablet:gap-8 tablet:pt-12 tablet:pb-16 desktop:w-[calc(100%+96px)] desktop:gap-10 desktop:pt-18 desktop:pb-24 hd:w-screen hd:pt-24 hd:pb-30">
+    <div className="flex w-[calc(100%+48px)] flex-col gap-6 bg-neutral-100 pt-10 pb-12 tablet:w-[calc(100%+64px)] tablet:gap-8 tablet:pt-12 tablet:pb-14 desktop:w-[calc(100%+96px)] desktop:gap-10 desktop:pt-18 desktop:pb-22 hd:w-screen hd:pt-24 hd:pb-28">
       <div
         ref={titleRef}
         className="flex items-center gap-3 pl-6 tablet:pl-8 desktop:pl-12 hd:pl-[calc(50vw-600px+64px)]"
@@ -113,7 +113,7 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
       </div>
       <div
         ref={scrollContainerRef}
-        className="flex scrollbar-thin snap-x snap-mandatory scroll-px-6 gap-6 overflow-x-auto px-6 tablet:scroll-px-8 tablet:px-8 desktop:scroll-px-12 desktop:gap-8 desktop:px-12 hd:scroll-pr-14 hd:scroll-pl-[calc(50vw-600px+64px)] hd:pr-14 hd:pl-[calc(50vw-600px+64px)]"
+        className="flex scrollbar-thin snap-x snap-mandatory scroll-px-6 gap-6 overflow-x-auto px-6 pb-2 tablet:scroll-px-8 tablet:px-8 desktop:scroll-px-12 desktop:gap-8 desktop:px-12 hd:scroll-pr-14 hd:scroll-pl-[calc(50vw-600px+64px)] hd:pr-14 hd:pl-[calc(50vw-600px+64px)]"
       >
         {posts?.map((post) => (
           <div key={post.id} className="flex-shrink-0 snap-start">

--- a/packages/frontend/src/modules/idea-hub/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/index.tsx
@@ -21,8 +21,8 @@ function IdeaHub() {
 
   return (
     <>
-      <div className="mx-auto flex w-full max-w-300 flex-col items-center gap-4 px-6 py-10 tablet:px-8 tablet:py-12 desktop:gap-6 desktop:px-12 desktop:py-18 hd:px-14 hd:py-24">
-        <div className="flex items-center gap-2">
+      <div className="mx-auto flex w-full max-w-300 flex-col items-center px-6 py-10 tablet:px-8 tablet:py-12 desktop:px-12 desktop:py-18 hd:px-14 hd:py-24">
+        <div className="mb-4 flex items-center gap-2 desktop:mb-6">
           <div className="flex size-11 items-center justify-center desktop:size-16">
             <IdeaHubIcon className="desktop:hidden" />
             <IdeaHubIconLarge className="hidden desktop:block" />

--- a/packages/frontend/src/modules/idea-hub/latest-answers/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/latest-answers/index.tsx
@@ -37,7 +37,7 @@ function LatestAnswers({ onOpenModal }: LatestAnswersProps) {
   }
 
   return (
-    <div className="mt-6 mb-14 flex w-[calc(100%+48px)] flex-col gap-6 tablet:mt-8 tablet:mb-16 tablet:w-full tablet:gap-8 desktop:mt-14 desktop:mb-24 desktop:gap-10 hd:mt-20 hd:mb-30">
+    <div className="mt-10 mb-14 flex w-[calc(100%+48px)] flex-col gap-6 tablet:mt-12 tablet:mb-16 tablet:w-full tablet:gap-8 desktop:mt-18 desktop:mb-24 desktop:gap-10 hd:mt-24 hd:mb-30">
       <div className="flex items-center gap-3 pl-6 tablet:pl-0">
         <div className="h-8 w-1.5 rounded-md bg-yellow-400" />
         <h3 className="prose-h3-small font-swei text-neutral-900 desktop:prose-h3-large">


### PR DESCRIPTION
## Summary

This PR fixes UI spacing and padding issues in the Idea Hub module to improve visual consistency and ensure proper shadow visibility. The changes adjust padding values across different breakpoints and refine spacing between components.

## Changes

- **all-answers/index.tsx**: Reduced bottom padding values across all breakpoints (pb-14 → pb-12, tablet:pb-16 → tablet:pb-14, desktop:pb-24 → desktop:pb-22, hd:pb-30 → hd:pb-28) and added `pb-2` to the scroll container to ensure card shadows are visible
- **index.tsx**: Removed `gap-4` from the main container and replaced it with margin-bottom spacing (`mb-4` and `desktop:mb-6`) on the header section for more precise control
- **latest-answers/index.tsx**: Increased top margin values across all breakpoints (mt-6 → mt-10, tablet:mt-8 → tablet:mt-12, desktop:mt-14 → desktop:mt-18, hd:mt-20 → hd:mt-24) to improve spacing between the header and the latest answers section

## Additional Notes

These spacing adjustments ensure that:
- Card shadows are fully visible in the horizontal scroll container
- Consistent spacing is maintained across different screen sizes
- The layout follows the design system spacing tokens

## Screenshot(s)

## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/defect-UI-2-2d78dbdca9328045bb7adacbea3b3e86)