### PR TITLE
chore(api-gateway): expand member avatar docs and tighten gql/codegen flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ gcskeyfile.json
 # generated files
 packages/**/lib
 packages/**/dist
+packages/**/__generated__
+packages/frontend/graphql
 # packages/**/public/*
 
 # cursor
@@ -63,6 +65,3 @@ packages/**/dist
 
 # vscode
 .vscode
-
-# generated files
-packages/**/__generated__

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -30,6 +30,11 @@ steps:
 
         if [[ "$_TARGET_PACKAGE" == "frontend" ]]; then
           cp packages/cms/schema.graphql packages/frontend/schema.graphql
+          # Ensure the operations directory exists before copying so codegen has
+          # the expected workspace layout in Cloud Build.
+          mkdir -p packages/frontend/graphql/operations
+          # Copy shared GraphQL operations into the frontend package for build-time codegen.
+          cp -r packages/api-gateway/src/graphql/operations/* packages/frontend/graphql/operations/
         fi
 
         cd packages/$_TARGET_PACKAGE

--- a/packages/api-gateway/package.json
+++ b/packages/api-gateway/package.json
@@ -19,12 +19,14 @@
     "cors": "^2.8.5",
     "dotenv-cli": "^10.0.0",
     "express": "^4.18.2",
+    "graphql-tag": "^2.12.6",
     "http-proxy-middleware": "^2.0.6"
   },
   "devDependencies": {
     "@types/cookie-parser": "^1.4.6",
     "@types/cors": "^2.8.15",
     "@types/express": "^4.17.20",
+    "graphql": "^16.8.1",
     "nodemon": "^2.0.20",
     "typescript": "5.9.2"
   },

--- a/packages/api-gateway/src/graphql/operations/answers.ts
+++ b/packages/api-gateway/src/graphql/operations/answers.ts
@@ -105,6 +105,9 @@ export const operations: Record<string, Operation> = {
           id
           question {
             id
+            post {
+              slug
+            }
           }
           member {
             id

--- a/packages/api-gateway/src/graphql/operations/answers.ts
+++ b/packages/api-gateway/src/graphql/operations/answers.ts
@@ -1,3 +1,5 @@
+import gql from 'graphql-tag'
+
 import { ensureRecord, normalizeOrderBy, Operation, toInt } from './shared.js'
 
 export const operations: Record<string, Operation> = {
@@ -5,12 +7,16 @@ export const operations: Record<string, Operation> = {
     method: 'GET',
     auth: 'auth',
     operationName: 'GetPostChoiceAnswers',
-    document: `
+    document: gql`
       query GetPostChoiceAnswers($where: PostChoiceAnswerWhereInput!) {
         postChoiceAnswers(where: $where) {
           id
-          question { id }
-          member { id }
+          question {
+            id
+          }
+          member {
+            id
+          }
           choiceIndex
           correct
         }
@@ -24,10 +30,12 @@ export const operations: Record<string, Operation> = {
     method: 'POST',
     auth: 'auth',
     operationName: 'CreatePostChoiceAnswer',
-    document: `
+    document: gql`
       mutation CreatePostChoiceAnswer($data: PostChoiceAnswerCreateInput!) {
         createPostChoiceAnswer(data: $data) {
-          question { id }
+          question {
+            id
+          }
           choiceIndex
           correct
         }
@@ -41,7 +49,7 @@ export const operations: Record<string, Operation> = {
     method: 'POST',
     auth: 'auth',
     operationName: 'UpdatePostChoiceAnswer',
-    document: `
+    document: gql`
       mutation UpdatePostChoiceAnswer(
         $id: ID!
         $data: PostChoiceAnswerUpdateInput!
@@ -65,12 +73,16 @@ export const operations: Record<string, Operation> = {
     method: 'GET',
     auth: 'auth',
     operationName: 'GetPostEssayAnswers',
-    document: `
+    document: gql`
       query GetPostEssayAnswers($where: PostEssayAnswerWhereInput!) {
         postEssayAnswers(where: $where) {
           id
-          question { id }
-          member { id }
+          question {
+            id
+          }
+          member {
+            id
+          }
           content
         }
       }
@@ -84,17 +96,21 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 60,
     auth: 'public',
     operationName: 'GetAllPostEssayAnswers',
-    document: `
+    document: gql`
       query GetAllPostEssayAnswers(
         $orderBy: [PostEssayAnswerOrderByInput!]!
         $take: Int
-  ) {
-    postEssayAnswers(orderBy: $orderBy, take: $take) {
-      id
-      question { id }
-      member {
+      ) {
+        postEssayAnswers(orderBy: $orderBy, take: $take) {
+          id
+          question {
             id
-            avatar { fileUrl }
+          }
+          member {
+            id
+            avatar {
+              fileUrl
+            }
             nickname
             name
           }
@@ -114,10 +130,12 @@ export const operations: Record<string, Operation> = {
     method: 'POST',
     auth: 'auth',
     operationName: 'CreatePostEssayAnswer',
-    document: `
+    document: gql`
       mutation CreatePostEssayAnswer($data: PostEssayAnswerCreateInput!) {
         createPostEssayAnswer(data: $data) {
-          question { id }
+          question {
+            id
+          }
           content
         }
       }
@@ -130,7 +148,7 @@ export const operations: Record<string, Operation> = {
     method: 'POST',
     auth: 'auth',
     operationName: 'UpdatePostEssayAnswer',
-    document: `
+    document: gql`
       mutation UpdatePostEssayAnswer(
         $id: ID!
         $data: PostEssayAnswerUpdateInput!
@@ -153,7 +171,7 @@ export const operations: Record<string, Operation> = {
     method: 'GET',
     auth: 'public',
     operationName: 'GetEssayQuestionEssayAnswers',
-    document: `
+    document: gql`
       query GetEssayQuestionEssayAnswers(
         $where: PostEssayQuestionWhereUniqueInput!
         $answerOrderBy: [PostEssayAnswerOrderByInput!]!
@@ -164,12 +182,19 @@ export const operations: Record<string, Operation> = {
           id
           title
           hint
-          answers(orderBy: $answerOrderBy, take: $answerTake, skip: $answerSkip) {
+          answers(
+            orderBy: $answerOrderBy
+            take: $answerTake
+            skip: $answerSkip
+          ) {
             id
             content
             member {
               id
-              avatar { fileUrl id }
+              avatar {
+                fileUrl
+                id
+              }
               name
               nickname
               email
@@ -198,13 +223,17 @@ export const operations: Record<string, Operation> = {
     method: 'POST',
     auth: 'auth',
     operationName: 'CreatePostEssayAnswerLike',
-    document: `
+    document: gql`
       mutation CreatePostEssayAnswerLike(
         $data: PostEssayAnswerLikeCreateInput!
       ) {
         createPostEssayAnswerLike(data: $data) {
-          answer { id }
-          member { id }
+          answer {
+            id
+          }
+          member {
+            id
+          }
         }
       }
     `,
@@ -216,7 +245,7 @@ export const operations: Record<string, Operation> = {
     method: 'POST',
     auth: 'auth',
     operationName: 'DeletePostEssayAnswerLike',
-    document: `
+    document: gql`
       mutation DeletePostEssayAnswerLike(
         $where: PostEssayAnswerLikeWhereUniqueInput!
       ) {

--- a/packages/api-gateway/src/graphql/operations/content.ts
+++ b/packages/api-gateway/src/graphql/operations/content.ts
@@ -1,3 +1,5 @@
+import gql from 'graphql-tag'
+
 import {
   ensureArray,
   ensureRecord,
@@ -14,7 +16,7 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'GetLatestPosts',
-    document: `
+    document: gql`
       ${postContentFragment}
       query GetLatestPosts($orderBy: [PostOrderByInput!]!, $take: Int) {
         posts(orderBy: $orderBy, take: $take) {
@@ -35,7 +37,7 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'GetEditorPicksSettings',
-    document: `
+    document: gql`
       ${postContentFragment}
       query GetEditorPicksSettings($take: Int) {
         editorPicksSettings(take: $take) {
@@ -43,7 +45,10 @@ export const operations: Record<string, Operation> = {
           editorPicksOfPostsOrdered {
             ...PostContent
           }
-          editorPicksOfTags { name slug }
+          editorPicksOfTags {
+            name
+            slug
+          }
         }
       }
     `,
@@ -56,7 +61,7 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 300,
     auth: 'public',
     operationName: 'GetCallBaodaozaiIntro',
-    document: `
+    document: gql`
       query GetCallBaodaozaiIntro($where: CallBaodaozaiIntroWhereUniqueInput!) {
         callBaodaozaiIntro(where: $where) {
           id
@@ -79,7 +84,7 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'GetCategoryPosts',
-    document: `
+    document: gql`
       ${postContentFragment}
       query GetCategoryPosts(
         $where: CategoryWhereUniqueInput!
@@ -107,7 +112,7 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'GetCategoryMetadata',
-    document: `
+    document: gql`
       query GetCategoryMetadata(
         $categoryWhere: CategoryWhereUniqueInput!
         $subcategoryWhere: SubcategoryWhereInput!
@@ -115,11 +120,19 @@ export const operations: Record<string, Operation> = {
         category(where: $categoryWhere) {
           ogTitle
           ogDescription
-          ogImage { resized { medium } }
+          ogImage {
+            resized {
+              medium
+            }
+          }
           subcategories(where: $subcategoryWhere) {
             ogTitle
             ogDescription
-            ogImage { resized { medium } }
+            ogImage {
+              resized {
+                medium
+              }
+            }
           }
         }
       }
@@ -142,12 +155,15 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'GetCategorySubcategoriesAndThemeColor',
-    document: `
+    document: gql`
       query GetCategorySubcategoriesAndThemeColor(
         $where: CategoryWhereUniqueInput!
       ) {
         category(where: $where) {
-          subcategories { name slug }
+          subcategories {
+            name
+            slug
+          }
           themeColor
         }
       }
@@ -161,7 +177,7 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'GetSubcategoryPosts',
-    document: `
+    document: gql`
       ${postContentFragment}
       query GetSubcategoryPosts(
         $where: SubcategoryWhereUniqueInput!
@@ -173,7 +189,9 @@ export const operations: Record<string, Operation> = {
             ...PostContent
           }
           relatedPostsCount
-          category { slug }
+          category {
+            slug
+          }
         }
       }
     `,
@@ -190,7 +208,7 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'GetSubSubcategoryPosts',
-    document: `
+    document: gql`
       ${postContentFragment}
       query GetSubSubcategoryPosts(
         $where: SubSubcategoryWhereUniqueInput!
@@ -205,7 +223,9 @@ export const operations: Record<string, Operation> = {
           relatedPostsCount
           subcategory {
             slug
-            category { slug }
+            category {
+              slug
+            }
           }
         }
       }
@@ -224,13 +244,17 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'GetTopicProjects',
-    document: `
+    document: gql`
       query GetTopicProjects($orderBy: [ProjectOrderByInput!]!, $take: Int) {
         projects(orderBy: $orderBy, take: $take) {
           title
           subtitle
           slug
-          heroImage { resized { small } }
+          heroImage {
+            resized {
+              small
+            }
+          }
         }
       }
     `,
@@ -246,7 +270,7 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'GetPost',
-    document: `
+    document: gql`
       ${postContentFragment}
       query GetPost(
         $where: PostWhereUniqueInput!
@@ -260,30 +284,55 @@ export const operations: Record<string, Operation> = {
           opening
           title
           showBaodaozai
-          newsReadingGroup { items(orderBy: $orderBy) { name embedCode } }
+          newsReadingGroup {
+            items(orderBy: $orderBy) {
+              name
+              embedCode
+            }
+          }
           brief
           content
           publishedDate
           heroImage {
-            imageFile { width height }
-            resized { small medium large }
+            imageFile {
+              width
+              height
+            }
+            resized {
+              small
+              medium
+              large
+            }
           }
           heroCaption
           authors {
-            avatar { resized { tiny } }
+            avatar {
+              resized {
+                tiny
+              }
+            }
             bio
             id
             name
             slug
           }
           authorsJSON
-          tagsOrdered { name slug }
+          tagsOrdered {
+            name
+            slug
+          }
           TWReporterRelatedPostsJSON
           relatedPostsOrdered {
             title
             slug
             publishedDate
-            heroImage { resized { small medium large } }
+            heroImage {
+              resized {
+                small
+                medium
+                large
+              }
+            }
             ogDescription
             subSubcategoriesOrdered {
               name
@@ -291,7 +340,11 @@ export const operations: Record<string, Operation> = {
               subcategory {
                 name
                 slug
-                category { name slug themeColor }
+                category {
+                  name
+                  slug
+                  themeColor
+                }
               }
             }
           }
@@ -302,10 +355,17 @@ export const operations: Record<string, Operation> = {
             subcategory {
               name
               slug
-              category { name slug themeColor }
+              category {
+                name
+                slug
+                themeColor
+              }
             }
           }
-          mainProject { title slug }
+          mainProject {
+            title
+            slug
+          }
           projects {
             title
             slug
@@ -346,20 +406,28 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'GetPostMeta',
-    document: `
+    document: gql`
       query GetPostMeta($where: PostWhereUniqueInput!) {
         post(where: $where) {
           publishedDate
           ogDescription
           ogTitle
-          ogImage { resized { small } }
+          ogImage {
+            resized {
+              small
+            }
+          }
           subSubcategoriesOrdered {
             name
             slug
             subcategory {
               name
               slug
-              category { name slug themeColor }
+              category {
+                name
+                slug
+                themeColor
+              }
             }
           }
         }
@@ -374,7 +442,7 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'PostsCount',
-    document: `
+    document: gql`
       query PostsCount {
         postsCount
       }
@@ -386,7 +454,7 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'GetPosts',
-    document: `
+    document: gql`
       ${postContentFragment}
       query GetPosts($orderBy: [PostOrderByInput!]!, $take: Int, $skip: Int) {
         posts(orderBy: $orderBy, take: $take, skip: $skip) {
@@ -406,7 +474,7 @@ export const operations: Record<string, Operation> = {
     method: 'GET',
     auth: 'public',
     operationName: 'GetPostsEssayAnswersWithLikes',
-    document: `
+    document: gql`
       query GetPostsEssayAnswersWithLikes(
         $orderBy: [PostOrderByInput!]!
         $take: Int
@@ -419,8 +487,14 @@ export const operations: Record<string, Operation> = {
           id
           title
           slug
-          heroImage { resized { medium } }
-          subSubcategoriesOrdered { name }
+          heroImage {
+            resized {
+              medium
+            }
+          }
+          subSubcategoriesOrdered {
+            name
+          }
           postEssayQuestions {
             id
             title
@@ -430,7 +504,10 @@ export const operations: Record<string, Operation> = {
               content
               member {
                 id
-                avatar { id fileUrl }
+                avatar {
+                  id
+                  fileUrl
+                }
                 name
                 nickname
                 email
@@ -459,15 +536,25 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'GetPostEssayQuestions',
-    document: `
+    document: gql`
       query GetPostEssayQuestions($where: PostWhereUniqueInput!) {
         post(where: $where) {
           id
           slug
           title
-          heroImage { resized { medium } }
-          postEssayQuestions { id title hint }
-          subSubcategoriesOrdered { name }
+          heroImage {
+            resized {
+              medium
+            }
+          }
+          postEssayQuestions {
+            id
+            title
+            hint
+          }
+          subSubcategoriesOrdered {
+            name
+          }
         }
       }
     `,
@@ -480,7 +567,7 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'GetTagPosts',
-    document: `
+    document: gql`
       ${postContentFragment}
       query GetTagPosts(
         $where: TagWhereUniqueInput!
@@ -511,12 +598,16 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'GetTagMeta',
-    document: `
+    document: gql`
       query GetTagMeta($where: TagWhereUniqueInput!) {
         tag(where: $where) {
           ogDescription
           ogTitle
-          ogImage { resized { small } }
+          ogImage {
+            resized {
+              small
+            }
+          }
         }
       }
     `,
@@ -529,9 +620,13 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'GetProject',
-    document: `
+    document: gql`
       fragment ImageEntity on Photo {
-        resized { small medium large }
+        resized {
+          small
+          medium
+          large
+        }
       }
       query GetProject($where: ProjectWhereUniqueInput!) {
         project(where: $where) {
@@ -541,13 +636,19 @@ export const operations: Record<string, Operation> = {
           content
           credits
           publishedDate
-          heroImage { ...ImageEntity }
-          mobileHeroImage { ...ImageEntity }
+          heroImage {
+            ...ImageEntity
+          }
+          mobileHeroImage {
+            ...ImageEntity
+          }
           relatedPostsOrdered {
             title
             slug
             publishedDate
-            heroImage { ...ImageEntity }
+            heroImage {
+              ...ImageEntity
+            }
             ogDescription
             subSubcategoriesOrdered {
               name
@@ -555,7 +656,11 @@ export const operations: Record<string, Operation> = {
               subcategory {
                 name
                 slug
-                category { name slug themeColor }
+                category {
+                  name
+                  slug
+                  themeColor
+                }
               }
             }
           }
@@ -571,13 +676,17 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'GetProjectMeta',
-    document: `
+    document: gql`
       query GetProjectMeta($where: ProjectWhereUniqueInput!) {
         project(where: $where) {
           publishedDate
           ogDescription
           ogTitle
-          ogImage { resized { small } }
+          ogImage {
+            resized {
+              small
+            }
+          }
         }
       }
     `,
@@ -590,7 +699,7 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'GetProjects',
-    document: `
+    document: gql`
       ${postContentFragment}
       query GetProjects(
         $orderBy: [ProjectOrderByInput!]!
@@ -602,7 +711,11 @@ export const operations: Record<string, Operation> = {
           title
           slug
           ogDescription
-          heroImage { resized { medium } }
+          heroImage {
+            resized {
+              medium
+            }
+          }
           publishedDate
           relatedPostsOrdered @include(if: $includeRelatedPosts) {
             ...PostContent
@@ -625,10 +738,8 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'GetProjectRelatedPostsCount',
-    document: `
-      query GetProjectRelatedPostsCount(
-        $where: ProjectWhereUniqueInput!
-      ) {
+    document: gql`
+      query GetProjectRelatedPostsCount($where: ProjectWhereUniqueInput!) {
         project(where: $where) {
           relatedPostsCount
         }
@@ -643,7 +754,7 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'GetAuthorPosts',
-    document: `
+    document: gql`
       ${postContentFragment}
       query GetAuthorPosts(
         $where: AuthorWhereUniqueInput!
@@ -655,7 +766,11 @@ export const operations: Record<string, Operation> = {
           bio
           name
           email
-          avatar { resized { tiny } }
+          avatar {
+            resized {
+              tiny
+            }
+          }
           posts(orderBy: $orderBy, take: $take, skip: $skip) {
             ...PostContent
           }
@@ -677,13 +792,17 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'GetAuthorMeta',
-    document: `
+    document: gql`
       query GetAuthorMeta($where: AuthorWhereUniqueInput!) {
         author(where: $where) {
           slug
           name
           bio
-          image { resized { small } }
+          image {
+            resized {
+              small
+            }
+          }
         }
       }
     `,
@@ -696,10 +815,14 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'GetAuthorAvatar',
-    document: `
+    document: gql`
       query GetAuthorAvatar($where: AuthorWhereUniqueInput!) {
         author(where: $where) {
-          avatar { resized { tiny } }
+          avatar {
+            resized {
+              tiny
+            }
+          }
         }
       }
     `,
@@ -712,7 +835,7 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 120,
     auth: 'public',
     operationName: 'GetAuthorPostsCount',
-    document: `
+    document: gql`
       query GetAuthorPostsCount($where: AuthorWhereUniqueInput!) {
         author(where: $where) {
           postsCount
@@ -728,7 +851,7 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 300,
     auth: 'public',
     operationName: 'GetPostsForSitemap',
-    document: `
+    document: gql`
       query GetPostsForSitemap($where: PostWhereInput!) {
         posts(where: $where) {
           slug
@@ -745,7 +868,7 @@ export const operations: Record<string, Operation> = {
     cacheTtl: 300,
     auth: 'public',
     operationName: 'GetProjectsForSitemap',
-    document: `
+    document: gql`
       query GetProjectsForSitemap($where: ProjectWhereInput!) {
         projects(where: $where) {
           slug

--- a/packages/api-gateway/src/graphql/operations/member-avatar.ts
+++ b/packages/api-gateway/src/graphql/operations/member-avatar.ts
@@ -1,0 +1,10 @@
+import gql from 'graphql-tag'
+
+export const CREATE_MEMBER_AVATAR_MUTATION = gql`
+  mutation CreateMemberAvatar($data: MemberAvatarCreateInput!) {
+    item: createMemberAvatar(data: $data) {
+      id
+      name
+    }
+  }
+`

--- a/packages/api-gateway/src/graphql/operations/members.ts
+++ b/packages/api-gateway/src/graphql/operations/members.ts
@@ -1,3 +1,5 @@
+import gql from 'graphql-tag'
+
 import { ensureRecord, Operation, toInt } from './shared.js'
 
 export const operations: Record<string, Operation> = {
@@ -5,7 +7,7 @@ export const operations: Record<string, Operation> = {
     method: 'GET',
     auth: 'auth',
     operationName: 'GetMemberProfile',
-    document: `
+    document: gql`
       query GetMemberProfile($where: MemberWhereUniqueInput!) {
         member(where: $where) {
           id
@@ -16,7 +18,10 @@ export const operations: Record<string, Operation> = {
           twreporter_user_id
           showBaodaozai
           essayQuestionCount
-          avatar { id fileUrl }
+          avatar {
+            id
+            fileUrl
+          }
           createdAt
         }
       }
@@ -29,7 +34,7 @@ export const operations: Record<string, Operation> = {
     method: 'POST',
     auth: 'auth',
     operationName: 'UpdateMemberProfile',
-    document: `
+    document: gql`
       mutation UpdateMemberProfile(
         $where: MemberWhereUniqueInput!
         $data: MemberUpdateInput!
@@ -41,7 +46,9 @@ export const operations: Record<string, Operation> = {
           contactEmail
           showBaodaozai
           essayQuestionCount
-          avatar { id }
+          avatar {
+            id
+          }
         }
       }
     `,
@@ -56,15 +63,9 @@ export const operations: Record<string, Operation> = {
     method: 'GET',
     auth: 'auth',
     operationName: 'GetMemberPostsWithAnswers',
-    document: `
-      query GetMemberPostsWithAnswers(
-        $take: Int
-        $nextCursor: String
-      ) {
-        getMemberPostsWithAnswers(
-          take: $take
-          cursor: $nextCursor
-        )
+    document: gql`
+      query GetMemberPostsWithAnswers($take: Int, $nextCursor: String) {
+        getMemberPostsWithAnswers(take: $take, cursor: $nextCursor)
       }
     `,
     buildVariables: (input) => {
@@ -79,7 +80,7 @@ export const operations: Record<string, Operation> = {
     method: 'POST',
     auth: 'auth',
     operationName: 'DeleteMemberAvatar',
-    document: `
+    document: gql`
       mutation DeleteMemberAvatar($where: MemberAvatarWhereUniqueInput!) {
         deleteMemberAvatar(where: $where) {
           id
@@ -94,7 +95,7 @@ export const operations: Record<string, Operation> = {
     method: 'GET',
     auth: 'auth',
     operationName: 'GetMemberEssayAnswersHasLiked',
-    document: `
+    document: gql`
       query GetMemberEssayAnswersHasLiked($essayAnswerIds: [ID!]!) {
         getMemberEssayAnswersHasLiked(essayAnswerIds: $essayAnswerIds) {
           essayAnswerId

--- a/packages/api-gateway/src/graphql/operations/shared.ts
+++ b/packages/api-gateway/src/graphql/operations/shared.ts
@@ -1,4 +1,5 @@
 import express from 'express'
+import gql from 'graphql-tag'
 
 export type Operation = {
   method: 'GET' | 'POST'
@@ -9,15 +10,25 @@ export type Operation = {
   buildVariables: (input: Record<string, unknown>) => Record<string, unknown>
 }
 
-export const postContentFragment = `
+export const postContentFragment = gql`
   fragment PostContent on Post {
     title
     slug
     ogDescription
-    heroImage { resized { small } }
+    heroImage {
+      resized {
+        small
+      }
+    }
     subSubcategoriesOrdered {
       name
-      subcategory { name category { slug themeColor } }
+      subcategory {
+        name
+        category {
+          slug
+          themeColor
+        }
+      }
     }
     publishedDate
   }

--- a/packages/api-gateway/src/graphql/operations/shared.ts
+++ b/packages/api-gateway/src/graphql/operations/shared.ts
@@ -1,4 +1,5 @@
 import express from 'express'
+import type { DocumentNode } from 'graphql'
 import gql from 'graphql-tag'
 
 export type Operation = {
@@ -6,7 +7,7 @@ export type Operation = {
   cacheTtl?: number
   auth: 'public' | 'auth'
   operationName: string
-  document: string
+  document: DocumentNode
   buildVariables: (input: Record<string, unknown>) => Record<string, unknown>
 }
 

--- a/packages/api-gateway/src/routes/gql-rest.ts
+++ b/packages/api-gateway/src/routes/gql-rest.ts
@@ -1,6 +1,7 @@
 // @ts-ignore `@twreporter/errors` does not have typescript definition file yet
 import _errors from '@twreporter/errors'
 import express from 'express'
+import { print } from 'graphql'
 
 import consts from '../constants.js'
 import { buildAuthContext } from '../graphql/auth.js'
@@ -189,7 +190,7 @@ export function createGqlRestRouter({
         try {
           const gqlRes = await callCmsGraphql({
             apiOrigin,
-            document: op.document,
+            document: print(op.document),
             variables,
             operationName: op.operationName,
             headers: authContext.headers,

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -12,7 +12,7 @@ RUN yarn install --immutable --ignore-scripts
 
 COPY . /build/
 
-RUN yarn build
+RUN yarn build:cloudbuild
 
 
 FROM node:${NODE_VERSION}

--- a/packages/frontend/codegen.cloudbuild.ts
+++ b/packages/frontend/codegen.cloudbuild.ts
@@ -1,16 +1,14 @@
 import { CodegenConfig } from '@graphql-codegen/cli'
 
-const schemaPath =
-  process.env.NODE_ENV === 'production'
-    ? 'schema.graphql'
-    : '../cms/schema.graphql'
+const schemaPath = 'schema.graphql'
+const documents = 'graphql/operations/**/*.ts'
 
 // Generated artifacts are written to packages/frontend/__generated__ so that
 // imports can use the "__generated__/" alias configured in tsconfig.json.
 const config: CodegenConfig = {
   overwrite: true,
   schema: schemaPath,
-  documents: '../api-gateway/src/graphql/operations/**/*.ts',
+  documents,
   generates: {
     '__generated__/types.ts': {
       plugins: ['typescript'],
@@ -31,20 +29,20 @@ const config: CodegenConfig = {
       presetConfig: {
         extension: '.generated.ts',
         // baseTypesPath is resolved *from the generated file location*.
-        // generated ops: packages/frontend/__generated__/operations/*.generated.ts
-        // base types:     packages/frontend/__generated__/types.ts
+        // generated ops: ./__generated__/operations/*.generated.ts
+        // base types:    ./__generated__/types.ts
         baseTypesPath: '../types.ts',
 
         // folder is resolved *from each operation file's directory*.
         //
-        // from: packages/api-gateway/src/graphql/operations/<operation-file>.ts (directory)
-        // to:   packages/frontend/__generated__/operations
+        // from: ./graphql/operations/<operation-file>.ts (directory)
+        // to:   ./__generated__/operations
         //
         // ⚠️ NOTE:
         // This relative path assumes operation files are only one level deep.
         // If operations become nested (operations/**), this value may need adjustment
         // because each additional subfolder adds one more ".." to the relative path.
-        folder: '../../../../frontend/__generated__/operations',
+        folder: '../../__generated__/operations',
       },
       config: {
         maybeValue: 'T | undefined',

--- a/packages/frontend/codegen.local.ts
+++ b/packages/frontend/codegen.local.ts
@@ -1,0 +1,62 @@
+import { CodegenConfig } from '@graphql-codegen/cli'
+
+const schemaPath = '../cms/schema.graphql'
+
+// Generated artifacts are written to packages/frontend/__generated__ so that
+// imports can use the "__generated__/" alias configured in tsconfig.json.
+const config: CodegenConfig = {
+  overwrite: true,
+  schema: schemaPath,
+  documents: '../api-gateway/src/graphql/operations/**/*.ts',
+  generates: {
+    '__generated__/types.ts': {
+      plugins: ['typescript'],
+      config: {
+        maybeValue: 'T | undefined',
+        inputMaybeValue: 'T | undefined',
+        enumsAsTypes: true,
+        scalars: {
+          DateTime: 'string',
+          JSON: 'any',
+          PasswordState: 'string',
+        },
+      },
+    },
+    '__generated__/operations': {
+      plugins: ['typescript-operations'],
+      preset: 'near-operation-file',
+      presetConfig: {
+        extension: '.generated.ts',
+        // baseTypesPath is resolved *from the generated file location*.
+        // generated ops: packages/frontend/__generated__/operations/*.generated.ts
+        // base types:     packages/frontend/__generated__/types.ts
+        baseTypesPath: '../types.ts',
+
+        // folder is resolved *from each operation file's directory*.
+        //
+        // from: packages/api-gateway/src/graphql/operations/<operation-file>.ts (directory)
+        // to:   packages/frontend/__generated__/operations
+        //
+        // ⚠️ NOTE:
+        // This relative path assumes operation files are only one level deep.
+        // If operations become nested (operations/**), this value may need adjustment
+        // because each additional subfolder adds one more ".." to the relative path.
+        folder: '../../../../frontend/__generated__/operations',
+      },
+      config: {
+        maybeValue: 'T | undefined',
+        inputMaybeValue: 'T | undefined',
+        scalars: {
+          DateTime: 'string',
+          JSON: 'any',
+          PasswordState: 'string',
+        },
+      },
+    },
+  },
+  hooks: {
+    afterAllFileWrite: ['prettier --write __generated__/**/*.ts'],
+  },
+}
+
+export default config

--- a/packages/frontend/codegen.ts
+++ b/packages/frontend/codegen.ts
@@ -3,14 +3,14 @@ import { CodegenConfig } from '@graphql-codegen/cli'
 const schemaPath =
   process.env.NODE_ENV === 'production'
     ? 'schema.graphql'
-    : '../../packages/cms/schema.graphql'
+    : '../cms/schema.graphql'
 
 // Generated artifacts are written to packages/frontend/__generated__ so that
 // imports can use the "__generated__/" alias configured in tsconfig.json.
 const config: CodegenConfig = {
   overwrite: true,
   schema: schemaPath,
-  documents: 'src/api/graphql/**/*.ts',
+  documents: '../api-gateway/src/graphql/operations/**/*.ts',
   generates: {
     '__generated__/types.ts': {
       plugins: ['typescript'],
@@ -30,8 +30,21 @@ const config: CodegenConfig = {
       preset: 'near-operation-file',
       presetConfig: {
         extension: '.generated.ts',
+        // baseTypesPath is resolved *from the generated file location*.
+        // generated ops: packages/frontend/__generated__/operations/*.generated.ts
+        // base types:     packages/frontend/__generated__/types.ts
         baseTypesPath: '../types.ts',
-        folder: '../../../__generated__/operations',
+
+        // folder is resolved *from each operation file's directory*.
+        //
+        // from: packages/api-gateway/src/graphql/operations/<operation-file>.ts (directory)
+        // to:   packages/frontend/__generated__/operations
+        //
+        // ⚠️ NOTE:
+        // This relative path assumes operation files are only one level deep.
+        // If operations become nested (operations/**), this value may need adjustment
+        // because each additional subfolder adds one more ".." to the relative path.
+        folder: '../../../../frontend/__generated__/operations',
       },
       config: {
         maybeValue: 'T | undefined',

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -4,13 +4,15 @@
   "private": true,
   "scripts": {
     "dev": "concurrently \"yarn codegen:local --watch\" \"next dev --port ${PORT:-3000}\"",
-    "build": "yarn codegen:production && next build",
+    "build": "yarn build:local",
+    "build:local": "yarn codegen:local && next build",
+    "build:cloudbuild": "yarn codegen:cloudbuild && next build",
     "start": "next start",
-    "analyze": "ANALYZE=true yarn build",
+    "analyze": "ANALYZE=true yarn build:local",
     "lint:check": "eslint src --ext .ts,.tsx,.js,.jsx",
     "type-check": "tsc --noEmit",
-    "codegen:local": "graphql-codegen --config codegen.ts",
-    "codegen:production": "NODE_ENV=production graphql-codegen --config codegen.ts",
+    "codegen:local": "graphql-codegen --config codegen.local.ts",
+    "codegen:cloudbuild": "graphql-codegen --config codegen.cloudbuild.ts",
     "postinstall": "yarn codegen:local && cd ../routing-ui && yarn build"
   },
   "dependencies": {

--- a/packages/frontend/src/api-utils/react-query/hooks/extended.ts
+++ b/packages/frontend/src/api-utils/react-query/hooks/extended.ts
@@ -1,4 +1,4 @@
-import { GetMemberPostsWithAnswersQueryVariables } from '__generated__/operations/extended.generated'
+import { GetMemberPostsWithAnswersQueryVariables } from '__generated__/operations/members.generated'
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 
 import {

--- a/packages/frontend/src/api-utils/react-query/hooks/member.ts
+++ b/packages/frontend/src/api-utils/react-query/hooks/member.ts
@@ -1,7 +1,7 @@
 import {
   UpdateMemberProfileMutation,
   UpdateMemberProfileMutationVariables,
-} from '__generated__/operations/member.generated'
+} from '__generated__/operations/members.generated'
 import { useMutation, UseMutationOptions } from '@tanstack/react-query'
 
 import { updateMemberProfile } from '@/api/member'

--- a/packages/frontend/src/api-utils/react-query/hooks/post-choice-answer.ts
+++ b/packages/frontend/src/api-utils/react-query/hooks/post-choice-answer.ts
@@ -1,7 +1,7 @@
 import {
   CreatePostChoiceAnswerMutationVariables,
   UpdatePostChoiceAnswerMutationVariables,
-} from '__generated__/operations/post-choice-answer.generated'
+} from '__generated__/operations/answers.generated'
 import { useMutation, useQuery } from '@tanstack/react-query'
 
 import {

--- a/packages/frontend/src/api-utils/react-query/hooks/post-essay-answer-like.ts
+++ b/packages/frontend/src/api-utils/react-query/hooks/post-essay-answer-like.ts
@@ -1,7 +1,7 @@
 import {
   CreatePostEssayAnswerLikeMutationVariables,
   DeletePostEssayAnswerLikeMutationVariables,
-} from '__generated__/operations/post-essay-answer-like.generated'
+} from '__generated__/operations/answers.generated'
 import { useMutation } from '@tanstack/react-query'
 
 import {

--- a/packages/frontend/src/api-utils/react-query/hooks/post-essay-answer.ts
+++ b/packages/frontend/src/api-utils/react-query/hooks/post-essay-answer.ts
@@ -1,7 +1,7 @@
 import {
   CreatePostEssayAnswerMutationVariables,
   UpdatePostEssayAnswerMutationVariables,
-} from '__generated__/operations/post-essay-answer.generated'
+} from '__generated__/operations/answers.generated'
 import { PostEssayAnswerOrderByInput } from '__generated__/types'
 import { useMutation, useQuery } from '@tanstack/react-query'
 

--- a/packages/frontend/src/api-utils/react-query/hooks/post.ts
+++ b/packages/frontend/src/api-utils/react-query/hooks/post.ts
@@ -1,4 +1,4 @@
-import { GetPostsEssayAnswersWithLikesQuery } from '__generated__/operations/post.generated'
+import { GetPostsEssayAnswersWithLikesQuery } from '__generated__/operations/content.generated'
 import {
   PostEssayAnswerOrderByInput,
   PostOrderByInput,

--- a/packages/frontend/src/api/call-baodaozai-intro.ts
+++ b/packages/frontend/src/api/call-baodaozai-intro.ts
@@ -1,7 +1,7 @@
 import {
   GetCallBaodaozaiIntroQuery,
   GetCallBaodaozaiIntroQueryVariables,
-} from '__generated__/operations/call-baodaozai-intro.generated'
+} from '__generated__/operations/content.generated'
 
 import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 

--- a/packages/frontend/src/api/category.ts
+++ b/packages/frontend/src/api/category.ts
@@ -5,7 +5,7 @@ import {
   GetCategoryPostsQueryVariables,
   GetCategorySubcategoriesAndThemeColorQuery,
   GetCategorySubcategoriesAndThemeColorQueryVariables,
-} from '__generated__/operations/category.generated'
+} from '__generated__/operations/content.generated'
 
 import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 

--- a/packages/frontend/src/api/editor-picks-settings.ts
+++ b/packages/frontend/src/api/editor-picks-settings.ts
@@ -1,7 +1,7 @@
 import {
   GetEditorPicksSettingsQuery,
   GetEditorPicksSettingsQueryVariables,
-} from '__generated__/operations/editor-picks-settings.generated'
+} from '__generated__/operations/content.generated'
 
 import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 

--- a/packages/frontend/src/api/extended.ts
+++ b/packages/frontend/src/api/extended.ts
@@ -2,7 +2,7 @@ import {
   GetMemberEssayAnswersHasLikedQuery,
   GetMemberEssayAnswersHasLikedQueryVariables,
   GetMemberPostsWithAnswersQueryVariables,
-} from '__generated__/operations/extended.generated'
+} from '__generated__/operations/members.generated'
 
 import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 

--- a/packages/frontend/src/api/member-avatar.ts
+++ b/packages/frontend/src/api/member-avatar.ts
@@ -1,7 +1,5 @@
-import {
-  CreateMemberAvatarMutation,
-  DeleteMemberAvatarMutation,
-} from '__generated__/operations/member-avatar.generated'
+import { CreateMemberAvatarMutation } from '__generated__/operations/member-avatar.generated'
+import { DeleteMemberAvatarMutation } from '__generated__/operations/members.generated'
 import axios, { AxiosResponse } from 'axios'
 import { print } from 'graphql/language/printer'
 

--- a/packages/frontend/src/api/member.ts
+++ b/packages/frontend/src/api/member.ts
@@ -3,7 +3,7 @@ import {
   GetMemberProfileQueryVariables,
   UpdateMemberProfileMutation,
   UpdateMemberProfileMutationVariables,
-} from '__generated__/operations/member.generated'
+} from '__generated__/operations/members.generated'
 
 import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 

--- a/packages/frontend/src/api/post-choice-answer.ts
+++ b/packages/frontend/src/api/post-choice-answer.ts
@@ -5,7 +5,7 @@ import {
   GetPostChoiceAnswersQueryVariables,
   UpdatePostChoiceAnswerMutation,
   UpdatePostChoiceAnswerMutationVariables,
-} from '__generated__/operations/post-choice-answer.generated'
+} from '__generated__/operations/answers.generated'
 
 import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 

--- a/packages/frontend/src/api/post-essay-answer-like.ts
+++ b/packages/frontend/src/api/post-essay-answer-like.ts
@@ -3,7 +3,7 @@ import {
   CreatePostEssayAnswerLikeMutationVariables,
   DeletePostEssayAnswerLikeMutation,
   DeletePostEssayAnswerLikeMutationVariables,
-} from '__generated__/operations/post-essay-answer-like.generated'
+} from '__generated__/operations/answers.generated'
 
 import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 

--- a/packages/frontend/src/api/post-essay-answer.ts
+++ b/packages/frontend/src/api/post-essay-answer.ts
@@ -7,7 +7,7 @@ import {
   GetPostEssayAnswersQueryVariables,
   UpdatePostEssayAnswerMutation,
   UpdatePostEssayAnswerMutationVariables,
-} from '__generated__/operations/post-essay-answer.generated'
+} from '__generated__/operations/answers.generated'
 import { PostEssayAnswerOrderByInput } from '__generated__/types'
 
 import { sendRestGqlRequest } from '@/utils/send-rest-gql'

--- a/packages/frontend/src/api/post-essay-question.ts
+++ b/packages/frontend/src/api/post-essay-question.ts
@@ -1,4 +1,4 @@
-import { GetEssayQuestionEssayAnswersQuery } from '__generated__/operations/post-essay-question.generated'
+import { GetEssayQuestionEssayAnswersQuery } from '__generated__/operations/answers.generated'
 import {
   PostEssayAnswerOrderByInput,
   PostEssayQuestionWhereUniqueInput,

--- a/packages/frontend/src/api/post.ts
+++ b/packages/frontend/src/api/post.ts
@@ -8,7 +8,7 @@ import {
   GetPostQueryVariables,
   GetPostsEssayAnswersWithLikesQuery,
   GetPostsEssayAnswersWithLikesQueryVariables,
-} from '__generated__/operations/post.generated'
+} from '__generated__/operations/content.generated'
 
 import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 

--- a/packages/frontend/src/api/project.ts
+++ b/packages/frontend/src/api/project.ts
@@ -1,7 +1,7 @@
 import {
   GetTopicProjectsQuery,
   GetTopicProjectsQueryVariables,
-} from '__generated__/operations/project.generated'
+} from '__generated__/operations/content.generated'
 
 import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 

--- a/packages/frontend/src/api/sub-subcategory.ts
+++ b/packages/frontend/src/api/sub-subcategory.ts
@@ -1,7 +1,7 @@
 import {
   GetSubSubcategoryPostsQuery,
   GetSubSubcategoryPostsQueryVariables,
-} from '__generated__/operations/sub-subcategory.generated'
+} from '__generated__/operations/content.generated'
 
 import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 

--- a/packages/frontend/src/api/subcategory.ts
+++ b/packages/frontend/src/api/subcategory.ts
@@ -1,7 +1,7 @@
 import {
   GetSubcategoryPostsQuery,
   GetSubcategoryPostsQueryVariables,
-} from '__generated__/operations/subcategory.generated'
+} from '__generated__/operations/content.generated'
 
 import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 

