### PR TITLE
feat(api-gateway,frontend): add REST gql endpoints and migrate frontend to REST operations

### DIFF
--- a/packages/api-gateway/src/graphql/operations/answers.ts
+++ b/packages/api-gateway/src/graphql/operations/answers.ts
@@ -1,4 +1,4 @@
-import { ensureRecord, Operation, parseVars, toInt } from './shared.js'
+import { ensureRecord, normalizeOrderBy, Operation, toInt } from './shared.js'
 
 export const operations: Record<string, Operation> = {
   'post-choice-answers': {
@@ -16,8 +16,7 @@ export const operations: Record<string, Operation> = {
         }
       }
     `,
-    buildVariables: (req) => {
-      const input = ensureRecord(parseVars(req), 'Missing variables')
+    buildVariables: (input) => {
       return { where: ensureRecord(input.where, 'Missing where') }
     },
   },
@@ -34,8 +33,7 @@ export const operations: Record<string, Operation> = {
         }
       }
     `,
-    buildVariables: (req) => {
-      const input = ensureRecord(parseVars(req), 'Missing variables')
+    buildVariables: (input) => {
       return { data: ensureRecord(input.data, 'Missing data') }
     },
   },
@@ -55,8 +53,7 @@ export const operations: Record<string, Operation> = {
         }
       }
     `,
-    buildVariables: (req) => {
-      const input = ensureRecord(parseVars(req), 'Missing variables')
+    buildVariables: (input) => {
       const id = input.id
       if (typeof id !== 'string') {
         throw new Error('Missing id')
@@ -78,8 +75,7 @@ export const operations: Record<string, Operation> = {
         }
       }
     `,
-    buildVariables: (req) => {
-      const input = ensureRecord(parseVars(req), 'Missing variables')
+    buildVariables: (input) => {
       return { where: ensureRecord(input.where, 'Missing where') }
     },
   },
@@ -107,12 +103,9 @@ export const operations: Record<string, Operation> = {
         }
       }
     `,
-    buildVariables: (req) => {
-      const input = ensureRecord(parseVars(req), 'Missing variables')
+    buildVariables: (input) => {
       return {
-        orderBy: Array.isArray(input.orderBy)
-          ? input.orderBy
-          : [{ createdAt: 'desc' }],
+        orderBy: normalizeOrderBy(input.orderBy, [{ createdAt: 'desc' }]),
         take: toInt(input.take),
       }
     },
@@ -129,8 +122,7 @@ export const operations: Record<string, Operation> = {
         }
       }
     `,
-    buildVariables: (req) => {
-      const input = ensureRecord(parseVars(req), 'Missing variables')
+    buildVariables: (input) => {
       return { data: ensureRecord(input.data, 'Missing data') }
     },
   },
@@ -149,13 +141,92 @@ export const operations: Record<string, Operation> = {
         }
       }
     `,
-    buildVariables: (req) => {
-      const input = ensureRecord(parseVars(req), 'Missing variables')
+    buildVariables: (input) => {
       const id = input.id
       if (typeof id !== 'string') {
         throw new Error('Missing id')
       }
       return { id, data: ensureRecord(input.data, 'Missing data') }
+    },
+  },
+  'post-essay-question-answers': {
+    method: 'GET',
+    auth: 'public',
+    operationName: 'GetEssayQuestionEssayAnswers',
+    document: `
+      query GetEssayQuestionEssayAnswers(
+        $where: PostEssayQuestionWhereUniqueInput!
+        $answerOrderBy: [PostEssayAnswerOrderByInput!]!
+        $answerTake: Int!
+        $answerSkip: Int
+      ) {
+        postEssayQuestion(where: $where) {
+          id
+          title
+          hint
+          answers(orderBy: $answerOrderBy, take: $answerTake, skip: $answerSkip) {
+            id
+            content
+            member {
+              id
+              avatar { fileUrl id }
+              name
+              nickname
+              email
+            }
+            likesCount
+          }
+        }
+      }
+    `,
+    buildVariables: (input) => {
+      const answerTake = toInt(input.answerTake)
+      if (typeof answerTake !== 'number') {
+        throw new Error('Missing required variable: answerTake')
+      }
+      return {
+        where: ensureRecord(input.where, 'Missing where'),
+        answerOrderBy: normalizeOrderBy(input.answerOrderBy, [
+          { createdAt: 'desc' },
+        ]),
+        answerTake,
+        answerSkip: toInt(input.answerSkip),
+      }
+    },
+  },
+  'create-post-essay-answer-like': {
+    method: 'POST',
+    auth: 'auth',
+    operationName: 'CreatePostEssayAnswerLike',
+    document: `
+      mutation CreatePostEssayAnswerLike(
+        $data: PostEssayAnswerLikeCreateInput!
+      ) {
+        createPostEssayAnswerLike(data: $data) {
+          answer { id }
+          member { id }
+        }
+      }
+    `,
+    buildVariables: (input) => {
+      return { data: ensureRecord(input.data, 'Missing data') }
+    },
+  },
+  'delete-post-essay-answer-like': {
+    method: 'POST',
+    auth: 'auth',
+    operationName: 'DeletePostEssayAnswerLike',
+    document: `
+      mutation DeletePostEssayAnswerLike(
+        $where: PostEssayAnswerLikeWhereUniqueInput!
+      ) {
+        deletePostEssayAnswerLike(where: $where) {
+          id
+        }
+      }
+    `,
+    buildVariables: (input) => {
+      return { where: ensureRecord(input.where, 'Missing where') }
     },
   },
 }

--- a/packages/api-gateway/src/graphql/operations/content.ts
+++ b/packages/api-gateway/src/graphql/operations/content.ts
@@ -1,8 +1,9 @@
 import {
   ensureArray,
   ensureRecord,
+  normalizeBoolean,
+  normalizeOrderBy,
   Operation,
-  parseVars,
   postContentFragment,
   toInt,
 } from './shared.js'
@@ -21,12 +22,11 @@ export const operations: Record<string, Operation> = {
         }
       }
     `,
-    buildVariables: (req) => {
-      const input = ensureRecord(parseVars(req), 'Missing variables')
+    buildVariables: (input) => {
       const take = toInt(input.take)
-      const orderBy = Array.isArray(input.orderBy)
-        ? input.orderBy
-        : [{ publishedDate: 'desc' }]
+      const orderBy = normalizeOrderBy(input.orderBy, [
+        { publishedDate: 'desc' },
+      ])
       return { orderBy, take }
     },
   },
@@ -47,8 +47,7 @@ export const operations: Record<string, Operation> = {
         }
       }
     `,
-    buildVariables: (req) => {
-      const input = ensureRecord(parseVars(req), 'Missing variables')
+    buildVariables: (input) => {
       return { take: toInt(input.take) }
     },
   },
@@ -66,8 +65,7 @@ export const operations: Record<string, Operation> = {
         }
       }
     `,
