### PR TITLE
chore: adjust cloudbuild command to copy .yarnrc.yml

### DIFF
--- a/packages/cronjob/Dockerfile
+++ b/packages/cronjob/Dockerfile
@@ -5,7 +5,7 @@ RUN corepack enable
 # Set the working directory in the container to /app
 WORKDIR /app
 
-# Copy package.json and package-lock.json to the working directory
+# Copy package.json and .yarnrc.yml to the working directory
 COPY package*.json .yarnrc.yml ./
 
 # Install the application dependencies

--- a/packages/cronjob/cloudbuild.yaml
+++ b/packages/cronjob/cloudbuild.yaml
@@ -26,6 +26,7 @@ steps:
       - '-c'
       - >
         cp yarn.lock packages/$_TARGET_PACKAGE
+        cp .yarnrc.yml packages/$_TARGET_PACKAGE
 
         cd packages/$_TARGET_PACKAGE
 

--- a/packages/image-resizer/Dockerfile
+++ b/packages/image-resizer/Dockerfile
@@ -5,7 +5,7 @@ RUN corepack enable
 # Set the working directory in the container to /app
 WORKDIR /app
 
-# Copy package.json and package-lock.json to the working directory
+# Copy package.json and .yarnrc.yml to the working directory
 COPY package*.json .yarnrc.yml ./
 
 # Install the application dependencies

--- a/packages/image-resizer/all/Dockerfile
+++ b/packages/image-resizer/all/Dockerfile
@@ -5,7 +5,7 @@ RUN corepack enable
 # Set the working directory in the container to /app
 WORKDIR /app
 
-# Copy package.json and package-lock.json to the working directory
+# Copy package.json and .yarnrc.yml to the working directory
 COPY package*.json .yarnrc.yml ./
 
 # Install the application dependencies


### PR DESCRIPTION
## Summary

This PR updates the Cloud Build configuration and Dockerfiles to ensure `.yarnrc.yml` is properly copied during the build process. The changes ensure Yarn configuration files are available when building Docker images for cronjob and image-resizer packages.

## Changes

- Updated `packages/cronjob/cloudbuild.yaml` to copy `.yarnrc.yml` to the target package before Docker build
- Updated Dockerfile comments in `packages/cronjob/Dockerfile`, `packages/image-resizer/Dockerfile`, and `packages/image-resizer/all/Dockerfile` to reflect that `.yarnrc.yml` is being copied instead of `package-lock.json`

## Additional Notes

The Dockerfiles were already copying `.yarnrc.yml` in the COPY command, but the comments were outdated. The Cloud Build configuration was missing the step to copy `.yarnrc.yml` to the target package directory, which could cause build failures if Yarn requires the configuration file during installation.

## Screenshot(s)

## Reference(s)