--- a/packages/frontend/src/app/(sticky-header)/_components/article/article.tsx
+++ b/packages/frontend/src/app/(sticky-header)/_components/article/article.tsx
@@ -1,7 +1,7 @@
 'use client'
 import './article.css'
 
-import { GetPostQuery } from '__generated__/operations/post.generated'
+import { GetPostQuery } from '__generated__/operations/content.generated'
 import { cn, ScrollLevel, useScrollLevel } from '@kids-reporter/routing-ui'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'

--- a/packages/frontend/src/app/(sticky-header)/_components/article/hero-image.tsx
+++ b/packages/frontend/src/app/(sticky-header)/_components/article/hero-image.tsx
@@ -1,4 +1,4 @@
-import { GetPostQuery } from '__generated__/operations/post.generated'
+import { GetPostQuery } from '__generated__/operations/content.generated'
 import debounce from 'lodash/debounce'
 import dynamic from 'next/dynamic'
 import { useEffect, useState } from 'react'

--- a/packages/frontend/src/app/(sticky-header)/_components/article/news-reading.tsx
+++ b/packages/frontend/src/app/(sticky-header)/_components/article/news-reading.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { GetPostQuery } from '__generated__/operations/post.generated'
+import { GetPostQuery } from '__generated__/operations/content.generated'
 import { useMemo, useState } from 'react'
 import styled from 'styled-components'
 

