### PR TITLE
feat(frontend): enhance essay answer editing experience

### DIFF
--- a/packages/frontend/src/api-utils/react-query/hooks/post.ts
+++ b/packages/frontend/src/api-utils/react-query/hooks/post.ts
@@ -55,6 +55,7 @@ export function usePostsEssayAnswersWithLikesInfinityQuery({
     },
     initialPageParam: 0,
     select,
+    refetchOnMount: 'always',
   })
 }
 

--- a/packages/frontend/src/modules/membership/my-reading/index.tsx
+++ b/packages/frontend/src/modules/membership/my-reading/index.tsx
@@ -3,7 +3,7 @@ import {
   Button,
   HeaderMobileBackButtonHrefSetter,
 } from '@kids-reporter/routing-ui'
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import { DEFAULT_PAGE_ITEM_COUNT } from '@/api-utils/react-query/constants'
 import { useMemberPostsWithAnswersInfinityQuery } from '@/api-utils/react-query/hooks/extended'
@@ -28,13 +28,10 @@ function MyReading() {
     accessToken: tokens?.accessToken ?? '',
   })
 
-  const memberPostsWithAnswers = useMemo(() => {
-    return memberPostsWithAnswersPageData?.pages[currentPage - 1]?.posts ?? []
-  }, [memberPostsWithAnswersPageData, currentPage])
-
-  const currentPostQuestionAnswers = memberPostsWithAnswers
-    ? parseMemberPostsWithAnswersToPostQuestionAnswers(memberPostsWithAnswers)
-    : []
+  const currentPostQuestionAnswers =
+    parseMemberPostsWithAnswersToPostQuestionAnswers(
+      memberPostsWithAnswersPageData?.pages[currentPage - 1]?.posts ?? []
+    )
 
   const isFirstPage = currentPage === 1
   const isLastPage =
@@ -46,6 +43,13 @@ function MyReading() {
     }
   }, [currentPage, fetchNextPage, hasNextPage])
 
