### PR TITLE
fix(api-gateway): rebuild dist when missing

### DIFF
--- a/packages/api-gateway/Makefile
+++ b/packages/api-gateway/Makefile
@@ -25,7 +25,7 @@ dev-server:
 	fi
 
 dev:
-	yarn nodemon -e ts --exec make dev-server
+	yarn nodemon -w ./src -e ts --exec make dev-server
 
 start: build-dist
 	@echo "$(P) Start production server"

--- a/packages/api-gateway/Makefile
+++ b/packages/api-gateway/Makefile
@@ -8,11 +8,15 @@ help:
 
 build-dist:
 	@echo "$(P) Transpile typescript files"
+	@if [ ! -d dist ]; then \
+		echo "$(P) dist/ missing, clearing incremental cache"; \
+		rm -f tsconfig.tsbuildinfo; \
+	fi
 	yarn tsc
 
 dev-server:
 	@echo "$(P) Start dev server"
-	@yarn tsc && \
+	@make build-dist && \
 	if [ -f "$(ENV_FILE)" ]; then \
 		NODE_ENV=development $(DOTENV) node dist/server; \
 	else \
@@ -41,5 +45,6 @@ lint:
 clean:
 	@echo "$(P) Clean dist/"
 	rm -rf dist/
+	rm -f tsconfig.tsbuildinfo
 
 .PHONY: build clean build-dist

--- a/packages/api-gateway/Makefile
+++ b/packages/api-gateway/Makefile
@@ -16,7 +16,7 @@ build-dist:
 
 dev-server:
 	@echo "$(P) Start dev server"
-	@make build-dist && \
+	@$(MAKE) build-dist && \
 	if [ -f "$(ENV_FILE)" ]; then \
 		NODE_ENV=development $(DOTENV) node dist/server; \
 	else \
@@ -47,4 +47,4 @@ clean:
 	rm -rf dist/
 	rm -f tsconfig.tsbuildinfo
 
-.PHONY: build clean build-dist
+.PHONY: build clean build-dist help dev-server dev start lint


### PR DESCRIPTION
## Summary
- clear tsconfig.tsbuildinfo when dist/ is gone so tsc re-emits
- route dev-server through build-dist for consistent build behavior
- clean also removes incremental cache to avoid stale builds
- fix recursive make call and phony target (to address code review comments)
- scope nodemon to src changes

##  Notes
- Fixes missing dist/ rebuild when the folder is deleted manually