### PR TITLE
fix(cms): simplify member avatar access control and fix image domain config

### DIFF
--- a/packages/cms/lists/member-avatar.ts
+++ b/packages/cms/lists/member-avatar.ts
@@ -9,10 +9,7 @@ import {
 
 import config from '../config'
 import { allowAllRoles } from './utils/access-control-list'
-import {
-  makeMemberOwnedFilter,
-  memberOwnedOperationAccess,
-} from './utils/member-owned-access'
+import { memberOwnedOperationAccess } from './utils/member-owned-access'
 
 const ALLOWED_IMAGE_TYPES = [
   'image/jpeg',
@@ -25,7 +22,6 @@ const ALLOWED_IMAGE_TYPES = [
 const MAX_IMAGE_SIZE = 5 * 1024 * 1024 // 5MB
 
 const operationAccessControl = memberOwnedOperationAccess
-const filterAccessControl = makeMemberOwnedFilter('self')
 export default list({
   fields: {
     name: text({
@@ -77,13 +73,13 @@ export default list({
     operation: {
       query: allowAllRoles(),
       create: operationAccessControl,
-      update: operationAccessControl,
+      update: () => false,
       delete: operationAccessControl,
     },
     filter: {
       query: undefined,
-      update: filterAccessControl,
-      delete: filterAccessControl,
+      update: undefined,
+      delete: () => ({ member: null }),
     },
   },
   hooks: {

--- a/packages/frontend/next.config.mjs
+++ b/packages/frontend/next.config.mjs
@@ -14,6 +14,10 @@ const nextConfig = {
         hostname: 'kids-storage.twreporter.org',
       },
       {
+        protocol: 'https',
+        hostname: '*-kids-storage.twreporter.org',
+      },
+      {
         protocol: 'http',
         hostname: 'localhost',
       },


### PR DESCRIPTION
## Summary

This PR fixes avatar update errors by simplifying the member avatar access control logic in the CMS and adding support for wildcard subdomains in the Next.js image configuration.

## Changes

- **packages/cms/lists/member-avatar.ts**:
  - Removed unused `makeMemberOwnedFilter` import and `filterAccessControl` constant
  - Disabled update operations by setting `update` access control to `() => false`
  - Simplified filter access control: set `update` filter to `undefined` and `delete` filter to `() => ({ member: null })`

- **packages/frontend/next.config.mjs**:
  - Added wildcard pattern `*-kids-storage.twreporter.org` to `remotePatterns` to support image loading from subdomains

## Additional Notes

The update operation for member avatars is now completely disabled. The access control logic has been simplified by removing the `makeMemberOwnedFilter` dependency and using more direct filter functions. Only allow orphan avatar to be deleted.

## Screenshot(s)

## Reference(s)