+  const [openedAccordionItemValue, setOpenedAccordionItemValue] = useState<
+    string | undefined
+  >(undefined)
+  const handleBackToFirstPage = useCallback((slug: string) => {
+    setCurrentPage(1)
+    setOpenedAccordionItemValue(slug)
+  }, [])
   const isGetMemberPostsWithAnswersLoading = isLoading || !member?.id
 
   return (
@@ -63,6 +67,8 @@ function MyReading() {
             postQuestionAnswers={currentPostQuestionAnswers}
             isLoading={isGetMemberPostsWithAnswersLoading}
             key={currentPage}
+            onBackToFirstPage={handleBackToFirstPage}
+            openedAccordionItemValue={openedAccordionItemValue}
           />
           {!isGetMemberPostsWithAnswersLoading &&
             currentPostQuestionAnswers.length > 0 && (
@@ -79,7 +85,10 @@ function MyReading() {
                   variant="secondary"
                   className="size-11 p-0"
                   disabled={isLastPage}
-                  onClick={() => setCurrentPage(currentPage + 1)}
+                  onClick={() => {
+                    setCurrentPage(currentPage + 1)
+                    setOpenedAccordionItemValue(undefined)
+                  }}
                 >
                   <ArrowRight />
                 </Button>

--- a/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/essay-answer-item.tsx
+++ b/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/essay-answer-item.tsx
@@ -1,22 +1,131 @@
+'use client'
+
 import { PostEssayAnswer } from '__generated__/types'
+import { useQueryClient } from '@tanstack/react-query'
+import errors from '@twreporter/errors'
+import { useState } from 'react'
+import { toast } from 'sonner'
 
+import { DEFAULT_PAGE_ITEM_COUNT } from '@/api-utils/react-query/constants'
+import { useMemberPostsWithAnswersInfinityQuery } from '@/api-utils/react-query/hooks/extended'
+import {
+  usePostEssayAnswersQuery,
+  useUpdatePostEssayAnswerMutation,
+} from '@/api-utils/react-query/hooks/post-essay-answer'
 import Divider from '@/components/divider'
-import { ThumbUpIcon } from '@/icons/miscellaneous'
+import { StarIcon } from '@/icons/miscellaneous'
 import { getDisplayLikesCount } from '@/modules/idea-hub/utils'
+import { useHydratedAuthStore } from '@/services/auth/use-hydrated-auth-store'
+import BaodaozaiQAModal from '@/services/call-baodaozai/components/qa-modal'
+import { CallBaodaozaiProvider } from '@/services/call-baodaozai/context'
+import { log, LogLevel } from '@/utils'
 
-function EssayAnswerItem({ answer }: { answer: PostEssayAnswer }) {
+function EssayAnswerItem({
+  answer,
+  postSlug,
+  onBackToFirstPage,
+}: {
+  answer: PostEssayAnswer
+  postSlug: string
+  onBackToFirstPage: (slug: string) => void
+}) {
   const likesCount = getDisplayLikesCount(answer.likesCount)
+  const [isOpen, setIsOpen] = useState(false)
+  const { tokens, member } = useHydratedAuthStore()
+  const { mutateAsync: updatePostEssayAnswer } =
+    useUpdatePostEssayAnswerMutation({
+      accessToken: tokens?.accessToken ?? '',
+    })
+
+  const queryClient = useQueryClient()
+
+  const handleSubmit = async (answers: Record<number, string>) => {
+    try {
+      await updatePostEssayAnswer({
+        id: answer.id,
+        data: {
+          content: answers[0],
+        },
+      })
+      toast.success('編輯成功')
+      setIsOpen(false)
+      queryClient.invalidateQueries({
+        queryKey: usePostEssayAnswersQuery.getQueryKey({
+          memberId: member?.id ?? '',
+          postSlug,
+        }),
+      })
+      queryClient.invalidateQueries({
+        queryKey: useMemberPostsWithAnswersInfinityQuery.getQueryKey({
+          memberId: member?.id ?? '',
+          take: DEFAULT_PAGE_ITEM_COUNT,
+        }),
+      })
+      onBackToFirstPage(postSlug)
+    } catch (_err) {
+      const err = errors.helpers.wrap(
+        _err,
+        'EssayAnswerItemError',
+        'Error updating essay answer',
+        answer.id
+      )
+
+      const msg = errors.helpers.printAll(
+        err,
+        {
+          withStack: true,
+          withPayload: true,
+        },
+        0,
+        0
+      )
+
+      log(LogLevel.ERROR, msg)
+      toast.error('編輯失敗，請稍後再試。')
+    }
+  }
+
   return (
-    <div className="flex gap-4 rounded-xl bg-white px-5 py-4">
-      <p className="prose-p1-medium text-neutral-900">{answer.content || ''}</p>
-      <Divider direction="vertical" className="ml-auto self-stretch" />
-      <div className="flex flex-col items-center gap-1">
-        <div className="text-neutral-600">
-          <ThumbUpIcon />
+    <>
+      <div className="flex gap-4 rounded-xl bg-white px-5 py-4">
+        <p className="prose-p1-medium text-neutral-900">
+          {answer.content || ''}
+          &nbsp;（
+          <button
+            type="button"
+            className="cursor-pointer text-neutral-600 underline"
+            onClick={() => setIsOpen(true)}
+          >
+            編輯答案
+          </button>
+          ）
+        </p>
+        <Divider direction="vertical" className="ml-auto h-auto self-stretch" />
+        <div className="flex flex-col items-center gap-1">
+          <div className="text-neutral-600">
+            <StarIcon />
+          </div>
+          <span className="prose-p2 text-neutral-600">{likesCount}</span>
         </div>
-        <span className="prose-p2 text-neutral-600">{likesCount}</span>
       </div>
-    </div>
+      <CallBaodaozaiProvider>
+        <BaodaozaiQAModal
+          questions={[
+            {
+              id: answer.question?.id ?? '',
+              type: 'essay',
+              title: answer.question?.title ?? '',
+              hint: answer.question?.hint ?? '',
+              defaultAnswer: answer.content ?? '',
+            },
+          ]}
+          onClose={() => setIsOpen(false)}
+          onSubmit={handleSubmit}
+          isOpen={isOpen}
+          mode="update"
+        />
+      </CallBaodaozaiProvider>
+    </>
   )
 }
 

--- a/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/index.tsx
+++ b/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/index.tsx
@@ -14,11 +14,15 @@ import QuestionAnswersListContent from './question-answers-list-content'
 type PostQuestionAnswersListProps = {
   postQuestionAnswers: PostQuestionAnswers
   isLoading: boolean
+  onBackToFirstPage: (slug: string) => void
+  openedAccordionItemValue: string | undefined
 }
 
 function PostQuestionAnswersList({
   postQuestionAnswers,
   isLoading,
+  onBackToFirstPage,
+  openedAccordionItemValue,
 }: PostQuestionAnswersListProps) {
   if (isLoading) {
     return (
@@ -44,12 +48,15 @@ function PostQuestionAnswersList({
     <Accordion
       type="multiple"
       className="flex w-full flex-col gap-0 border-t-[2px] border-t-neutral-200"
+      defaultValue={
+        openedAccordionItemValue ? [openedAccordionItemValue] : undefined
+      }
     >
       {postQuestionAnswers.map((group) => {
         return (
           <AccordionItem
-            key={group.title}
-            value={group.title}
+            key={group.slug}
+            value={group.slug}
             className="border-b-[2px] border-b-neutral-200 last:border-b"
           >
             <AccordionTrigger
@@ -82,6 +89,8 @@ function PostQuestionAnswersList({
               <QuestionAnswersListContent
                 href={group.href}
                 answers={group.answers}
+                postSlug={group.slug}
+                onBackToFirstPage={onBackToFirstPage}
               />
             </AccordionContent>
           </AccordionItem>

--- a/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/question-answers-list-content.tsx
+++ b/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/question-answers-list-content.tsx
@@ -10,11 +10,15 @@ import EssayAnswerItem from './essay-answer-item'
 type QuestionAnswersListContentProps = {
   answers: PostQuestionAnswers[number]['answers']
   href: string
+  postSlug: string
+  onBackToFirstPage: (slug: string) => void
 }
 
 function QuestionAnswersListContent({
   href,
   answers,
+  postSlug,
+  onBackToFirstPage,
 }: QuestionAnswersListContentProps) {
   if (answers.length === 0) {
     return (
@@ -45,7 +49,13 @@ function QuestionAnswersListContent({
             </div>
 
             <div className="flex flex-col gap-3">
-              {isEssayAnswer && <EssayAnswerItem answer={answer} />}
+              {isEssayAnswer && (
+                <EssayAnswerItem
+                  answer={answer}
+                  postSlug={postSlug}
+                  onBackToFirstPage={onBackToFirstPage}
+                />
+              )}
               {isChoiceAnswer && <ChoiceAnswerItem answer={answer} />}
             </div>
           </div>

--- a/packages/frontend/src/modules/membership/my-reading/utils.ts
+++ b/packages/frontend/src/modules/membership/my-reading/utils.ts
@@ -10,6 +10,7 @@ export function parseMemberPostsWithAnswersToPostQuestionAnswers(
 
     return {
       title: post.title,
+      slug: post.slug,
       href: `/article/${post.slug}`,
       lastAnsweredTime: post.lastAnsweredTime,
       answers,

--- a/packages/frontend/src/modules/membership/types.ts
+++ b/packages/frontend/src/modules/membership/types.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 
 export type PostQuestionAnswers = {
   title: string
+  slug: string
   href: string
   answers: (PostChoiceAnswer | PostEssayAnswer)[]
   lastAnsweredTime: string

--- a/packages/frontend/src/services/call-baodaozai/components/qa-modal/constants.ts
+++ b/packages/frontend/src/services/call-baodaozai/components/qa-modal/constants.ts
@@ -1,0 +1,8 @@
+export const UPDATE_QA_MODAL_OVERRIDES = {
+  title: '編輯答案',
+  cancelButtonText: '取消',
+  onLeavingModal: {
+    subtitle: '確定要放棄編輯答案嗎？',
+    content: '你可以隨時回到這裡，修改已送出的答案！',
+  },
+}

--- a/packages/frontend/src/services/call-baodaozai/components/qa-modal/index.tsx
+++ b/packages/frontend/src/services/call-baodaozai/components/qa-modal/index.tsx
@@ -6,7 +6,13 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { CallBaodaozaiProps, useCallBaodaozaiContext } from '../../context'
 import { BaodaozaiAction, BaodaozaiQuestions } from '../../types'
-import { getModalStepsFromQuestions, ModalStep } from './utils'
+import { UPDATE_QA_MODAL_OVERRIDES } from './constants'
+import { QAModalMode } from './types'
+import {
+  getDefaultAnswerFromQuestions,
+  getModalStepsFromQuestions,
+  ModalStep,
+} from './utils'
 
 export type QAModalEvent = {
   setHide: (hide: boolean) => void
@@ -27,11 +33,32 @@ type QAModalProps = {
   }: QAModalEvent) => void
   onSubmit: (answers: Record<number, string>, events: QAModalEvent) => void
   isOpen: boolean
+  mode?: QAModalMode
 }
 
-function QAModal({ questions, onClose, onSubmit, isOpen }: QAModalProps) {
+function QAModal({
+  questions,
+  onClose,
+  onSubmit,
+  isOpen,
+  mode = 'default',
+}: QAModalProps) {
   const [currentModalStepIndex, setCurrentModalStepIndex] = useState(0)
-  const [answers, setAnswers] = useState<Record<number, string>>({})
+  const defaultAnswers = useMemo(
+    () => getDefaultAnswerFromQuestions(questions),
+    [questions]
+  )
+  const [answers, setAnswers] = useState<Record<number, string>>(defaultAnswers)
+  const isCleanAnswers = useMemo(() => {
+    if (Object.keys(answers).length !== Object.keys(defaultAnswers).length) {
+      return false
+    }
+    return Object.keys(answers).every((key) => {
+      const index = parseInt(key)
+      return defaultAnswers[index] === answers[index]
+    })
+  }, [answers, defaultAnswers])
+
   const [isLeaving, setIsLeaving] = useState(false)
 
   const {
@@ -54,6 +81,7 @@ function QAModal({ questions, onClose, onSubmit, isOpen }: QAModalProps) {
     [currentModalStepIndex, setAnswers]
   )
 
+  const shouldByPassOnLeaving = mode === 'update' && isCleanAnswers
   const handleShowLeaving = useCallback(() => {
     setIsLeaving(true)
   }, [])
@@ -89,14 +117,15 @@ function QAModal({ questions, onClose, onSubmit, isOpen }: QAModalProps) {
       onNext: handleNext,
       onPass: handlePass,
       onSubmit: handleSubmit,
+      mode,
     })
-  }, [handleNext, handlePass, questions, handleSubmit])
+  }, [handleNext, handlePass, questions, handleSubmit, mode])
 
   const handleReset = useCallback(() => {
-    setAnswers({})
+    setAnswers(defaultAnswers)
     setCurrentModalStepIndex(0)
     setIsLeaving(false)
-  }, [])
+  }, [defaultAnswers])
 
   useEffect(() => {
     if (isOpen) {
@@ -129,6 +158,9 @@ function QAModal({ questions, onClose, onSubmit, isOpen }: QAModalProps) {
     if (isLeaving) {
       return '再想一下'
     }
+    if (mode === 'update') {
+      return UPDATE_QA_MODAL_OVERRIDES.title
+    }
     if (!currentModalStep) return null
     if (
       currentModalStep?.type === 'choice-result' ||
@@ -137,17 +169,25 @@ function QAModal({ questions, onClose, onSubmit, isOpen }: QAModalProps) {
       return '作答結果'
     }
     return `${currentModalStep?.questionIndex + 1}/${questions.length}`
-  }, [currentModalStep, questions.length, isLeaving])
+  }, [currentModalStep, questions.length, isLeaving, mode])
+
+  const handleLeaving = useCallback(() => {
+    return shouldByPassOnLeaving ? onClose(events) : handleShowLeaving()
+  }, [shouldByPassOnLeaving, onClose, events, handleShowLeaving])
 
   const renderModalContent = useMemo(() => {
     if (isLeaving) {
       return (
         <div className="mb-5 flex w-full flex-col items-start p-6 tablet:mb-0">
           <h2 className="mb-3 prose-h6-large text-neutral-900">
-            確定要放棄作答嗎？
+            {mode === 'update'
+              ? UPDATE_QA_MODAL_OVERRIDES.onLeavingModal.subtitle
+              : '確定要放棄作答嗎？'}
           </h2>
           <p className="prose-p1 text-neutral-700">
-            你可以隨時呼叫報導仔，重新挑戰！
+            {mode === 'update'
+              ? UPDATE_QA_MODAL_OVERRIDES.onLeavingModal.content
+              : '你可以隨時呼叫報導仔，重新挑戰！'}
           </p>
         </div>
       )
@@ -191,7 +231,7 @@ function QAModal({ questions, onClose, onSubmit, isOpen }: QAModalProps) {
         )
       case 'essay':
         return (
-          <div className="flex h-full w-full flex-col p-6 pb-10 tablet:pb-6">
+          <div className="flex h-full w-full flex-col p-6 pb-10 tablet:pb-1">
             <div className="mb-6 w-full">
               <h2 className="mb-3 prose-h6-large text-neutral-900">
                 {currentModalStep.title}
@@ -203,7 +243,7 @@ function QAModal({ questions, onClose, onSubmit, isOpen }: QAModalProps) {
 
             <textarea
               className={cn(
-                'h-72 w-full flex-1 resize-none rounded-2xl border-2 bg-white px-5 py-4 prose-p1 text-neutral-900 transition-all focus:outline-none',
+                'h-38 w-full flex-1 resize-none rounded-2xl border-2 bg-white px-5 py-4 prose-p1 text-neutral-900 transition-all focus:outline-none',
                 (answers[currentModalStep.questionIndex] || '').trim()
                   ? 'border-neutral-600'
                   : 'border-neutral-200 hover:border-neutral-600 focus:border-neutral-600'
@@ -217,6 +257,21 @@ function QAModal({ questions, onClose, onSubmit, isOpen }: QAModalProps) {
                 )
               }
             />
+            <span className="mt-5 flex items-center gap-2 prose-p1 text-neutral-400">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+              >
+                <path
+                  d="M12 17C12.2833 17 12.5208 16.9042 12.7125 16.7125C12.9042 16.5208 13 16.2833 13 16V12C13 11.7167 12.9042 11.4792 12.7125 11.2875C12.5208 11.0958 12.2833 11 12 11C11.7167 11 11.4792 11.0958 11.2875 11.2875C11.0958 11.4792 11 11.7167 11 12V16C11 16.2833 11.0958 16.5208 11.2875 16.7125C11.4792 16.9042 11.7167 17 12 17ZM12 9C12.2833 9 12.5208 8.90417 12.7125 8.7125C12.9042 8.52083 13 8.28333 13 8C13 7.71667 12.9042 7.47917 12.7125 7.2875C12.5208 7.09583 12.2833 7 12 7C11.7167 7 11.4792 7.09583 11.2875 7.2875C11.0958 7.47917 11 7.71667 11 8C11 8.28333 11.0958 8.52083 11.2875 8.7125C11.4792 8.90417 11.7167 9 12 9ZM12 22C10.6167 22 9.31667 21.7375 8.1 21.2125C6.88333 20.6875 5.825 19.975 4.925 19.075C4.025 18.175 3.3125 17.1167 2.7875 15.9C2.2625 14.6833 2 13.3833 2 12C2 10.6167 2.2625 9.31667 2.7875 8.1C3.3125 6.88333 4.025 5.825 4.925 4.925C5.825 4.025 6.88333 3.3125 8.1 2.7875C9.31667 2.2625 10.6167 2 12 2C13.3833 2 14.6833 2.2625 15.9 2.7875C17.1167 3.3125 18.175 4.025 19.075 4.925C19.975 5.825 20.6875 6.88333 21.2125 8.1C21.7375 9.31667 22 10.6167 22 12C22 13.3833 21.7375 14.6833 21.2125 15.9C20.6875 17.1167 19.975 18.175 19.075 19.075C18.175 19.975 17.1167 20.6875 15.9 21.2125C14.6833 21.7375 13.3833 22 12 22ZM12 20C14.2333 20 16.125 19.225 17.675 17.675C19.225 16.125 20 14.2333 20 12C20 9.76667 19.225 7.875 17.675 6.325C16.125 4.775 14.2333 4 12 4C9.76667 4 7.875 4.775 6.325 6.325C4.775 7.875 4 9.76667 4 12C4 14.2333 4.775 16.125 6.325 17.675C7.875 19.225 9.76667 20 12 20Z"
+                  fill="#8E8E8E"
+                />
+              </svg>
+              答案送出後會公開在「小讀者觀點大集合」頁面。
+            </span>
           </div>
         )
       case 'choice-result':
@@ -279,7 +334,7 @@ function QAModal({ questions, onClose, onSubmit, isOpen }: QAModalProps) {
             <div className="flex flex-col bg-neutral-white">
               <div className="mb-6 w-full px-6 pt-6">
                 <h2 className="text-center prose-h6-large text-neutral-900">
-                  已送出
+                  這個觀點真不錯，謝謝你的分享
                 </h2>
               </div>
 
@@ -311,7 +366,14 @@ function QAModal({ questions, onClose, onSubmit, isOpen }: QAModalProps) {
           </div>
         )
     }
-  }, [answers, currentAnswer, currentModalStep, handleAnswerChange, isLeaving])
+  }, [
+    answers,
+    currentAnswer,
+    currentModalStep,
+    handleAnswerChange,
+    isLeaving,
+    mode,
+  ])
 
   const renderModalButtons = useMemo(() => {
     if (isLeaving) {
@@ -354,16 +416,23 @@ function QAModal({ questions, onClose, onSubmit, isOpen }: QAModalProps) {
         return (
           <div className="flex w-full gap-4">
             <Button
-              onClick={currentModalStep.onPass}
+              onClick={
+                mode === 'update' ? handleLeaving : currentModalStep.onPass
+              }
               variant="secondary"
               size={36}
               className="flex-1"
             >
-              跳過
+              {mode === 'update'
+                ? UPDATE_QA_MODAL_OVERRIDES.cancelButtonText
+                : '跳過'}
             </Button>
             <Button
               onClick={currentModalStep.onNext}
-              disabled={!(currentAnswer || '').trim()}
+              disabled={
+                !(currentAnswer || '').trim() ||
+                (mode === 'update' && isCleanAnswers)
+              }
               variant="primary"
               size={36}
               className="flex-1"
@@ -398,12 +467,14 @@ function QAModal({ questions, onClose, onSubmit, isOpen }: QAModalProps) {
         return null
     }
   }, [
-    currentModalStep,
-    isLastQuestion,
-    currentAnswer,
     isLeaving,
+    currentModalStep,
     handleCancelLeaving,
     handleConfirmLeaving,
+    currentAnswer,
+    mode,
+    handleLeaving,
+    isLastQuestion,
   ])
 
   const renderBaodaozai = useMemo(() => {
@@ -455,7 +526,7 @@ function QAModal({ questions, onClose, onSubmit, isOpen }: QAModalProps) {
           </span>
           {!isLeaving && (
             <button
-              onClick={handleShowLeaving}
+              onClick={handleLeaving}
               className="absolute top-5 right-6 flex h-8 w-8 cursor-pointer items-center justify-center text-neutral-600 transition-colors hover:text-neutral-800"
             >
               <svg

--- a/packages/frontend/src/services/call-baodaozai/components/qa-modal/types.ts
+++ b/packages/frontend/src/services/call-baodaozai/components/qa-modal/types.ts
@@ -1,0 +1,1 @@
+export type QAModalMode = 'default' | 'update'

--- a/packages/frontend/src/services/call-baodaozai/components/qa-modal/utils.ts
+++ b/packages/frontend/src/services/call-baodaozai/components/qa-modal/utils.ts
@@ -3,12 +3,14 @@ import {
   BaodaozaiQuestion,
   BaodaozaiQuestions,
 } from '../../types'
+import { QAModalMode } from './types'
 
 type EssayStep = {
   type: 'essay'
   title: string
   tips: string
   questionIndex: number
+  defaultAnswer?: string
   onNext: () => void
   onPass: () => void
 }
@@ -49,6 +51,7 @@ const parseQuestionToStep = ({
   onNext,
   onPass,
   onSubmit,
+  mode = 'default',
 }: {
   question: BaodaozaiQuestion
   questionIndex: number
@@ -56,6 +59,7 @@ const parseQuestionToStep = ({
   onNext: () => void
   onPass: (questionIndex: number) => void
   onSubmit: () => void
+  mode?: QAModalMode
 }): ModalStep => {
   if (question.type === 'essay') {
     return {
@@ -63,8 +67,9 @@ const parseQuestionToStep = ({
       title: question.title,
       tips: question.hint,
       questionIndex,
-      onNext,
+      onNext: mode === 'update' ? onSubmit : onNext,
       onPass: isLastQuestion ? onSubmit : () => onPass(questionIndex),
+      defaultAnswer: question.defaultAnswer,
     }
   }
 
@@ -117,11 +122,13 @@ export const getModalStepsFromQuestions = ({
   onNext,
   onPass,
   onSubmit,
+  mode = 'default',
 }: {
   questions: BaodaozaiQuestions
   onNext: () => void
   onPass: (questionIndex: number) => void
   onSubmit: () => void
+  mode?: QAModalMode
 }): ModalStep[] => {
   return questions.reduce<ModalStep[]>((steps, question, index) => {
     const questionStep = parseQuestionToStep({
@@ -131,7 +138,11 @@ export const getModalStepsFromQuestions = ({
       onNext,
       onPass,
       onSubmit,
+      mode,
     })
+    if (mode === 'update') {
+      return [...steps, questionStep]
+    }
     const resultStep = parseAnswerToResultStep({
       question,
       questionIndex: index,
@@ -141,4 +152,18 @@ export const getModalStepsFromQuestions = ({
     })
     return [...steps, questionStep, resultStep]
   }, [])
+}
+
+export const getDefaultAnswerFromQuestions = (
+  questions: BaodaozaiQuestions
+): Record<number, string> => {
+  return questions.reduce<Record<number, string>>(
+    (answers, question, index) => {
+      if (question.type === 'essay' && question.defaultAnswer) {
+        return { ...answers, [index]: question.defaultAnswer }
+      }
+      return answers
+    },
+    {}
+  )
 }

--- a/packages/frontend/src/services/call-baodaozai/types.ts
+++ b/packages/frontend/src/services/call-baodaozai/types.ts
@@ -15,6 +15,7 @@ export type BaodaozaiEssayQuestion = {
   type: 'essay'
   title: string
   hint: string
+  defaultAnswer?: string
 }
 
 export type BaodaozaiChoiceQuestion = {
@@ -30,9 +31,7 @@ export type BaodaozaiChoiceQuestion = {
 
 export type BaodaozaiQuestion = BaodaozaiEssayQuestion | BaodaozaiChoiceQuestion
 
-// only support 3 questions for now
-export type BaodaozaiQuestions = [
-  BaodaozaiQuestion,
-  BaodaozaiQuestion,
-  BaodaozaiQuestion,
-]
+// only support 3 questions (default flow) or 1 question (update flow) for now
+export type BaodaozaiQuestions =
+  | [BaodaozaiQuestion, BaodaozaiQuestion, BaodaozaiQuestion]
+  | [BaodaozaiQuestion]

--- a/packages/frontend/src/utils/log.ts
+++ b/packages/frontend/src/utils/log.ts
@@ -5,22 +5,21 @@ export enum LogLevel {
 }
 
 export const log = (level: LogLevel = LogLevel.INFO, msg: string) => {
+  const isInBrowser = typeof window !== 'undefined'
   const structuredMsg = JSON.stringify({
     severity: level,
     message: msg,
+    ...(!isInBrowser && level === LogLevel.ERROR
+      ? {
+          '@type':
+            'type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent',
+        }
+      : {}),
   })
 
   switch (level) {
     case LogLevel.ERROR: {
-      // Follow https://cloud.google.com/error-reporting/docs/formatting-error-messages doc to print structured error log
-      // and trigger GCP error reporting.
-      const errorLogEntry = {
-        severity: level,
-        '@type':
-          'type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent',
-        message: msg,
-      }
-      console.error(JSON.stringify(errorLogEntry))
+      console.error(structuredMsg)
       return
     }
     case LogLevel.WARNING:


### PR DESCRIPTION
## Summary

This PR adds the ability for users to edit their essay answers directly from the "My Reading" page. Users can now click an "編輯答案" (Edit Answer) button on any essay answer item to open a modal where they can modify their previously submitted answers. The implementation includes proper state management, query invalidation, and UX improvements such as auto-opening the relevant accordion item after editing.

## Changes

- **Added essay answer editing functionality**: Integrated the Q&A modal component in "update" mode to allow users to edit their essay answers
- **Enhanced EssayAnswerItem component**: 
  - Added edit button with inline styling next to answer content
  - Integrated `BaodaozaiQAModal` with update mutation support
  - Added proper error handling and success toast notifications
  - Changed icon from `ThumbUpIcon` to `StarIcon`
- **Extended Q&A modal with update mode**:
  - Added `update` mode detection (single question = update mode)
  - Created `UPDATE_QA_MODAL_OVERRIDES` constants for update-specific UI text
  - Implemented `getDefaultAnswerFromQuestions` utility to pre-populate answers
  - Added logic to bypass "leaving modal" confirmation when answers are unchanged
  - Adjusted modal styling for update mode (reduced textarea height, updated padding)
- **Improved accordion state management**:
  - Added `openedAccordionItemValue` state to control which accordion item is open
  - Implemented `onBackToFirstPage` callback to navigate back to first page and open relevant accordion after editing
  - Added slug-based accordion value tracking instead of title-based
- **Enhanced data fetching**:
  - Added `refetchOnMount: 'always'` to `usePostsEssayAnswersWithLikesInfinityQuery` to ensure fresh data
  - Added query invalidation for both post essay answers and member posts after successful updates
- **Type system updates**:
  - Added `slug` field to `PostQuestionAnswers` type
  - Created `QAModalMode` type for modal mode distinction
  - Updated utility functions to include slug in parsed data

## Additional Notes

- The edit functionality only applies to essay answers, not choice answers
- After successfully editing an answer, the user is automatically navigated back to the first page and the relevant accordion item is opened
- The modal intelligently detects if answers have been modified and skips the "leaving" confirmation dialog if no changes were made
- Error handling includes proper logging and user-friendly error messages

## Screenshot(s)
https://github.com/user-attachments/assets/3f0c253a-8935-403b-9980-333910afbe55
## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/UI-Integration-2e68dbdca9328004b1a5e5ffeda5e09c?source=copy_link)