-    buildVariables: (req) => {
-      const input = ensureRecord(parseVars(req), 'Missing variables')
+    buildVariables: (input) => {
       const where = ensureRecord(input.where, 'Missing where')
       const page = where.page
       if (typeof page !== 'string') {
@@ -96,8 +94,7 @@ export const operations: Record<string, Operation> = {
         }
       }
     `,
-    buildVariables: (req) => {
-      const input = ensureRecord(parseVars(req), 'Missing variables')
+    buildVariables: (input) => {
       return {
         where: ensureRecord(input.where, 'Missing where'),
         take: toInt(input.take),
@@ -127,8 +124,7 @@ export const operations: Record<string, Operation> = {
         }
       }
     `,
-    buildVariables: (req) => {
-      const input = ensureRecord(parseVars(req), 'Missing variables')
+    buildVariables: (input) => {
       return {
         categoryWhere: ensureRecord(
           input.categoryWhere,
@@ -156,8 +152,7 @@ export const operations: Record<string, Operation> = {
         }
       }
     `,
-    buildVariables: (req) => {
-      const input = ensureRecord(parseVars(req), 'Missing variables')
+    buildVariables: (input) => {
       return { where: ensureRecord(input.where, 'Missing where') }
     },
   },
@@ -182,8 +177,7 @@ export const operations: Record<string, Operation> = {
         }
       }
     `,
-    buildVariables: (req) => {
-      const input = ensureRecord(parseVars(req), 'Missing variables')
+    buildVariables: (input) => {
       return {
         where: ensureRecord(input.where, 'Missing where'),
         take: toInt(input.take),
@@ -216,8 +210,7 @@ export const operations: Record<string, Operation> = {
         }
       }
     `,
-    buildVariables: (req) => {
-      const input = ensureRecord(parseVars(req), 'Missing variables')
+    buildVariables: (input) => {
       return {
         where: ensureRecord(input.where, 'Missing where'),
         take: toInt(input.take),
@@ -241,8 +234,7 @@ export const operations: Record<string, Operation> = {
         }
       }
     `,
-    buildVariables: (req) => {
-      const input = ensureRecord(parseVars(req), 'Missing variables')
+    buildVariables: (input) => {
       return {
         orderBy: ensureArray(input.orderBy, 'Missing orderBy'),
         take: toInt(input.take),
@@ -335,8 +327,7 @@ export const operations: Record<string, Operation> = {
         }
       }
     `,
-    buildVariables: (req) => {
-      const input = ensureRecord(parseVars(req), 'Missing variables')
+    buildVariables: (input) => {
       return {
         where: ensureRecord(input.where, 'Missing where'),
         orderBy: ensureArray(input.orderBy, 'Missing orderBy'),
@@ -374,8 +365,395 @@ export const operations: Record<string, Operation> = {
         }
       }
     `,
-    buildVariables: (req) => {
-      const input = ensureRecord(parseVars(req), 'Missing variables')
+    buildVariables: (input) => {
+      return { where: ensureRecord(input.where, 'Missing where') }
+    },
+  },
+  'posts-count': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'PostsCount',
+    document: `
+      query PostsCount {
+        postsCount
+      }
+    `,
+    buildVariables: () => ({}),
+  },
+  'posts-paged': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'GetPosts',
+    document: `
+      ${postContentFragment}
+      query GetPosts($orderBy: [PostOrderByInput!]!, $take: Int, $skip: Int) {
+        posts(orderBy: $orderBy, take: $take, skip: $skip) {
+          ...PostContent
+        }
+      }
+    `,
+    buildVariables: (input) => {
+      return {
+        orderBy: normalizeOrderBy(input.orderBy, [{ publishedDate: 'desc' }]),
+        take: toInt(input.take),
+        skip: toInt(input.skip),
+      }
+    },
+  },
+  'posts-essay-answers-with-likes': {
+    method: 'GET',
+    auth: 'public',
+    operationName: 'GetPostsEssayAnswersWithLikes',
+    document: `
+      query GetPostsEssayAnswersWithLikes(
+        $orderBy: [PostOrderByInput!]!
+        $take: Int
+        $skip: Int
+        $answerOrderBy: [PostEssayAnswerOrderByInput!]!
+        $answerTake: Int
+        $where: PostWhereInput!
+      ) {
+        posts(orderBy: $orderBy, take: $take, skip: $skip, where: $where) {
+          id
+          title
+          slug
+          heroImage { resized { medium } }
+          subSubcategoriesOrdered { name }
+          postEssayQuestions {
+            id
+            title
+            hint
+            answers(orderBy: $answerOrderBy, take: $answerTake) {
+              id
+              content
+              member {
+                id
+                avatar { id fileUrl }
+                name
+                nickname
+                email
+              }
+              likesCount
+            }
+          }
+        }
+      }
+    `,
+    buildVariables: (input) => {
+      return {
+        orderBy: normalizeOrderBy(input.orderBy, [{ publishedDate: 'desc' }]),
+        take: toInt(input.take),
+        skip: toInt(input.skip),
+        answerOrderBy: normalizeOrderBy(input.answerOrderBy, [
+          { createdAt: 'desc' },
+        ]),
+        answerTake: toInt(input.answerTake),
+        where: ensureRecord(input.where, 'Missing where'),
+      }
+    },
+  },
+  'post-essay-questions': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'GetPostEssayQuestions',
+    document: `
+      query GetPostEssayQuestions($where: PostWhereUniqueInput!) {
+        post(where: $where) {
+          id
+          slug
+          title
+          heroImage { resized { medium } }
+          postEssayQuestions { id title hint }
+          subSubcategoriesOrdered { name }
+        }
+      }
+    `,
+    buildVariables: (input) => {
+      return { where: ensureRecord(input.where, 'Missing where') }
+    },
+  },
+  'tag-posts': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'GetTagPosts',
+    document: `
+      ${postContentFragment}
+      query GetTagPosts(
+        $where: TagWhereUniqueInput!
+        $take: Int
+        $skip: Int
+        $orderBy: [PostOrderByInput!]!
+      ) {
+        tag(where: $where) {
+          posts(orderBy: $orderBy, take: $take, skip: $skip) {
+            ...PostContent
+          }
+          postsCount
+          name
+        }
+      }
+    `,
+    buildVariables: (input) => {
+      return {
+        where: ensureRecord(input.where, 'Missing where'),
+        orderBy: normalizeOrderBy(input.orderBy, [{ publishedDate: 'desc' }]),
+        take: toInt(input.take),
+        skip: toInt(input.skip),
+      }
+    },
+  },
+  'tag-meta': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'GetTagMeta',
+    document: `
+      query GetTagMeta($where: TagWhereUniqueInput!) {
+        tag(where: $where) {
+          ogDescription
+          ogTitle
+          ogImage { resized { small } }
+        }
+      }
+    `,
+    buildVariables: (input) => {
+      return { where: ensureRecord(input.where, 'Missing where') }
+    },
+  },
+  'project-detail': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'GetProject',
+    document: `
+      fragment ImageEntity on Photo {
+        resized { small medium large }
+      }
+      query GetProject($where: ProjectWhereUniqueInput!) {
+        project(where: $where) {
+          title
+          titlePosition
+          subtitle
+          content
+          credits
+          publishedDate
+          heroImage { ...ImageEntity }
+          mobileHeroImage { ...ImageEntity }
+          relatedPostsOrdered {
+            title
+            slug
+            publishedDate
+            heroImage { ...ImageEntity }
+            ogDescription
+            subSubcategoriesOrdered {
+              name
+              slug
+              subcategory {
+                name
+                slug
+                category { name slug themeColor }
+              }
+            }
+          }
+        }
+      }
+    `,
+    buildVariables: (input) => {
+      return { where: ensureRecord(input.where, 'Missing where') }
+    },
+  },
+  'project-meta': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'GetProjectMeta',
+    document: `
+      query GetProjectMeta($where: ProjectWhereUniqueInput!) {
+        project(where: $where) {
+          publishedDate
+          ogDescription
+          ogTitle
+          ogImage { resized { small } }
+        }
+      }
+    `,
+    buildVariables: (input) => {
+      return { where: ensureRecord(input.where, 'Missing where') }
+    },
+  },
+  'projects-paged': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'GetProjects',
+    document: `
+      ${postContentFragment}
+      query GetProjects(
+        $orderBy: [ProjectOrderByInput!]!
+        $take: Int
+        $skip: Int
+        $includeRelatedPosts: Boolean = false
+      ) {
+        projects(orderBy: $orderBy, take: $take, skip: $skip) {
+          title
+          slug
+          ogDescription
+          heroImage { resized { medium } }
+          publishedDate
+          relatedPostsOrdered @include(if: $includeRelatedPosts) {
+            ...PostContent
+          }
+        }
+        projectsCount
+      }
+    `,
+    buildVariables: (input) => {
+      return {
+        orderBy: normalizeOrderBy(input.orderBy, [{ publishedDate: 'desc' }]),
+        take: toInt(input.take),
+        skip: toInt(input.skip),
+        includeRelatedPosts: normalizeBoolean(input.includeRelatedPosts),
+      }
+    },
+  },
+  'project-related-posts-count': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'GetProjectRelatedPostsCount',
+    document: `
+      query GetProjectRelatedPostsCount(
+        $where: ProjectWhereUniqueInput!
+      ) {
+        project(where: $where) {
+          relatedPostsCount
+        }
+      }
+    `,
+    buildVariables: (input) => {
+      return { where: ensureRecord(input.where, 'Missing where') }
+    },
+  },
+  'author-posts': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'GetAuthorPosts',
+    document: `
+      ${postContentFragment}
+      query GetAuthorPosts(
+        $where: AuthorWhereUniqueInput!
+        $take: Int
+        $skip: Int
+        $orderBy: [PostOrderByInput!]!
+      ) {
+        author(where: $where) {
+          bio
+          name
+          email
+          avatar { resized { tiny } }
+          posts(orderBy: $orderBy, take: $take, skip: $skip) {
+            ...PostContent
+          }
+          postsCount
+        }
+      }
+    `,
+    buildVariables: (input) => {
+      return {
+        where: ensureRecord(input.where, 'Missing where'),
+        orderBy: normalizeOrderBy(input.orderBy, [{ publishedDate: 'desc' }]),
+        take: toInt(input.take),
+        skip: toInt(input.skip),
+      }
+    },
+  },
+  'author-meta': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'GetAuthorMeta',
+    document: `
+      query GetAuthorMeta($where: AuthorWhereUniqueInput!) {
+        author(where: $where) {
+          slug
+          name
+          bio
+          image { resized { small } }
+        }
+      }
+    `,
+    buildVariables: (input) => {
+      return { where: ensureRecord(input.where, 'Missing where') }
+    },
+  },
+  'author-avatar': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'GetAuthorAvatar',
+    document: `
+      query GetAuthorAvatar($where: AuthorWhereUniqueInput!) {
+        author(where: $where) {
+          avatar { resized { tiny } }
+        }
+      }
+    `,
+    buildVariables: (input) => {
+      return { where: ensureRecord(input.where, 'Missing where') }
+    },
+  },
+  'author-posts-count': {
+    method: 'GET',
+    cacheTtl: 120,
+    auth: 'public',
+    operationName: 'GetAuthorPostsCount',
+    document: `
+      query GetAuthorPostsCount($where: AuthorWhereUniqueInput!) {
+        author(where: $where) {
+          postsCount
+        }
+      }
+    `,
+    buildVariables: (input) => {
+      return { where: ensureRecord(input.where, 'Missing where') }
+    },
+  },
+  'posts-sitemap': {
+    method: 'GET',
+    cacheTtl: 300,
+    auth: 'public',
+    operationName: 'GetPostsForSitemap',
+    document: `
+      query GetPostsForSitemap($where: PostWhereInput!) {
+        posts(where: $where) {
+          slug
+          publishedDate
+        }
+      }
+    `,
+    buildVariables: (input) => {
+      return { where: ensureRecord(input.where, 'Missing where') }
+    },
+  },
+  'projects-sitemap': {
+    method: 'GET',
+    cacheTtl: 300,
+    auth: 'public',
+    operationName: 'GetProjectsForSitemap',
+    document: `
+      query GetProjectsForSitemap($where: ProjectWhereInput!) {
+        projects(where: $where) {
+          slug
+          publishedDate
+        }
+      }
+    `,
+    buildVariables: (input) => {
       return { where: ensureRecord(input.where, 'Missing where') }
     },
   },

