### PR TITLE
fix(api-gateway): forward parsed GraphQL bodies to proxy

### DIFF
--- a/packages/api-gateway/src/app.ts
+++ b/packages/api-gateway/src/app.ts
@@ -54,8 +54,8 @@ export function createApp({
     cookieParser()
   )
 
-  // Set the global JSON body limit to 100KB
-  app.use(express.json({ limit: '100kb' }))
+  // Set the global JSON body limit to 1MB to support typical GraphQL payloads
+  app.use(express.json({ limit: '1mb' }))
 
   // RESTful GraphQL mini app
   app.use(createGqlRestRouter(gql))

--- a/packages/api-gateway/src/app.ts
+++ b/packages/api-gateway/src/app.ts
@@ -54,6 +54,9 @@ export function createApp({
     cookieParser()
   )
 
+  // Set the global JSON body limit to 100KB
+  app.use(express.json({ limit: '100kb' }))
+
   // RESTful GraphQL mini app
   app.use(createGqlRestRouter(gql))
   // mini app: GraphQL API

--- a/packages/api-gateway/src/gql-proxy-mini-app.ts
+++ b/packages/api-gateway/src/gql-proxy-mini-app.ts
@@ -80,14 +80,22 @@ export function createGraphQLProxy({
         // Preserve original Content-Type for multipart/form-data (file uploads)
         // Only set to application/json for regular GraphQL requests
         const originalContentType = req.get('Content-Type') || ''
-        if (originalContentType.includes('multipart/form-data')) {
+        const isMultipart = originalContentType.includes('multipart/form-data')
+        if (isMultipart) {
           // Preserve multipart/form-data with boundary for file uploads
           proxyReq.setHeader('Content-Type', originalContentType)
         } else {
-          // Set to application/json for regular GraphQL JSON requests
+          // Force JSON for regular GraphQL requests
           proxyReq.setHeader('Content-Type', 'application/json')
         }
         proxyReq.setHeader('x-apollo-operation-name', '')
+
+        const bodyData =
+          !isMultipart && req.body
+            ? typeof req.body === 'string'
+              ? req.body
+              : JSON.stringify(req.body)
+            : null
 
         if (mode === 'jwt') {
           // Forward Authorization header
@@ -108,37 +116,44 @@ export function createGraphQLProxy({
               },
             })
           )
-          return
-        }
+        } else {
+          const originalCookie = req.get('Cookie') || ''
+          // Cookie mode: attach keystonejs-session token
+          const sessionToken = res.locals.sessionToken || ''
+          const cookie = originalCookie
+            ? `${originalCookie};keystonejs-session=${sessionToken}`
+            : `keystonejs-session=${sessionToken}`
 
-        const originalCookie = req.get('Cookie') || ''
-        // Cookie mode: attach keystonejs-session token
-        const sessionToken = res.locals.sessionToken || ''
-        const cookie = originalCookie
-          ? `${originalCookie};keystonejs-session=${sessionToken}`
-          : `keystonejs-session=${sessionToken}`
+          proxyReq.setHeader('Cookie', cookie)
+          // Ensure Authorization is not present to avoid ambiguity
+          proxyReq.removeHeader?.('Authorization')
 
-        proxyReq.setHeader('Cookie', cookie)
-        // Ensure Authorization is not present to avoid ambiguity
-        proxyReq.removeHeader?.('Authorization')
-
-        console.log(
-          JSON.stringify({
-            severity: 'DEBUG',
-            message:
-              'Proxy with keystonejs-session to ' + apiOrigin + proxyReq.path,
-            ...res?.locals?.globalLogFields,
-            debugPayload: {
-              req: {
-                headers: {
-                  cookie: '[REDACTED]',
-                  'content-type': 'application/json',
+          console.log(
+            JSON.stringify({
+              severity: 'DEBUG',
+              message:
+                'Proxy with keystonejs-session to ' + apiOrigin + proxyReq.path,
+              ...res?.locals?.globalLogFields,
+              debugPayload: {
+                req: {
+                  headers: {
+                    cookie: '[REDACTED]',
+                    'content-type': 'application/json',
+                  },
                 },
               },
-            },
-          })
-        )
+            })
+          )
+        }
+
+        // If body was already parsed by express.json,
+        // re-attach it so the upstream server doesn't hang waiting for bytes.
+        if (bodyData && !proxyReq.headersSent) {
+          proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData))
+          proxyReq.write(bodyData)
+        }
       },
+      // end onProxyReq
 
       onProxyRes: async (proxyRes, req, res) => {
         const statusCode = proxyRes.statusCode

--- a/packages/api-gateway/src/gql-proxy-mini-app.ts
+++ b/packages/api-gateway/src/gql-proxy-mini-app.ts
@@ -110,7 +110,7 @@ export function createGraphQLProxy({
                 req: {
                   headers: {
                     authorization: '[REDACTED]',
-                    'content-type': 'application/json',
+                    'content-type': proxyReq.getHeader('Content-Type'),
                   },
                 },
               },
@@ -138,7 +138,7 @@ export function createGraphQLProxy({
                 req: {
                   headers: {
                     cookie: '[REDACTED]',
-                    'content-type': 'application/json',
+                    'content-type': proxyReq.getHeader('Content-Type'),
                   },
                 },
               },

--- a/packages/api-gateway/src/gql-proxy-mini-app.ts
+++ b/packages/api-gateway/src/gql-proxy-mini-app.ts
@@ -151,6 +151,7 @@ export function createGraphQLProxy({
         if (bodyData && !proxyReq.headersSent) {
           proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData))
           proxyReq.write(bodyData)
+          proxyReq.end()
         }
       },
       // end onProxyReq

--- a/packages/api-gateway/src/routes/gql-rest.ts
+++ b/packages/api-gateway/src/routes/gql-rest.ts
@@ -69,7 +69,6 @@ export function createGqlRestRouter({
   headlessAccount: { email: string; password: string }
 }) {
   const router = express.Router()
-  router.use(express.json({ limit: '1mb' }))
 
   // Register method-specific handlers for each operation
   Object.entries(operations).forEach(([operationName, op]) => {


### PR DESCRIPTION
## Summary

- Fix GraphQL proxy requests hanging when the body is parsed by Express before proxying.
- Centralize JSON body parsing with a smaller default limit.

## Bug Description
- The proxy forwarded headers but not the already-parsed request body, so the upstream GraphQL server waited for bytes that never arrived, causing requests to hang.

### Error Logs
- [504 error response logs](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%0Aresource.labels.service_name%20%3D%20%22ndx-api-gateway%22%0Aresource.labels.location%20%3D%20%22asia-east1%22%0A%20severity%3E%3DDEFAULT%0Aseverity%3D%22ERROR%22%0AhttpRequest.status%3D504;storageScope=project;cursorTimestamp=2026-01-07T00:32:09.094007Z;startTime=2026-01-05T03:14:36.408Z;endTime=2026-01-07T03:14:36.408976Z?project=kids-reporter)

## Changes
- Add a global express.json({ limit: '1mb' }) middleware in packages/api-gateway/src/app.ts.
- Remove the redundant JSON parser from packages/api-gateway/src/routes/gql-rest.ts.
- In packages/api-gateway/src/gql-proxy-mini-app.ts, reattach the parsed body for non-multipart GraphQL requests by setting Content-Length and writing the body to
    the proxied request.