### PR TITLE
frontend: route server-side REST GQL via internal API gateway and document /api-gateway proxy

### DIFF
--- a/packages/frontend/.env.dev.public
+++ b/packages/frontend/.env.dev.public
@@ -1,6 +1,9 @@
 # NOTE: This URL should be NEXT_PUBLIC_API_GATEWAY_ENDPOINT + '/api/graphql'
 NEXT_PUBLIC_GQL_ENDPOINT=https://dev-kids.twreporter.org/api-gateway/api/graphql
 
+# Browser requests must go through the frontend /api-gateway proxy because
+# dev-kids-api.twreporter.org is protected by IAP and direct calls are blocked.
+# The /api-gateway route is configured in the Google Cloud Platform load balancer.
 NEXT_PUBLIC_API_GATEWAY_ENDPOINT=https://dev-kids.twreporter.org/api-gateway
 NEXT_PUBLIC_BASE_URL=https://dev-kids.twreporter.org
 

--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -3,6 +3,7 @@ INTERNAL_GQL_ENDPOINT=http://localhost:3000/api/graphql
 NEXT_PUBLIC_GQL_ENDPOINT=http://localhost:3000/api/graphql
 
 # API Gateway Endpoint
+INTERNAL_API_GATEWAY_ENDPOINT=http://localhost:3000
 NEXT_PUBLIC_API_GATEWAY_ENDPOINT=http://localhost:3000
 
 # Mock id_token

--- a/packages/frontend/.env.staging.public
+++ b/packages/frontend/.env.staging.public
@@ -1,6 +1,9 @@
 # NOTE: This URL should be NEXT_PUBLIC_API_GATEWAY_ENDPOINT + '/api/graphql'
 NEXT_PUBLIC_GQL_ENDPOINT=https://staging-kids.twreporter.org/api-gateway/api/graphql
 
+# Browser requests must go through the frontend /api-gateway proxy because
+# staging-kids-api.twreporter.org is protected by IAP and direct calls are blocked.
+# The /api-gateway route is configured in the Google Cloud Platform load balancer.
 NEXT_PUBLIC_API_GATEWAY_ENDPOINT=https://staging-kids.twreporter.org/api-gateway
 NEXT_PUBLIC_BASE_URL=https://staging-kids.twreporter.org
 

--- a/packages/frontend/src/constants/index.tsx
+++ b/packages/frontend/src/constants/index.tsx
@@ -7,6 +7,7 @@ export const INTERNAL_API_URL = envVars.internalGqlEndpoint
 export const API_URL = envVars.gqlEndpoint
 export const ACCESS_TOKEN_ENDPOINT = `${envVars.apiGatewayEndpoint}/auth/access-token`
 export const REST_GQL_ENDPOINT = `${envVars.apiGatewayEndpoint}/api/rest`
+export const INTERNAL_REST_GQL_ENDPOINT = `${envVars.internalApiGatewayEndpoint}/api/rest`
 export const LOGOUT_ENDPOINT = '/api/logout'
 
 export const KIDS_URL_ORIGIN = 'https://kids.twreporter.org'

--- a/packages/frontend/src/environment-variables.ts
+++ b/packages/frontend/src/environment-variables.ts
@@ -4,6 +4,9 @@ const gqlEndpoint =
   process.env.NEXT_PUBLIC_GQL_ENDPOINT || 'http://localhost:3001/api/graphql'
 const apiGatewayEndpoint =
   process.env.NEXT_PUBLIC_API_GATEWAY_ENDPOINT || 'http://localhost:3000'
+const internalApiGatewayEndpoint =
+  process.env.INTERNAL_API_GATEWAY_ENDPOINT || apiGatewayEndpoint
+
 const isProduction = process.env.NEXT_PUBLIC_RELEASE_ENV === 'prod'
 
 const searchAPIKey = process.env.SEARCH_API_KEY || ''
@@ -19,6 +22,7 @@ const loginWidgetUrl =
 const nodeEnv = process.env.NODE_ENV
 
 const environmentVariables = {
+  internalApiGatewayEndpoint,
   internalGqlEndpoint,
   gqlEndpoint,
   apiGatewayEndpoint,

--- a/packages/frontend/src/utils/send-rest-gql.ts
+++ b/packages/frontend/src/utils/send-rest-gql.ts
@@ -1,7 +1,7 @@
 import errors from '@twreporter/errors'
 import axios, { AxiosResponse } from 'axios'
 
-import { REST_GQL_ENDPOINT } from '@/constants'
+import { INTERNAL_REST_GQL_ENDPOINT, REST_GQL_ENDPOINT } from '@/constants'
 
 import { log, LogLevel } from './log'
 import { AXIOS_TIMEOUT } from './send-gql-request'
@@ -24,7 +24,12 @@ export async function sendRestGqlRequest<TData = Record<string, unknown>>({
   authToken?: string
   signal?: AbortSignal
 }) {
-  const url = `${REST_GQL_ENDPOINT}/${operation}`
+  let url
+  if (typeof window === 'undefined') {
+    url = `${INTERNAL_REST_GQL_ENDPOINT}/${operation}`
+  } else {
+    url = `${REST_GQL_ENDPOINT}/${operation}`
+  }
 
   let response: AxiosResponse<GraphQLResponse<TData>> | undefined
   try {


### PR DESCRIPTION
## Summary
This PR updates server-side REST GQL requests to use an internal API gateway endpoint and documents why browser requests must go through the /api-gateway proxy (to avoid IAP blocking direct API calls, with routing handled by the GCP load balancer).

## Changes
- Add INTERNAL_API_GATEWAY_ENDPOINT with fallback and expose INTERNAL_REST_GQL_ENDPOINT for server-side use
- Route REST GQL requests through the internal gateway when running on the server while keeping the public endpoint for browser usage
- Document the /api-gateway proxy requirement for dev and staging environments, including the IAP and GCP load balancer context
- Add a reference to the new internal gateway variable