--- a/packages/api-gateway/src/graphql/operations/members.ts
+++ b/packages/api-gateway/src/graphql/operations/members.ts
@@ -1,4 +1,4 @@
-import { ensureRecord, Operation, parseVars, toInt } from './shared.js'
+import { ensureRecord, Operation, toInt } from './shared.js'
 
 export const operations: Record<string, Operation> = {
   'member-profile': {
@@ -21,8 +21,7 @@ export const operations: Record<string, Operation> = {
         }
       }
     `,
-    buildVariables: (req) => {
-      const input = ensureRecord(parseVars(req), 'Missing variables')
+    buildVariables: (input) => {
       return { where: ensureRecord(input.where, 'Missing where') }
     },
   },
@@ -46,8 +45,7 @@ export const operations: Record<string, Operation> = {
         }
       }
     `,
-    buildVariables: (req) => {
-      const input = ensureRecord(parseVars(req), 'Missing variables')
+    buildVariables: (input) => {
       return {
         where: ensureRecord(input.where, 'Missing where'),
         data: ensureRecord(input.data, 'Missing data'),
@@ -69,8 +67,7 @@ export const operations: Record<string, Operation> = {
         )
       }
     `,
-    buildVariables: (req) => {
-      const input = ensureRecord(parseVars(req), 'Missing variables')
+    buildVariables: (input) => {
       return {
         take: toInt(input.take),
         nextCursor:
@@ -89,9 +86,27 @@ export const operations: Record<string, Operation> = {
         }
       }
     `,
-    buildVariables: (req) => {
-      const input = ensureRecord(parseVars(req), 'Missing variables')
+    buildVariables: (input) => {
       return { where: ensureRecord(input.where, 'Missing where') }
+    },
+  },
+  'member-essay-answers-has-liked': {
+    method: 'GET',
+    auth: 'auth',
+    operationName: 'GetMemberEssayAnswersHasLiked',
+    document: `
+      query GetMemberEssayAnswersHasLiked($essayAnswerIds: [ID!]!) {
+        getMemberEssayAnswersHasLiked(essayAnswerIds: $essayAnswerIds) {
+          essayAnswerId
+          hasLiked
+        }
+      }
+    `,
+    buildVariables: (input) => {
+      if (!Array.isArray(input.essayAnswerIds)) {
+        throw new Error('Missing essayAnswerIds')
+      }
+      return { essayAnswerIds: input.essayAnswerIds }
     },
   },
 }

--- a/packages/api-gateway/src/graphql/operations/shared.ts
+++ b/packages/api-gateway/src/graphql/operations/shared.ts
@@ -6,7 +6,7 @@ export type Operation = {
   auth: 'public' | 'auth'
   operationName: string
   document: string
-  buildVariables: (req: express.Request) => Record<string, unknown>
+  buildVariables: (input: Record<string, unknown>) => Record<string, unknown>
 }
 
 export const postContentFragment = `
@@ -43,18 +43,46 @@ export const ensureArray = (val: unknown, errorMessage: string): unknown[] => {
   return val
 }
 
-export const parseVars = (
-  req: express.Request
-): Record<string, unknown> | unknown[] => {
+export const normalizeOrderBy = (
+  raw: unknown,
+  fallback: unknown[] = []
+): unknown[] => {
+  if (Array.isArray(raw)) {
+    return raw
+  }
+  if (raw && typeof raw === 'object') {
+    return [raw]
+  }
+  return fallback
+}
+
+export const normalizeBoolean = (raw: unknown): boolean => {
+  if (typeof raw === 'boolean') {
+    return raw
+  }
+  if (typeof raw === 'number') {
+    if (raw === 1) return true
+    if (raw === 0) return false
+    return false
+  }
+  if (typeof raw === 'string') {
+    const normalized = raw.trim().toLowerCase()
+    if (normalized === 'true' || normalized === '1') return true
+    if (normalized === 'false' || normalized === '0') return false
+  }
+  return false
+}
+
+export const parseVars = (req: express.Request): Record<string, unknown> => {
   const source = req.method === 'GET' ? req.query : req.body
   const raw = (isRecord(source) ? source.variables : source) ?? {}
   if (typeof raw === 'string') {
     try {
       const parsed = JSON.parse(raw)
-      if (isRecord(parsed) || Array.isArray(parsed)) {
+      if (isRecord(parsed)) {
         return parsed
       }
-      throw new Error('Variables must be an object or array')
+      throw new Error('Variables must be an object')
     } catch (_err) {
       throw new Error(
         'Invalid JSON in variables: ' +
@@ -62,10 +90,10 @@ export const parseVars = (
       )
     }
   }
-  if (isRecord(raw) || Array.isArray(raw)) {
+  if (isRecord(raw)) {
     return raw
   }
-  throw new Error('Variables must be an object or array')
+  throw new Error('Variables must be an object')
 }
 
 export const toInt = (val: unknown): number | undefined => {

--- a/packages/api-gateway/src/routes/gql-rest.ts
+++ b/packages/api-gateway/src/routes/gql-rest.ts
@@ -6,6 +6,7 @@ import consts from '../constants.js'
 import { buildAuthContext } from '../graphql/auth.js'
 import { callCmsGraphql } from '../graphql/cms-client.js'
 import { operations } from '../graphql/operations.js'
+import { ensureRecord, parseVars } from '../graphql/operations/shared.js'
 
 const errors = _errors.default
 const statusCodes = consts.statusCodes
@@ -85,7 +86,8 @@ export function createGqlRestRouter({
       ).call(router, `/api/rest/${operationName}`, async (req, res) => {
         let variables
         try {
-          variables = op.buildVariables(req)
+          const input = ensureRecord(parseVars(req), 'Missing variables')
+          variables = op.buildVariables(input)
         } catch (err) {
           return logResponse(res, statusCodes.badRequest, {
             status: 'fail',

--- a/packages/frontend/src/api/extended.ts
+++ b/packages/frontend/src/api/extended.ts
@@ -4,10 +4,7 @@ import {
   GetMemberPostsWithAnswersQueryVariables,
 } from '__generated__/operations/extended.generated'
 
-import { sendGQLRequest } from '@/utils/send-gql-request'
 import { sendRestGqlRequest } from '@/utils/send-rest-gql'
-
-import { GET_MEMBER_ESSAY_ANSWERS_HAS_LIKED_GQL } from './graphql/extended'
 
 export type GetMemberPostsWithAnswersQuerySchema = {
   getMemberPostsWithAnswers: {
@@ -72,13 +69,13 @@ export const getMemberEssayAnswersHasLiked = async (
     accessToken: string
   }
 ) => {
-  const response = await sendGQLRequest<GetMemberEssayAnswersHasLikedQuery>(
+  const { accessToken, ...restVariables } = variables
+  const response = await sendRestGqlRequest<GetMemberEssayAnswersHasLikedQuery>(
     {
-      query: GET_MEMBER_ESSAY_ANSWERS_HAS_LIKED_GQL,
-      variables,
-    },
-    {
-      authToken: variables.accessToken,
+      operation: 'member-essay-answers-has-liked',
+      method: 'GET',
+      variables: restVariables,
+      authToken: accessToken,
     }
   )
   return response?.data?.data?.getMemberEssayAnswersHasLiked

--- a/packages/frontend/src/api/post-essay-answer-like.ts
+++ b/packages/frontend/src/api/post-essay-answer-like.ts
@@ -5,26 +5,18 @@ import {
   DeletePostEssayAnswerLikeMutationVariables,
 } from '__generated__/operations/post-essay-answer-like.generated'
 
-import { sendGQLRequest } from '@/utils'
-
-import {
-  CREATE_POST_ESSAY_ANSWER_LIKE_MUTATION,
-  DELETE_POST_ESSAY_ANSWER_LIKE_MUTATION,
-} from './graphql/post-essay-answer-like'
+import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
 export const createPostEssayAnswerLike = async (
   variables: CreatePostEssayAnswerLikeMutationVariables,
   accessToken: string
 ) => {
-  const response = await sendGQLRequest<CreatePostEssayAnswerLikeMutation>(
-    {
-      query: CREATE_POST_ESSAY_ANSWER_LIKE_MUTATION,
-      variables,
-    },
-    {
-      authToken: accessToken,
-    }
-  )
+  const response = await sendRestGqlRequest<CreatePostEssayAnswerLikeMutation>({
+    operation: 'create-post-essay-answer-like',
+    method: 'POST',
+    variables,
+    authToken: accessToken,
+  })
   return response?.data?.data?.createPostEssayAnswerLike
 }
 
@@ -32,14 +24,11 @@ export const deletePostEssayAnswerLike = async (
   variables: DeletePostEssayAnswerLikeMutationVariables,
   accessToken: string
 ) => {
-  const response = await sendGQLRequest<DeletePostEssayAnswerLikeMutation>(
-    {
-      query: DELETE_POST_ESSAY_ANSWER_LIKE_MUTATION,
-      variables,
-    },
-    {
-      authToken: accessToken,
-    }
-  )
+  const response = await sendRestGqlRequest<DeletePostEssayAnswerLikeMutation>({
+    operation: 'delete-post-essay-answer-like',
+    method: 'POST',
+    variables,
+    authToken: accessToken,
+  })
   return response?.data?.data?.deletePostEssayAnswerLike
 }

--- a/packages/frontend/src/api/post-essay-question.ts
+++ b/packages/frontend/src/api/post-essay-question.ts
@@ -4,9 +4,7 @@ import {
   PostEssayQuestionWhereUniqueInput,
 } from '__generated__/types'
 
-import { sendGQLRequest } from '@/utils/send-gql-request'
-
-import { GET_ESSAY_QUESTION_ESSAY_ANSWERS_GQL } from './graphql/post-essay-question'
+import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
 export const getPostEssayQuestionEssayAnswers = async ({
   where,
@@ -19,8 +17,9 @@ export const getPostEssayQuestionEssayAnswers = async ({
   answerTake: number
   answerSkip: number
 }) => {
-  const response = await sendGQLRequest<GetEssayQuestionEssayAnswersQuery>({
-    query: GET_ESSAY_QUESTION_ESSAY_ANSWERS_GQL,
+  const response = await sendRestGqlRequest<GetEssayQuestionEssayAnswersQuery>({
+    operation: 'post-essay-question-answers',
+    method: 'GET',
     variables: {
       where,
       answerOrderBy,

--- a/packages/frontend/src/api/post.ts
+++ b/packages/frontend/src/api/post.ts
@@ -10,13 +10,7 @@ import {
   GetPostsEssayAnswersWithLikesQueryVariables,
 } from '__generated__/operations/post.generated'
 
-import { sendGQLRequest } from '@/utils'
 import { sendRestGqlRequest } from '@/utils/send-rest-gql'
-
-import {
-  GET_POST_ESSAY_QUESTIONS_GQL,
-  GET_POSTS_ESSAY_ANSWERS_WITH_LIKES_GQL,
-} from './graphql/post'
 
 export const getLatestPosts = async (
   variables: GetLatestPostsQueryVariables
@@ -52,10 +46,13 @@ export const getPostMeta = async (
 export const getPostsEssayAnswersWithLikes = async (
   variables: GetPostsEssayAnswersWithLikesQueryVariables
 ) => {
-  const response = await sendGQLRequest<GetPostsEssayAnswersWithLikesQuery>({
-    query: GET_POSTS_ESSAY_ANSWERS_WITH_LIKES_GQL,
-    variables,
-  })
+  const response = await sendRestGqlRequest<GetPostsEssayAnswersWithLikesQuery>(
+    {
+      operation: 'posts-essay-answers-with-likes',
+      method: 'GET',
+      variables,
+    }
+  )
   return response?.data?.data?.posts
 }
 
@@ -64,8 +61,9 @@ export const getPostEssayQuestionsByPostSlug = async ({
 }: {
   slug: string
 }) => {
-  const response = await sendGQLRequest<GetPostEssayQuestionsQuery>({
-    query: GET_POST_ESSAY_QUESTIONS_GQL,
+  const response = await sendRestGqlRequest<GetPostEssayQuestionsQuery>({
+    operation: 'post-essay-questions',
+    method: 'GET',
     variables: { where: { slug } },
   })
   return response?.data?.data?.post

--- a/packages/frontend/src/app/(sticky-header)/about/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/about/page.tsx
@@ -15,7 +15,7 @@ import {
   SUBSCRIBE_URL,
 } from '@/constants'
 import envVars from '@/environment-variables'
-import { sendGQLRequest } from '@/utils'
+import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
 export const metadata: Metadata = {
   title: '關於少年報導者 - 少年報導者 The Reporter for Kids',
@@ -23,18 +23,6 @@ export const metadata: Metadata = {
 }
 
 export const revalidate = envVars.isProduction ? 86400 : 0 // 1 day
-
-const authorGQL = `
-query($where: AuthorWhereUniqueInput!) {
-  author(where: $where) {
-    avatar {
-      resized {
-        tiny
-      }
-    }
-  }
-}
-`
 
 const tellYouItems = [
   { image: '/assets/images/about_tell_pic1.svg', desc: '重要的議題' },
@@ -157,8 +145,9 @@ const consultants = [
 export default async function About() {
   // Fetch memeber avatar
   for (const member of teamMembers) {
-    const res = await sendGQLRequest({
-      query: authorGQL,
+    const res = await sendRestGqlRequest({
+      operation: 'author-avatar',
+      method: 'GET',
       variables: {
         where: {
           slug: member.slug,

--- a/packages/frontend/src/app/(sticky-header)/all/[[...page]]/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/all/[[...page]]/page.tsx
@@ -5,33 +5,15 @@ import { getCallBaodaozaiIntroContent } from '@/api/call-baodaozai-intro'
 import AllSiteBaodaozaiEventTrigger from '@/components/all-site-baodaozai-event-trigger'
 import Pagination from '@/components/pagination'
 import PostList from '@/components/post-list'
-import {
-  ERROR_PAGE,
-  GENERAL_DESCRIPTION,
-  POST_CONTENT_GQL,
-  POST_PER_PAGE,
-} from '@/constants'
+import { ERROR_PAGE, GENERAL_DESCRIPTION, POST_PER_PAGE } from '@/constants'
 import { BaodaozaiVisibilitySetter } from '@/services/call-baodaozai'
-import { getPostSummaries, log, LogLevel, sendGQLRequest } from '@/utils'
+import { getPostSummaries, log, LogLevel } from '@/utils'
+import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
 export const metadata: Metadata = {
   title: '所有文章 - 少年報導者 The Reporter for Kids',
   description: GENERAL_DESCRIPTION,
 }
-
-const postsCountGQL = `
-query Query {
-  postsCount
-}
-`
-
-const latestPostsGQL = `
-query($orderBy: [PostOrderByInput!]!, $take: Int, $skip: Int!) {
-  posts(orderBy: $orderBy, take: $take, skip: $skip) {
-    ${POST_CONTENT_GQL}
-  }
-}
-`
 
 // TODO: improve posts loading with ajax instead of routing to avoid page reload
 // Latest post page's routing path: /all/[page num], ex: /all/1
@@ -48,8 +30,9 @@ export default async function LatestPosts({
   }
 
   // Fetch total posts count
-  const postsCountRes = await sendGQLRequest({
-    query: postsCountGQL,
+  const postsCountRes = await sendRestGqlRequest({
+    operation: 'posts-count',
+    method: 'GET',
   })
   if (!postsCountRes) {
     log(LogLevel.WARNING, `Empty post count response!`)
@@ -68,12 +51,15 @@ export default async function LatestPosts({
     }
 
     // Fetch posts of specific page
-    const postsRes = await sendGQLRequest({
-      query: latestPostsGQL,
+    const postsRes = await sendRestGqlRequest({
+      operation: 'posts-paged',
+      method: 'GET',
       variables: {
-        orderBy: {
-          publishedDate: 'desc',
-        },
+        orderBy: [
+          {
+            publishedDate: 'desc',
+          },
+        ],
         take: POST_PER_PAGE,
         skip: (currentPage - 1) * POST_PER_PAGE,
       },

--- a/packages/frontend/src/app/(sticky-header)/author/[[...slug]]/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/author/[[...slug]]/page.tsx
@@ -9,44 +9,10 @@ import {
   DEFAULT_AVATAR,
   GENERAL_DESCRIPTION,
   KIDS_URL_ORIGIN,
-  POST_CONTENT_GQL,
   POST_PER_PAGE,
 } from '@/constants'
-import { getPostSummaries, log, LogLevel, sendGQLRequest } from '@/utils'
-
-const authorGQL = `
-  query($authorWhere2: AuthorWhereUniqueInput!, $take: Int, $skip: Int!, $orderBy: [PostOrderByInput!]!) {
-    author(where: $authorWhere2) {
-      bio
-      name
-      email
-      avatar {
-        resized {
-          tiny
-        }
-      }
-      posts(orderBy: $orderBy, take: $take, skip: $skip) {
-        ${POST_CONTENT_GQL}
-      }
-      postsCount
-    }
-  }
-`
-
-const metaGQL = `
-query($where: AuthorWhereUniqueInput!) {
-  author(where: $where) {
-    slug
-    name
-    bio
-    image {
-      resized {
-        small
-      }
-    }
-  }
-}
-`
+import { getPostSummaries, log, LogLevel } from '@/utils'
+import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
 export async function generateMetadata({
   params,
@@ -55,8 +21,9 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const slug = params.slug?.[0]
 
-  const authorMetaRes = await sendGQLRequest({
-    query: metaGQL,
+  const authorMetaRes = await sendRestGqlRequest({
+    operation: 'author-meta',
+    method: 'GET',
     variables: {
       where: {
         slug: slug,
@@ -100,10 +67,11 @@ export default async function Author({ params }: { params: { slug: any } }) {
     notFound()
   }
 
-  const response = await sendGQLRequest({
-    query: authorGQL,
+  const response = await sendRestGqlRequest({
+    operation: 'author-posts',
+    method: 'GET',
     variables: {
-      authorWhere2: {
+      where: {
         slug: slug,
       },
       orderBy: [

--- a/packages/frontend/src/app/(sticky-header)/tag/[[...slug]]/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/tag/[[...slug]]/page.tsx
@@ -8,36 +8,10 @@ import {
   GENERAL_DESCRIPTION,
   KIDS_URL_ORIGIN,
   OG_SUFFIX,
-  POST_CONTENT_GQL,
   POST_PER_PAGE,
 } from '@/constants'
-import { getPostSummaries, log, LogLevel, sendGQLRequest } from '@/utils'
-
-const tagGQL = `
-query($where: TagWhereUniqueInput!, $take: Int, $skip: Int!, $orderBy: [PostOrderByInput!]!) {
-  tag(where: $where) {
-    posts(orderBy: $orderBy, take: $take, skip: $skip) {
-      ${POST_CONTENT_GQL}
-    }
-    postsCount
-    name
-  }
-}
-`
-
-const metaGQL = `
-query($where: TagWhereUniqueInput!) {
-  tag(where: $where) {
-    ogDescription
-    ogTitle
-    ogImage {
-      resized {
-        small
-      }
-    }
-  }
-}
-`
+import { getPostSummaries, log, LogLevel } from '@/utils'
+import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
 export async function generateMetadata({
   params,
@@ -46,8 +20,9 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const slug = params.slug?.[0]
 
-  const tagOGRes = await sendGQLRequest({
-    query: metaGQL,
+  const tagOGRes = await sendRestGqlRequest({
+    operation: 'tag-meta',
+    method: 'GET',
     variables: {
       where: {
         slug: slug,
@@ -90,8 +65,9 @@ export default async function Tag({ params }: { params: { slug: any } }) {
     notFound()
   }
 
-  const response = await sendGQLRequest({
-    query: tagGQL,
+  const response = await sendRestGqlRequest({
+    operation: 'tag-posts',
+    method: 'GET',
     variables: {
       where: {
         slug: slug,

--- a/packages/frontend/src/app/(sticky-header)/topic/[slug]/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/topic/[slug]/page.tsx
@@ -9,82 +9,14 @@ import {
   OG_SUFFIX,
   Theme,
 } from '@/constants'
-import {
-  getFormattedDate,
-  getPostSummaries,
-  log,
-  LogLevel,
-  sendGQLRequest,
-} from '@/utils'
+import { getFormattedDate, getPostSummaries, log, LogLevel } from '@/utils'
+import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
 import { Content } from '../../_components/topic/content'
 import { Credits } from '../../_components/topic/credits'
 import { Leading } from '../../_components/topic/leading'
 import { RelatedPosts } from '../../_components/topic/related-posts'
 import { PublishedDate } from '../../_components/topic/styled'
-
-const query = `
-  fragment ImageEntity on Photo {
-    resized {
-      small
-      medium
-      large
-    }
-  }
-  query GetAProject($where: ProjectWhereUniqueInput!) {
-    project(where: $where) {
-      title
-      titlePosition
-      subtitle
-      content
-      credits
-      publishedDate
-      heroImage {
-        ...ImageEntity
-      }
-      mobileHeroImage {
-        ...ImageEntity
-      }
-      relatedPostsOrdered {
-        title
-        slug
-        publishedDate
-        heroImage {
-          ...ImageEntity
-        }
-        ogDescription
-        subSubcategoriesOrdered {
-          name
-          slug
-          subcategory {
-            name
-            slug
-            category {
-              name
-              slug
-              themeColor
-            }
-          }
-        }
-      }
-    }
-  }
-`
-
-const metaGQL = `
-query($where: ProjectWhereUniqueInput!) {
-  project(where: $where) {
-    publishedDate
-    ogDescription
-    ogTitle
-    ogImage {
-      resized {
-        small
-      }
-    }
-  }
-}
-`
 
 export async function generateMetadata({
   params,
@@ -93,8 +25,9 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const slug = params.slug
 
-  const topicOGRes = await sendGQLRequest({
-    query: metaGQL,
+  const topicOGRes = await sendRestGqlRequest({
+    operation: 'project-meta',
+    method: 'GET',
     variables: {
       where: {
         slug: slug,
@@ -139,8 +72,9 @@ export default async function TopicPage({
   }
 
   // TODO: maybe we could try apollo-client pkg
-  const axiosRes = await sendGQLRequest({
-    query,
+  const axiosRes = await sendRestGqlRequest({
+    operation: 'project-detail',
+    method: 'GET',
     variables: {
       where: {
         slug: params.slug,

--- a/packages/frontend/src/app/(sticky-header)/topic/page/[[...pageNum]]/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/topic/page/[[...pageNum]]/page.tsx
@@ -10,19 +10,13 @@ import PostSlider from '@/components/post-slider'
 import {
   FALLBACK_IMG,
   GENERAL_DESCRIPTION,
-  POST_CONTENT_GQL,
   POST_PER_PAGE,
   Theme,
   TOPIC_PAGE_ROUTE,
 } from '@/constants'
 import { BaodaozaiVisibilitySetter } from '@/services/call-baodaozai'
-import {
-  getFormattedDate,
-  getPostSummaries,
-  log,
-  LogLevel,
-  sendGQLRequest,
-} from '@/utils'
+import { getFormattedDate, getPostSummaries, log, LogLevel } from '@/utils'
+import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
 import styles from './page.module.css'
 
@@ -34,32 +28,6 @@ const ImageWithFallback = dynamic(
 export const metadata: Metadata = {
   title: '彙整: 專題 - 少年報導者 The Reporter for Kids',
   description: GENERAL_DESCRIPTION,
-}
-
-const genTopicsGQL = (hasRelatedPosts: boolean): string => {
-  const relatedPostsGQL = `
-    relatedPostsOrdered {
-      ${POST_CONTENT_GQL}
-    }
-  `
-
-  return `
-  query ($orderBy: [ProjectOrderByInput!]!, $take: Int, $skip: Int!) {
-    projects(orderBy: $orderBy, take: $take, skip: $skip) {
-      title
-      slug
-      ogDescription
-      heroImage {
-        resized {
-          medium
-        }
-      }
-      publishedDate
-      ${hasRelatedPosts ? relatedPostsGQL : ''}
-    }
-    projectsCount
-  }
-  `
 }
 
 type TopicSummary = {
@@ -170,8 +138,9 @@ export default async function Topic({
 
   const [projectsRes, topicsIntroContentRes] = await Promise.allSettled([
     // Fetch projects of specific page
-    sendGQLRequest({
-      query: genTopicsGQL(currentPage === 1),
+    sendRestGqlRequest({
+      operation: 'projects-paged',
+      method: 'GET',
       variables: {
         orderBy: [
           {
@@ -180,6 +149,7 @@ export default async function Topic({
         ],
         take: POST_PER_PAGE,
         skip: (currentPage - 1) * POST_PER_PAGE,
+        includeRelatedPosts: currentPage === 1,
       },
     }),
     getCallBaodaozaiIntroContent({ where: { page: 'topics' } }),

--- a/packages/frontend/src/app/api/search/utils.ts
+++ b/packages/frontend/src/app/api/search/utils.ts
@@ -30,80 +30,81 @@ export async function transferItemsToCards(
     return items
   }
 
-  const cardItems: CardProp[] = []
-  for (const item of items) {
-    const metaTag = item?.pagemap?.metatags?.[0]
-    const contentType = metaTag?.['contenttype']
+  const cardItems = await Promise.all(
+    items.map(async (item) => {
+      const metaTag = item?.pagemap?.metatags?.[0]
+      const contentType = metaTag?.['contenttype']
 
-    if (!validContentTypes.includes(contentType)) {
-      continue
-    }
+      if (!validContentTypes.includes(contentType)) {
+        return null
+      }
 
-    const creativeWork = item?.pagemap?.creativework?.[0]
-    const contentSummary = {
-      type: contentType,
-      image: creativeWork?.image || metaTag?.['og:image'],
-      title: creativeWork?.headline || metaTag?.['og:title'],
-      desc: metaTag?.['og:description'],
-      publishedDate: metaTag?.['publisheddate'] ?? '',
-      url: item?.link || metaTag?.['og:url'],
-      category: metaTag?.['category'] ?? '',
-      subSubcategory: metaTag?.['subSubcategory'] ?? '',
-      theme: Theme.BLUE,
-      postCount: 0,
-    }
+      const creativeWork = item?.pagemap?.creativework?.[0]
+      const contentSummary = {
+        type: contentType,
+        image: creativeWork?.image || metaTag?.['og:image'],
+        title: creativeWork?.headline || metaTag?.['og:title'],
+        desc: metaTag?.['og:description'],
+        publishedDate: metaTag?.['publisheddate'] ?? '',
+        url: item?.link || metaTag?.['og:url'],
+        category: metaTag?.['category'] ?? '',
+        subSubcategory: metaTag?.['subSubcategory'] ?? '',
+        theme: Theme.BLUE,
+        postCount: 0,
+      }
 
-    const url = item?.link || metaTag?.['og:url']
-    const slug = url.match(/(author|topic|tag)\/([^/]*)\/?/)?.[2]
-    if (contentType === ContentType.TOPIC && slug) {
-      const topicRes = await sendRestGqlRequest({
-        operation: 'project-related-posts-count',
-        method: 'GET',
-        variables: {
-          where: {
-            slug: slug,
+      const url = item?.link || metaTag?.['og:url']
+      const slug = url?.match(/(author|topic|tag)\/([^/]*)\/?/)?.[2]
+      if (contentType === ContentType.TOPIC && slug) {
+        const topicRes = await sendRestGqlRequest({
+          operation: 'project-related-posts-count',
+          method: 'GET',
+          variables: {
+            where: {
+              slug: slug,
+            },
           },
-        },
-      })
-      contentSummary.category = '專題'
-      contentSummary.postCount =
-        topicRes?.data?.data?.project?.relatedPostsCount
-    } else if (contentType === ContentType.AUTHOR && slug) {
-      const authorRes = await sendRestGqlRequest({
-        operation: 'author-posts-count',
-        method: 'GET',
-        variables: {
-          where: {
-            slug: slug,
+        })
+        contentSummary.category = '專題'
+        contentSummary.postCount =
+          topicRes?.data?.data?.project?.relatedPostsCount
+      } else if (contentType === ContentType.AUTHOR && slug) {
+        const authorRes = await sendRestGqlRequest({
+          operation: 'author-posts-count',
+          method: 'GET',
+          variables: {
+            where: {
+              slug: slug,
+            },
           },
-        },
-      })
-      contentSummary.category = '作者'
-      contentSummary.postCount = authorRes?.data?.data?.author?.postsCount
-    } else if (contentType === ContentType.TAG && slug) {
-      const tagRes = await sendRestGqlRequest({
-        operation: 'tag-posts',
-        method: 'GET',
-        variables: {
-          where: {
-            slug: slug,
+        })
+        contentSummary.category = '作者'
+        contentSummary.postCount = authorRes?.data?.data?.author?.postsCount
+      } else if (contentType === ContentType.TAG && slug) {
+        const tagRes = await sendRestGqlRequest({
+          operation: 'tag-posts',
+          method: 'GET',
+          variables: {
+            where: {
+              slug: slug,
+            },
+            take: 1,
+            orderBy: {
+              publishedDate: 'desc',
+            },
           },
-          take: 1,
-          orderBy: {
-            publishedDate: 'desc',
-          },
-        },
-      })
-      contentSummary.category = '標籤'
-      contentSummary.postCount = tagRes?.data?.data?.tag?.postsCount
-      contentSummary.image =
-        tagRes?.data?.data?.tag?.posts?.[0]?.heroImage?.resized?.tiny
-    }
+        })
+        contentSummary.category = '標籤'
+        contentSummary.postCount = tagRes?.data?.data?.tag?.postsCount
+        contentSummary.image =
+          tagRes?.data?.data?.tag?.posts?.[0]?.heroImage?.resized?.tiny
+      }
 
-    cardItems.push({ content: contentSummary })
-  }
+      return { content: contentSummary }
+    })
+  )
 
-  return cardItems
+  return cardItems.filter((item): item is CardProp => Boolean(item))
 }
 
 async function getSearchResults({

--- a/packages/frontend/src/app/api/search/utils.ts
+++ b/packages/frontend/src/app/api/search/utils.ts
@@ -4,38 +4,8 @@ import errors from '@twreporter/errors'
 
 import { CardProp } from '@/app/(sticky-header)/_components/search/card'
 import { ContentType, Theme } from '@/constants'
-import { log, LogLevel, sendGQLRequest } from '@/utils'
-
-const topicQuery = `
-query Query($where: ProjectWhereUniqueInput!) {
-  project(where: $where) {
-    relatedPostsCount
-  }
-}
-`
-
-const authorQuery = `
-query Query($where: AuthorWhereUniqueInput!) {
-  author(where: $where) {
-    postsCount
-  }
-}
-`
-
-const tagQuery = `
-query Query($where: TagWhereUniqueInput!, $take: Int, $orderBy: [PostOrderByInput!]!) {
-  tag(where: $where) {
-    posts(take: $take, orderBy: $orderBy) {
-      heroImage {
-        resized {
-          tiny
-        }
-      }
-    }
-    postsCount
-  }
-}
-`
+import { log, LogLevel } from '@/utils'
+import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
 const client = customsearch('v1')
 export const defaultCount = 10
@@ -86,8 +56,9 @@ export async function transferItemsToCards(
     const url = item?.link || metaTag?.['og:url']
     const slug = url.match(/(author|topic|tag)\/([^/]*)\/?/)?.[2]
     if (contentType === ContentType.TOPIC && slug) {
-      const topicRes = await sendGQLRequest({
-        query: topicQuery,
+      const topicRes = await sendRestGqlRequest({
+        operation: 'project-related-posts-count',
+        method: 'GET',
         variables: {
           where: {
             slug: slug,
@@ -98,8 +69,9 @@ export async function transferItemsToCards(
       contentSummary.postCount =
         topicRes?.data?.data?.project?.relatedPostsCount
     } else if (contentType === ContentType.AUTHOR && slug) {
-      const authorRes = await sendGQLRequest({
-        query: authorQuery,
+      const authorRes = await sendRestGqlRequest({
+        operation: 'author-posts-count',
+        method: 'GET',
         variables: {
           where: {
             slug: slug,
@@ -109,8 +81,9 @@ export async function transferItemsToCards(
       contentSummary.category = '作者'
       contentSummary.postCount = authorRes?.data?.data?.author?.postsCount
     } else if (contentType === ContentType.TAG && slug) {
-      const tagRes = await sendGQLRequest({
-        query: tagQuery,
+      const tagRes = await sendRestGqlRequest({
+        operation: 'tag-posts',
+        method: 'GET',
         variables: {
           where: {
             slug: slug,

--- a/packages/frontend/src/app/sitemap.ts
+++ b/packages/frontend/src/app/sitemap.ts
@@ -14,27 +14,9 @@ import { MetadataRoute } from 'next'
 
 import { KIDS_URL_ORIGIN } from '@/constants'
 import envVars from '@/environment-variables'
-import { sendGQLRequest } from '@/utils'
+import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
 export const revalidate = envVars.isProduction ? 86400 : 0 // 1 day
-
-const postsGQL = `
-query($where: PostWhereInput!) {
-  posts(where: $where) {
-    slug
-    publishedDate
-  }
-}
-`
-
-const topicsGQL = `
-query($where: ProjectWhereInput!) {
-  projects(where: $where) {
-    slug
-    publishedDate
-  }
-}
-`
 
 const fetchSitemaps = async (): Promise<
   { url: string; lastModified: Date }[]
@@ -43,8 +25,9 @@ const fetchSitemaps = async (): Promise<
   const sixtyDaysBefore = new Date(
     new Date().setHours(0, 0, 0, 0) - 60 * 24 * 60 * 60 * 1000
   )
-  const postsRes = await sendGQLRequest({
-    query: postsGQL,
+  const postsRes = await sendRestGqlRequest({
+    operation: 'posts-sitemap',
+    method: 'GET',
     variables: {
       where: {
         publishedDate: {
@@ -63,8 +46,9 @@ const fetchSitemaps = async (): Promise<
     sitemaps = [...posts]
   }
 
-  const topicsRes = await sendGQLRequest({
-    query: topicsGQL,
+  const topicsRes = await sendRestGqlRequest({
+    operation: 'projects-sitemap',
+    method: 'GET',
     variables: {
       where: {
         publishedDate: {


### PR DESCRIPTION
## Summary
This PR adds new REST-backed GraphQL operations in the API gateway for posts, tags, authors, projects, sitemap, and essay interactions, then migrates frontend API helpers and server components to call those REST operations instead of issuing direct GraphQL requests.

## Changes
- Added API gateway REST operations for content listings, metadata, sitemap queries, and essay-related queries/mutations, including member essay-like status lookup.
- Replaced frontend GraphQL calls in API helpers with REST gql gateway calls for post essay Q/A and likes.
- Migrated server components and utilities (about, all, author, tag, topic, search, sitemap) to REST operations; removed inline GraphQL strings and unused imports.
- Normalized REST query variable handling for orderBy arrays and boolean flags in gateway content operations.

## Why
- Centralize data access through the API gateway.
- Reduce direct GraphQL usage in the frontend and consolidate schema access behind REST operations.

##  Testing
- Not run (no automated tests were executed).

##  Notes / Follow-ups
- Verify endpoints behave as expected for public and auth routes (e.g., essay answer likes and member like status).
- Confirm sitemap and search helper requests match prior GraphQL behavior and caching expectations.