--- a/packages/frontend/src/app/(sticky-header)/about/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/about/page.tsx
@@ -1,3 +1,4 @@
+import type { GetAuthorAvatarQuery } from '__generated__/operations/content.generated'
 import { Metadata } from 'next'
 import Link from 'next/link'
 
@@ -145,7 +146,7 @@ const consultants = [
 export default async function About() {
   // Fetch memeber avatar
   for (const member of teamMembers) {
-    const res = await sendRestGqlRequest({
+    const res = await sendRestGqlRequest<GetAuthorAvatarQuery>({
       operation: 'author-avatar',
       method: 'GET',
       variables: {

--- a/packages/frontend/src/app/(sticky-header)/all/[[...page]]/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/all/[[...page]]/page.tsx
@@ -1,3 +1,8 @@
+import type {
+  GetPostsQuery,
+  PostsCountQuery,
+} from '__generated__/operations/content.generated'
+import type { Post } from '__generated__/types'
 import { Metadata } from 'next'
 import { notFound, redirect } from 'next/navigation'
 
@@ -7,6 +12,7 @@ import Pagination from '@/components/pagination'
 import PostList from '@/components/post-list'
 import { ERROR_PAGE, GENERAL_DESCRIPTION, POST_PER_PAGE } from '@/constants'
 import { BaodaozaiVisibilitySetter } from '@/services/call-baodaozai'
+import type { DeepPartial } from '@/types/utils'
 import { getPostSummaries, log, LogLevel } from '@/utils'
 import { sendRestGqlRequest } from '@/utils/send-rest-gql'
 
@@ -30,16 +36,17 @@ export default async function LatestPosts({
   }
 
   // Fetch total posts count
-  const postsCountRes = await sendRestGqlRequest({
+  const postsCountRes = await sendRestGqlRequest<PostsCountQuery>({
     operation: 'posts-count',
     method: 'GET',
   })
   if (!postsCountRes) {
     log(LogLevel.WARNING, `Empty post count response!`)
   }
-  const postsCount = postsCountRes?.data?.data?.postsCount
+  const postsCount = postsCountRes?.data?.data?.postsCount ?? 0
 
-  let posts, totalPages
+  let posts: DeepPartial<Post>[] = []
+  let totalPages
   if (postsCount > 0) {
     totalPages = Math.ceil(postsCount / POST_PER_PAGE)
     if (currentPage > 1 && currentPage > totalPages) {
@@ -51,7 +58,7 @@ export default async function LatestPosts({
     }
 
     // Fetch posts of specific page
-    const postsRes = await sendRestGqlRequest({
+    const postsRes = await sendRestGqlRequest<GetPostsQuery>({
       operation: 'posts-paged',
       method: 'GET',
       variables: {
@@ -68,7 +75,7 @@ export default async function LatestPosts({
       log(LogLevel.WARNING, `Empty posts response!`)
       redirect(ERROR_PAGE)
     }
-    posts = postsRes?.data?.data?.posts
+    posts = postsRes?.data?.data?.posts ?? []
   }
 
   const postSummaries = getPostSummaries(posts)

--- a/packages/frontend/src/app/(sticky-header)/author/[[...slug]]/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/author/[[...slug]]/page.tsx
@@ -1,3 +1,7 @@
+import type {
+  GetAuthorMetaQuery,
+  GetAuthorPostsQuery,
+} from '__generated__/operations/content.generated'
 import { Metadata } from 'next'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
@@ -21,7 +25,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const slug = params.slug?.[0]
 
-  const authorMetaRes = await sendRestGqlRequest({
+  const authorMetaRes = await sendRestGqlRequest<GetAuthorMetaQuery>({
     operation: 'author-meta',
     method: 'GET',
     variables: {
@@ -67,7 +71,7 @@ export default async function Author({ params }: { params: { slug: any } }) {
     notFound()
   }
 
-  const response = await sendRestGqlRequest({
+  const response = await sendRestGqlRequest<GetAuthorPostsQuery>({
     operation: 'author-posts',
     method: 'GET',
     variables: {
@@ -88,8 +92,8 @@ export default async function Author({ params }: { params: { slug: any } }) {
     log(LogLevel.WARNING, 'Author not found!')
     notFound()
   }
-  const posts = author.posts
-  const postsCount = author.postsCount
+  const posts = author.posts ?? []
+  const postsCount = author.postsCount ?? 0
 
   const avatarURL = author.avatar?.resized?.tiny ?? DEFAULT_AVATAR
 

--- a/packages/frontend/src/app/(sticky-header)/tag/[[...slug]]/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/tag/[[...slug]]/page.tsx
@@ -1,3 +1,7 @@
+import type {
+  GetTagMetaQuery,
+  GetTagPostsQuery,
+} from '__generated__/operations/content.generated'
 import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 
@@ -20,7 +24,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const slug = params.slug?.[0]
 
-  const tagOGRes = await sendRestGqlRequest({
+  const tagOGRes = await sendRestGqlRequest<GetTagMetaQuery>({
     operation: 'tag-meta',
     method: 'GET',
     variables: {
@@ -65,7 +69,7 @@ export default async function Tag({ params }: { params: { slug: any } }) {
     notFound()
   }
 
-  const response = await sendRestGqlRequest({
+  const response = await sendRestGqlRequest<GetTagPostsQuery>({
     operation: 'tag-posts',
     method: 'GET',
     variables: {
@@ -87,8 +91,8 @@ export default async function Tag({ params }: { params: { slug: any } }) {
     log(LogLevel.WARNING, 'Tag not found!')
     notFound()
   }
-  const posts = tag.posts
-  const postsCount = tag.postsCount
+  const posts = tag.posts ?? []
+  const postsCount = tag.postsCount ?? 0
 
   const totalPages = Math.ceil(postsCount / POST_PER_PAGE)
   if (currentPage > 1 && currentPage > totalPages) {

--- a/packages/frontend/src/app/(sticky-header)/topic/[slug]/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/topic/[slug]/page.tsx
@@ -1,9 +1,14 @@
+import type {
+  GetProjectMetaQuery,
+  GetProjectQuery,
+} from '__generated__/operations/content.generated'
 import { HeaderPostTitleSetter } from '@kids-reporter/routing-ui'
 import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 
 import {
   ContentType,
+  FALLBACK_IMG,
   GENERAL_DESCRIPTION,
   KIDS_URL_ORIGIN,
   OG_SUFFIX,
@@ -18,6 +23,22 @@ import { Leading } from '../../_components/topic/leading'
 import { RelatedPosts } from '../../_components/topic/related-posts'
 import { PublishedDate } from '../../_components/topic/styled'
 
+const normalizePhoto = (photo: {
+  resized?: { small?: string; medium?: string; large?: string }
+}) => {
+  return {
+    resized: {
+      small: photo.resized?.small ?? FALLBACK_IMG,
+      medium: photo.resized?.medium ?? photo.resized?.small ?? FALLBACK_IMG,
+      large:
+        photo.resized?.large ??
+        photo.resized?.medium ??
+        photo.resized?.small ??
+        FALLBACK_IMG,
+    },
+  }
+}
+
 export async function generateMetadata({
   params,
 }: {
@@ -25,7 +46,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const slug = params.slug
 
-  const topicOGRes = await sendRestGqlRequest({
+  const topicOGRes = await sendRestGqlRequest<GetProjectMetaQuery>({
     operation: 'project-meta',
     method: 'GET',
     variables: {
@@ -72,7 +93,7 @@ export default async function TopicPage({
   }
 
   // TODO: maybe we could try apollo-client pkg
-  const axiosRes = await sendRestGqlRequest({
+  const axiosRes = await sendRestGqlRequest<GetProjectQuery>({
     operation: 'project-detail',
     method: 'GET',
     variables: {
@@ -87,18 +108,22 @@ export default async function TopicPage({
     notFound()
   }
 
-  const relatedPosts = getPostSummaries(project?.relatedPostsOrdered)
+  const relatedPosts = getPostSummaries(project?.relatedPostsOrdered ?? [])
+  const heroImage = normalizePhoto(project?.heroImage ?? {})
+  const mobileHeroImage = project?.mobileHeroImage
+    ? normalizePhoto(project.mobileHeroImage)
+    : undefined
 
   return (
     project && (
       <div>
         <HeaderPostTitleSetter postTitle={project.title} />
         <Leading
-          title={project.title}
+          title={project.title ?? ''}
           subtitle={project.subtitle ?? ''}
           titlePosition={project.titlePosition}
-          backgroundImage={project.heroImage}
-          mobileBgImage={project.mobileHeroImage}
+          backgroundImage={heroImage}
+          mobileBgImage={mobileHeroImage}
         />
         {project.publishedDate ? (
           <PublishedDate>

--- a/packages/frontend/src/app/(sticky-header)/topic/page/[[...pageNum]]/page.tsx
+++ b/packages/frontend/src/app/(sticky-header)/topic/page/[[...pageNum]]/page.tsx
@@ -1,3 +1,4 @@
+import type { GetProjectsQuery } from '__generated__/operations/content.generated'
 import { Metadata } from 'next'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
@@ -138,7 +139,7 @@ export default async function Topic({
 
   const [projectsRes, topicsIntroContentRes] = await Promise.allSettled([
     // Fetch projects of specific page
-    sendRestGqlRequest({
+    sendRestGqlRequest<GetProjectsQuery>({
       operation: 'projects-paged',
       method: 'GET',
       variables: {
@@ -161,7 +162,7 @@ export default async function Topic({
 
   const projects = projectsRes.value
   const topics = projects?.data?.data?.projects
-  const topicsCount = projects?.data?.data?.projectsCount
+  const topicsCount = projects?.data?.data?.projectsCount ?? 0
   const totalPages = Math.ceil(topicsCount / POST_PER_PAGE)
   if (currentPage > 1 && currentPage > totalPages) {
     log(

--- a/packages/frontend/src/app/api/search/utils.ts
+++ b/packages/frontend/src/app/api/search/utils.ts
@@ -1,3 +1,8 @@
+import type {
+  GetAuthorPostsCountQuery,
+  GetProjectRelatedPostsCountQuery,
+  GetTagPostsQuery,
+} from '__generated__/operations/content.generated'
 import { customsearch } from '@googleapis/customsearch'
 import { customsearch_v1 } from '@googleapis/customsearch/v1'
 import errors from '@twreporter/errors'
@@ -56,20 +61,21 @@ export async function transferItemsToCards(
       const url = item?.link || metaTag?.['og:url']
       const slug = url?.match(/(author|topic|tag)\/([^/]*)\/?/)?.[2]
       if (contentType === ContentType.TOPIC && slug) {
-        const topicRes = await sendRestGqlRequest({
-          operation: 'project-related-posts-count',
-          method: 'GET',
-          variables: {
-            where: {
-              slug: slug,
+        const topicRes =
+          await sendRestGqlRequest<GetProjectRelatedPostsCountQuery>({
+            operation: 'project-related-posts-count',
+            method: 'GET',
+            variables: {
+              where: {
+                slug: slug,
+              },
             },
-          },
-        })
+          })
         contentSummary.category = '專題'
         contentSummary.postCount =
-          topicRes?.data?.data?.project?.relatedPostsCount
+          topicRes?.data?.data?.project?.relatedPostsCount ?? 0
       } else if (contentType === ContentType.AUTHOR && slug) {
-        const authorRes = await sendRestGqlRequest({
+        const authorRes = await sendRestGqlRequest<GetAuthorPostsCountQuery>({
           operation: 'author-posts-count',
           method: 'GET',
           variables: {
@@ -79,9 +85,10 @@ export async function transferItemsToCards(
           },
         })
         contentSummary.category = '作者'
-        contentSummary.postCount = authorRes?.data?.data?.author?.postsCount
+        contentSummary.postCount =
+          authorRes?.data?.data?.author?.postsCount ?? 0
       } else if (contentType === ContentType.TAG && slug) {
-        const tagRes = await sendRestGqlRequest({
+        const tagRes = await sendRestGqlRequest<GetTagPostsQuery>({
           operation: 'tag-posts',
           method: 'GET',
           variables: {
@@ -95,9 +102,9 @@ export async function transferItemsToCards(
           },
         })
         contentSummary.category = '標籤'
-        contentSummary.postCount = tagRes?.data?.data?.tag?.postsCount
+        contentSummary.postCount = tagRes?.data?.data?.tag?.postsCount ?? 0
         contentSummary.image =
-          tagRes?.data?.data?.tag?.posts?.[0]?.heroImage?.resized?.tiny
+          tagRes?.data?.data?.tag?.posts?.[0]?.heroImage?.resized?.small
       }
 
       return { content: contentSummary }

--- a/packages/frontend/src/app/sitemap.ts
+++ b/packages/frontend/src/app/sitemap.ts
@@ -10,6 +10,10 @@ https://github.com/vercel/next.js/issues/56018
 Therefore, so far we can't upgrade to v13.5.4 due to #56018 & #54057 remains.
 */
 
+import type {
+  GetPostsForSitemapQuery,
+  GetProjectsForSitemapQuery,
+} from '__generated__/operations/content.generated'
 import { MetadataRoute } from 'next'
 
 import { KIDS_URL_ORIGIN } from '@/constants'
@@ -25,7 +29,7 @@ const fetchSitemaps = async (): Promise<
   const sixtyDaysBefore = new Date(
     new Date().setHours(0, 0, 0, 0) - 60 * 24 * 60 * 60 * 1000
   )
-  const postsRes = await sendRestGqlRequest({
+  const postsRes = await sendRestGqlRequest<GetPostsForSitemapQuery>({
     operation: 'posts-sitemap',
     method: 'GET',
     variables: {
@@ -46,7 +50,7 @@ const fetchSitemaps = async (): Promise<
     sitemaps = [...posts]
   }
 
-  const topicsRes = await sendRestGqlRequest({
+  const topicsRes = await sendRestGqlRequest<GetProjectsForSitemapQuery>({
     operation: 'projects-sitemap',
     method: 'GET',
     variables: {

--- a/packages/frontend/src/components/tags.tsx
+++ b/packages/frontend/src/components/tags.tsx
@@ -1,4 +1,4 @@
-import { GetPostQuery } from '__generated__/operations/post.generated'
+import { GetPostQuery } from '__generated__/operations/content.generated'
 import Link from 'next/link'
 
 import { RecursiveNonNullable } from '@/types/utils'

--- a/packages/frontend/src/modules/idea-hub/all-answers/utils.ts
+++ b/packages/frontend/src/modules/idea-hub/all-answers/utils.ts
@@ -1,4 +1,4 @@
-import { GetPostsEssayAnswersWithLikesQuery } from '__generated__/operations/post.generated'
+import { GetPostsEssayAnswersWithLikesQuery } from '__generated__/operations/content.generated'
 import { InfiniteData } from '@tanstack/react-query'
 
 import { PostWithTwoTopLikesAnswersPerQuestion } from '../types'

--- a/packages/frontend/src/modules/idea-hub/types.ts
+++ b/packages/frontend/src/modules/idea-hub/types.ts
@@ -1,4 +1,4 @@
-import { GetPostsEssayAnswersWithLikesQuery } from '__generated__/operations/post.generated'
+import { GetPostsEssayAnswersWithLikesQuery } from '__generated__/operations/content.generated'
 
 import { RecursiveNonNullable } from '@/types/utils'
 

--- a/packages/frontend/src/modules/idea-hub/utils.ts
+++ b/packages/frontend/src/modules/idea-hub/utils.ts
@@ -2,7 +2,9 @@ import { Member } from '__generated__/types'
 
 import { DEFAULT_TEXT_HOLDER } from '@/constants/input-field'
 
-export const getMemberDisplayName = (member: Member | undefined) => {
+type MemberDisplay = Partial<Pick<Member, 'nickname' | 'name' | 'email'>>
+
+export const getMemberDisplayName = (member: MemberDisplay | undefined) => {
   if (!member) return DEFAULT_TEXT_HOLDER
   return member.nickname || member.name || member.email || DEFAULT_TEXT_HOLDER
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6268,6 +6268,8 @@ __metadata:
     cors: "npm:^2.8.5"
     dotenv-cli: "npm:^10.0.0"
     express: "npm:^4.18.2"
+    graphql: "npm:^16.8.1"
+    graphql-tag: "npm:^2.12.6"
     http-proxy-middleware: "npm:^2.0.6"
     nodemon: "npm:^2.0.20"
     typescript: "npm:5.9.2"


### PR DESCRIPTION
## Summary

- sync api-gateway docs and GraphQL ops for member avatar + answers query improvements
- improve frontend codegen flow and type alignment

## Changes
- api-gateway: add member avatar docs and enrich answers query payload
- api-gateway: wrap operations in gql documents
- frontend codegen: align generated imports and tighten REST types
- frontend codegen: split local vs cloudbuild paths
- docs: source codegen documentation from api-gateway ops

## Addition Notes
- CreateMemberAvatar is still using /api/graphql and has not moved to /api/rest/, so it cannot be handled via api-gateway/graphql/operations.
- The api-gateway endpoint implementation for create member avatar will be added in the next PR.