### PR TITLE
fix(frontend): update PostEssayQuestionsModal to show IdeaHub link when opened from article

### DIFF
--- a/packages/frontend/src/icons/miscellaneous.tsx
+++ b/packages/frontend/src/icons/miscellaneous.tsx
@@ -578,6 +578,35 @@ export const ArticleShortcutIconLarge = () => {
   )
 }
 
+export const IdeaHubShortcutIcon = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="23"
+      height="21"
+      viewBox="0 0 23 21"
+      fill="none"
+    >
+      <path
+        d="M14.7441 3.10024L14.7441 9.30334C14.7441 10.4079 13.8487 11.3033 12.7441 11.3033L4.31339 11.3033L1.09987 14.3467L1.09987 11.3033L1.09987 3.10024C1.09987 1.99567 1.9953 1.10024 3.09987 1.10024L12.7441 1.10024C13.8487 1.10024 14.7441 1.99567 14.7441 3.10024Z"
+        stroke="white"
+        strokeWidth="2.2"
+        strokeMiterlimit="10"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M17.8868 7.38442L19.1003 7.38442C20.2049 7.38442 21.1003 8.27985 21.1003 9.38442L21.1003 16.5875L21.1003 19.6309L17.8868 16.5875L9.44347 16.5875C8.34585 16.5875 7.45605 15.6977 7.45605 14.6001"
+        stroke="white"
+        strokeWidth="2.2"
+        strokeMiterlimit="10"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
 export const GroupIcon = () => {
   return (
     <svg

--- a/packages/frontend/src/modules/article/components/toolbar.tsx
+++ b/packages/frontend/src/modules/article/components/toolbar.tsx
@@ -296,6 +296,7 @@ function Toolbar({ topicURL, postSlug }: ToolbarProp) {
         open={isPostEssayQuestionsModalOpen}
         onClose={() => setIsPostEssayQuestionsModalOpen(false)}
         postSlug={postSlug}
+        mode="in-article"
       />
     </>
   )

--- a/packages/frontend/src/modules/idea-hub/post-essay-questions-modal/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/post-essay-questions-modal/index.tsx
@@ -176,21 +176,18 @@ function PostEssayQuestionsModal({
                 </div>
 
                 <div className="flex items-center justify-center gap-4">
-                  {mode === 'default' ? (
-                    <Link
-                      href={`/article/${postSlug}`}
-                      className="flex size-10 items-center justify-center gap-1 rounded-full bg-neutral-white/30 text-neutral-white hover:bg-neutral-white/50"
-                    >
+                  <Link
+                    href={
+                      mode === 'default' ? `/article/${postSlug}` : '/idea-hub'
+                    }
+                    className="flex size-10 items-center justify-center gap-1 rounded-full bg-neutral-white/30 text-neutral-white hover:bg-neutral-white/50"
+                  >
+                    {mode === 'default' ? (
                       <ArticleShortcutIconLarge />
-                    </Link>
-                  ) : (
-                    <Link
-                      href="/idea-hub"
-                      className="flex size-10 items-center justify-center gap-1 rounded-full bg-neutral-white/30 text-neutral-white hover:bg-neutral-white/50"
-                    >
+                    ) : (
                       <IdeaHubShortcutIcon />
-                    </Link>
-                  )}
+                    )}
+                  </Link>
                   <DialogClose className="flex size-10 cursor-pointer items-center justify-center gap-1 rounded-full bg-neutral-white/30 text-neutral-white hover:bg-neutral-white/50">
                     <XIcon />
                     <span className="sr-only">Close</span>

--- a/packages/frontend/src/modules/idea-hub/post-essay-questions-modal/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/post-essay-questions-modal/index.tsx
@@ -15,7 +15,11 @@ import {
   DialogTitle,
 } from '@/components/dialog'
 import { FALLBACK_IMG } from '@/constants'
-import { ArticleShortcutIconLarge, XIcon } from '@/icons/miscellaneous'
+import {
+  ArticleShortcutIconLarge,
+  IdeaHubShortcutIcon,
+  XIcon,
+} from '@/icons/miscellaneous'
 
 import ModalQuestionCard from './modal-question-card'
 
@@ -23,12 +27,14 @@ type PostEssayQuestionsModalProps = {
   postSlug: string
   open: boolean
   onClose: () => void
+  mode?: 'default' | 'in-article'
 }
 
 function PostEssayQuestionsModal({
   postSlug,
   open,
   onClose,
+  mode = 'default',
 }: PostEssayQuestionsModalProps) {
   const { data: post, isPending } = usePostEssayQuestionsByPostSlugQuery({
     slug: postSlug,
@@ -170,12 +176,21 @@ function PostEssayQuestionsModal({
                 </div>
 
                 <div className="flex items-center justify-center gap-4">
-                  <Link
-                    href={`/article/${postSlug}`}
-                    className="flex size-10 items-center justify-center gap-1 rounded-full bg-neutral-white/30 text-neutral-white hover:bg-neutral-white/50"
-                  >
-                    <ArticleShortcutIconLarge />
-                  </Link>
+                  {mode === 'default' ? (
+                    <Link
+                      href={`/article/${postSlug}`}
+                      className="flex size-10 items-center justify-center gap-1 rounded-full bg-neutral-white/30 text-neutral-white hover:bg-neutral-white/50"
+                    >
+                      <ArticleShortcutIconLarge />
+                    </Link>
+                  ) : (
+                    <Link
+                      href="/idea-hub"
+                      className="flex size-10 items-center justify-center gap-1 rounded-full bg-neutral-white/30 text-neutral-white hover:bg-neutral-white/50"
+                    >
+                      <IdeaHubShortcutIcon />
+                    </Link>
+                  )}
                   <DialogClose className="flex size-10 cursor-pointer items-center justify-center gap-1 rounded-full bg-neutral-white/30 text-neutral-white hover:bg-neutral-white/50">
                     <XIcon />
                     <span className="sr-only">Close</span>


### PR DESCRIPTION
## Summary

This PR fixes the navigation behavior in the PostEssayQuestionsModal when opened from an article page. Previously, the modal would show a link back to the article (which doesn't make sense when already viewing the article). Now, when opened from an article, the modal displays a link to the Idea Hub instead.

## Changes

- Added new `IdeaHubShortcutIcon` component to `miscellaneous.tsx` icons file
- Updated `PostEssayQuestionsModal` to accept an optional `mode` prop (`'default' | 'in-article'`)
- Modified modal to conditionally render either the Article shortcut icon (default mode) or IdeaHub shortcut icon (in-article mode)
- Updated the shortcut link destination: `/article/${postSlug}` in default mode, `/idea-hub` in in-article mode
- Updated article toolbar to pass `mode="in-article"` prop when opening the modal

## Additional Notes

When users open the PostEssayQuestionsModal from an article page, they will now see a shortcut to the Idea Hub instead of a redundant link back to the current article. This improves the user experience by providing more meaningful navigation options.

## Screenshot(s)
<img width="1231" height="923" alt="image" src="https://github.com/user-attachments/assets/7ccbd34c-af76-440c-87d1-daa6328a022e" />

## Reference(s)

