### PR TITLE
fix(api-gateway): add missing member email for display

### DIFF
--- a/packages/api-gateway/src/graphql/documents/answers.ts
+++ b/packages/api-gateway/src/graphql/documents/answers.ts
@@ -76,6 +76,7 @@ export const GET_ALL_POST_ESSAY_ANSWERS_QUERY = gql`
         }
         nickname
         name
+        email
       }
       content
       likesCount


### PR DESCRIPTION
## Issue
- the fallback display name for member in latest answers is email, but it's missing in the graphql query string.
<img width="857" height="390" alt="image" src="https://github.com/user-attachments/assets/4dc3360e-f5d2-4ee4-913c-9a332955a0ba" />
