### PR TITLE
chore(frontend): update public GQL endpoint for dev and staging

### DIFF
--- a/packages/frontend/.env.dev.public
+++ b/packages/frontend/.env.dev.public
@@ -1,4 +1,6 @@
-NEXT_PUBLIC_GQL_ENDPOINT=https://dev-kids-api.twreporter.org/api-gateway/api/graphql
+# NOTE: This URL should be NEXT_PUBLIC_API_GATEWAY_ENDPOINT + '/api/graphql'
+NEXT_PUBLIC_GQL_ENDPOINT=https://dev-kids.twreporter.org/api-gateway/api/graphql
+
 NEXT_PUBLIC_API_GATEWAY_ENDPOINT=https://dev-kids.twreporter.org/api-gateway
 NEXT_PUBLIC_BASE_URL=https://dev-kids.twreporter.org
 

--- a/packages/frontend/.env.staging.public
+++ b/packages/frontend/.env.staging.public
@@ -1,4 +1,6 @@
-NEXT_PUBLIC_GQL_ENDPOINT=https://staging-kids-api.twreporter.org/api-gateway/api/graphql
+# NOTE: This URL should be NEXT_PUBLIC_API_GATEWAY_ENDPOINT + '/api/graphql'
+NEXT_PUBLIC_GQL_ENDPOINT=https://staging-kids.twreporter.org/api-gateway/api/graphql
+
 NEXT_PUBLIC_API_GATEWAY_ENDPOINT=https://staging-kids.twreporter.org/api-gateway
 NEXT_PUBLIC_BASE_URL=https://staging-kids.twreporter.org
 


### PR DESCRIPTION
## 背景/問題
  - dev 與 staging 環境在 load balancer 之前有 IAP（Identity-Aware Proxy）
  - dev-kids.twreporter.org 呼叫 dev-kids-api.twreporter.org 時會先經過 IAP
  - 要通過 dev-kids-api.twreporter.org 的 IAP，需要先用瀏覽器開啟並登入，取得 IAP session
  - 正常使用流程不會直接開 dev-kids-api.twreporter.org，因此拿不到 IAP session
  - 導致 dev-kids.twreporter.org 呼叫 API 時遇到非預期錯誤（目前觀察到 CORS Error）

## 變更內容
  - 改為呼叫 dev-kids.twreporter.org/api-gateway/
  - 該 endpoint 會 proxy request 到 dev-kids-api.twreporter.org
  - 因此避開前端直接觸發 IAP 的問題