### PR TITLE
fix(frontend): improve article toolbar and table of content UX

### DIFF
--- a/packages/frontend/src/modules/article/components/table-of-content-side-menu.tsx
+++ b/packages/frontend/src/modules/article/components/table-of-content-side-menu.tsx
@@ -139,7 +139,7 @@ function TableOfContentSideMenu({ indexes }: TableOfContentSideMenuProps) {
   return (
     <nav
       ref={menuContainerRef}
-      className="fixed top-0 left-0 z-1002 print:hidden"
+      className="fixed top-0 left-0 z-1000 print:hidden"
       aria-label="文章目錄"
     >
       <button

--- a/packages/frontend/src/modules/article/components/table-of-content-side-menu.tsx
+++ b/packages/frontend/src/modules/article/components/table-of-content-side-menu.tsx
@@ -221,9 +221,9 @@ function TableOfContentSideMenu({ indexes }: TableOfContentSideMenuProps) {
               : undefined
           }
           className={cn(
-            'w-full cursor-pointer rounded bg-transparent px-1 py-[1px] text-start prose-p2 break-words text-neutral-600 transition-all duration-100 ease-in-out',
+            'w-full cursor-pointer rounded bg-transparent px-1 py-[1px] text-start prose-p2 break-words text-neutral-600 transition-all duration-100 ease-in-out hover:bg-neutral-black/5 active:bg-neutral-black/10',
             // Desktop/HD: match Figma design
-            'desktop:rounded desktop:px-1 desktop:py-[1px] desktop:font-medium',
+            'desktop:rounded desktop:px-1 desktop:py-[1px]',
             currentActiveIndex ===
               makeAnchorKey(TABLE_OF_CONTENT_BACK_TO_TOP_KEY) &&
               'font-bold text-red-400'
@@ -244,11 +244,11 @@ function TableOfContentSideMenu({ indexes }: TableOfContentSideMenuProps) {
               currentActiveIndex === makeAnchorKey(key) ? 'location' : undefined
             }
             className={cn(
-              'w-full cursor-pointer rounded bg-transparent px-1 py-[1px] text-start prose-p2 break-words text-neutral-600 transition-all duration-100 ease-in-out',
+              'w-full cursor-pointer rounded bg-transparent px-1 py-[1px] text-start prose-p2 break-words text-neutral-600 transition-all duration-100 ease-in-out hover:bg-neutral-black/5 active:bg-neutral-black/10',
               // Desktop/HD: match Figma design
-              'desktop:rounded desktop:px-1 desktop:py-[1px] desktop:font-medium',
+              'desktop:rounded desktop:px-1 desktop:py-[1px]',
               currentActiveIndex === makeAnchorKey(key) &&
-                'font-bold text-red-400 desktop:font-bold'
+                'font-bold text-red-400'
             )}
           >
             {label}

--- a/packages/frontend/src/modules/article/components/table-of-content-side-menu.tsx
+++ b/packages/frontend/src/modules/article/components/table-of-content-side-menu.tsx
@@ -178,7 +178,7 @@ function TableOfContentSideMenu({ indexes }: TableOfContentSideMenuProps) {
       >
         <div
           className={cn(
-            'absolute top-0 left-0 flex h-24 w-8 flex-col items-center justify-center gap-2.5 rounded-r-[20px] bg-neutral-black/8 px-[9px] py-[26px] text-sm leading-[1.6] text-neutral-700 backdrop-blur-xs transition-all duration-300 ease-in-out hover:text-red-400 desktop:hidden',
+            'absolute top-0 left-0 flex h-24 w-8 flex-col items-center justify-center gap-2.5 rounded-r-[20px] bg-neutral-black/8 px-[9px] py-[26px] text-sm leading-[1.6] text-neutral-700 backdrop-blur-xs transition-colors duration-300 ease-in-out hover:text-red-400 desktop:hidden',
             isExpanded && 'bg-neutral-200'
           )}
         >
@@ -230,7 +230,7 @@ function TableOfContentSideMenu({ indexes }: TableOfContentSideMenuProps) {
               : undefined
           }
           className={cn(
-            'w-full cursor-pointer rounded bg-transparent px-1 py-[1px] text-start prose-p2 break-words text-neutral-600 transition-all duration-300 ease-in-out hover:bg-neutral-black/5 active:bg-neutral-black/10',
+            'w-full cursor-pointer rounded bg-transparent px-1 py-[1px] text-start prose-p2 break-words text-neutral-600 transition-colors duration-300 ease-in-out hover:bg-neutral-black/5 active:bg-neutral-black/10',
             // Desktop/HD: match Figma design
             'desktop:rounded desktop:px-1 desktop:py-[1px]',
             currentActiveIndex ===
@@ -253,7 +253,7 @@ function TableOfContentSideMenu({ indexes }: TableOfContentSideMenuProps) {
               currentActiveIndex === makeAnchorKey(key) ? 'location' : undefined
             }
             className={cn(
-              'w-full cursor-pointer rounded bg-transparent px-1 py-[1px] text-start prose-p2 break-words text-neutral-600 transition-all duration-300 ease-in-out hover:bg-neutral-black/5 active:bg-neutral-black/10',
+              'w-full cursor-pointer rounded bg-transparent px-1 py-[1px] text-start prose-p2 break-words text-neutral-600 transition-colors duration-300 ease-in-out hover:bg-neutral-black/5 active:bg-neutral-black/10',
               // Desktop/HD: match Figma design
               'desktop:rounded desktop:px-1 desktop:py-[1px]',
               currentActiveIndex === makeAnchorKey(key) &&

--- a/packages/frontend/src/modules/article/components/table-of-content-side-menu.tsx
+++ b/packages/frontend/src/modules/article/components/table-of-content-side-menu.tsx
@@ -1,5 +1,10 @@
 'use client'
-import { cn, useMediaQuery } from '@kids-reporter/routing-ui'
+import {
+  cn,
+  ScrollLevel,
+  useMediaQuery,
+  useScrollLevel,
+} from '@kids-reporter/routing-ui'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { STICKY_HEADER_HEIGHT } from '@/constants'
@@ -131,6 +136,9 @@ function TableOfContentSideMenu({ indexes }: TableOfContentSideMenuProps) {
   useClickOutside(menuContainerRef, handleClickOutside)
 
   const isDesktop = useMediaQuery('(min-width: 1024px)')
+  const scrollLevel = useScrollLevel()
+  const isHidden =
+    scrollLevel === ScrollLevel.DOWN_HIDDEN && !isDesktop && !isExpanded
 
   if (indexes.length === 0) {
     return null
@@ -161,15 +169,16 @@ function TableOfContentSideMenu({ indexes }: TableOfContentSideMenuProps) {
         aria-label={isExpanded ? '關閉目錄' : '開啟目錄'}
         aria-expanded={isExpanded}
         className={cn(
-          'fixed top-[80px] left-0 w-8 cursor-pointer transition-transform delay-100 duration-100 ease-in-out desktop:top-1/2 desktop:-translate-y-1/2',
+          'fixed top-[80px] left-0 w-8 cursor-pointer transition-transform duration-300 ease-in-out desktop:top-1/2 desktop:-translate-y-1/2',
           isExpanded
             ? 'translate-x-[200px] desktop:translate-x-0'
-            : 'translate-x-0'
+            : 'translate-x-0',
+          isHidden && 'translate-x-[-200px]'
         )}
       >
         <div
           className={cn(
-            'absolute top-0 left-0 flex h-24 w-8 flex-col items-center justify-center gap-2.5 rounded-r-[20px] bg-neutral-black/8 px-[9px] py-[26px] text-sm leading-[1.6] text-neutral-700 backdrop-blur-xs transition-all duration-100 ease-in-out hover:text-red-400 desktop:hidden',
+            'absolute top-0 left-0 flex h-24 w-8 flex-col items-center justify-center gap-2.5 rounded-r-[20px] bg-neutral-black/8 px-[9px] py-[26px] text-sm leading-[1.6] text-neutral-700 backdrop-blur-xs transition-all duration-300 ease-in-out hover:text-red-400 desktop:hidden',
             isExpanded && 'bg-neutral-200'
           )}
         >
@@ -193,7 +202,7 @@ function TableOfContentSideMenu({ indexes }: TableOfContentSideMenuProps) {
       <div
         role="list"
         className={cn(
-          'fixed top-0 left-0 flex h-screen w-[200px] flex-col justify-center gap-2 bg-neutral-100 px-5 py-6 shadow-[0px_2px_12px_0px_rgba(0,0,0,0.2)] transition-transform delay-100 duration-100 ease-in-out desktop:left-4',
+          'fixed top-0 left-0 flex h-screen w-[200px] flex-col justify-center gap-2 bg-neutral-100 px-5 py-6 shadow-[0px_2px_12px_0px_rgba(0,0,0,0.2)] transition-transform duration-300 ease-in-out desktop:left-4',
           isExpanded ? 'translate-x-0' : '-translate-x-[200px]',
           'desktop:top-1/2 desktop:h-auto desktop:min-h-75 desktop:-translate-y-1/2 desktop:rounded-[20px] desktop:px-5 desktop:py-6',
           isExpanded && isDesktop
@@ -221,7 +230,7 @@ function TableOfContentSideMenu({ indexes }: TableOfContentSideMenuProps) {
               : undefined
           }
           className={cn(
-            'w-full cursor-pointer rounded bg-transparent px-1 py-[1px] text-start prose-p2 break-words text-neutral-600 transition-all duration-100 ease-in-out hover:bg-neutral-black/5 active:bg-neutral-black/10',
+            'w-full cursor-pointer rounded bg-transparent px-1 py-[1px] text-start prose-p2 break-words text-neutral-600 transition-all duration-300 ease-in-out hover:bg-neutral-black/5 active:bg-neutral-black/10',
             // Desktop/HD: match Figma design
             'desktop:rounded desktop:px-1 desktop:py-[1px]',
             currentActiveIndex ===
@@ -244,7 +253,7 @@ function TableOfContentSideMenu({ indexes }: TableOfContentSideMenuProps) {
               currentActiveIndex === makeAnchorKey(key) ? 'location' : undefined
             }
             className={cn(
-              'w-full cursor-pointer rounded bg-transparent px-1 py-[1px] text-start prose-p2 break-words text-neutral-600 transition-all duration-100 ease-in-out hover:bg-neutral-black/5 active:bg-neutral-black/10',
+              'w-full cursor-pointer rounded bg-transparent px-1 py-[1px] text-start prose-p2 break-words text-neutral-600 transition-all duration-300 ease-in-out hover:bg-neutral-black/5 active:bg-neutral-black/10',
               // Desktop/HD: match Figma design
               'desktop:rounded desktop:px-1 desktop:py-[1px]',
               currentActiveIndex === makeAnchorKey(key) &&

--- a/packages/frontend/src/modules/article/components/toolbar.tsx
+++ b/packages/frontend/src/modules/article/components/toolbar.tsx
@@ -164,7 +164,7 @@ function DesktopToolbar({ topicURL, onCheckAnswerClick }: DesktopToolbarProp) {
           <div className="relative z-1">
             <ToolbarTopicIcon />
           </div>
-          <span className="absolute z-0 w-4 text-start prose-p3-bold text-nowrap text-neutral-black opacity-0 transition-all duration-200 [text-shadow:0_0_6px_white,0_0_12px_white] group-hover:translate-x-12 group-hover:opacity-100">
+          <span className="pointer-events-none absolute left-15 z-0 w-4 text-start prose-p3-bold text-nowrap text-neutral-black opacity-0 transition-opacity duration-200 [text-shadow:0_0_6px_white,0_0_12px_white] group-hover:pointer-events-auto group-hover:opacity-100">
             前往專題
           </span>
         </Link>
@@ -176,7 +176,7 @@ function DesktopToolbar({ topicURL, onCheckAnswerClick }: DesktopToolbarProp) {
           <div className="relative z-1">
             <ToolbarCheckAnswerIcon />
           </div>
-          <span className="absolute z-0 w-4 text-start prose-p3-bold text-nowrap text-neutral-black opacity-0 transition-all duration-200 [text-shadow:0_0_6px_white,0_0_12px_white] group-hover:translate-x-12 group-hover:opacity-100">
+          <span className="pointer-events-none absolute left-15 z-0 w-4 text-start prose-p3-bold text-nowrap text-neutral-black opacity-0 transition-opacity duration-200 [text-shadow:0_0_6px_white,0_0_12px_white] group-hover:pointer-events-auto group-hover:opacity-100">
             查看回答
           </span>
         </button>
@@ -190,7 +190,7 @@ function DesktopToolbar({ topicURL, onCheckAnswerClick }: DesktopToolbarProp) {
           <div className="relative z-1">
             <ToolbarFontIcon />
           </div>
-          <span className="absolute z-0 w-4 text-start prose-p3-bold text-nowrap text-neutral-black opacity-0 transition-all duration-200 [text-shadow:0_0_6px_white,0_0_12px_white] group-hover:translate-x-12 group-hover:opacity-100">
+          <span className="pointer-events-none absolute left-15 z-0 w-4 text-start prose-p3-bold text-nowrap text-neutral-black opacity-0 transition-opacity duration-200 [text-shadow:0_0_6px_white,0_0_12px_white] group-hover:pointer-events-auto group-hover:opacity-100">
             字體大小{fontSize === FontSizeLevel.NORMAL ? '100%' : '125%'}
           </span>
         </button>
@@ -202,15 +202,15 @@ function DesktopToolbar({ topicURL, onCheckAnswerClick }: DesktopToolbarProp) {
           <div className="relative z-1">
             <ToolbarPrintIcon />
           </div>
-          <span className="absolute z-0 w-4 text-start prose-p3-bold text-nowrap text-neutral-black opacity-0 transition-all duration-200 [text-shadow:0_0_6px_white,0_0_12px_white] group-hover:translate-x-12 group-hover:opacity-100">
+          <span className="pointer-events-none absolute left-15 z-0 w-4 text-start prose-p3-bold text-nowrap text-neutral-black opacity-0 transition-opacity duration-200 [text-shadow:0_0_6px_white,0_0_12px_white] group-hover:pointer-events-auto group-hover:opacity-100">
             列印
           </span>
         </button>
         <div
           className={cn(
-            'pointer-events-none absolute top-6 left-21 flex translate-x-[-15px] flex-col gap-3 rounded-[40px] bg-neutral-white p-3 opacity-0 shadow-[var(--shadow-baodaozai-card)] transition-all duration-300 ease-in-out',
+            'pointer-events-none absolute top-6 left-21 flex flex-col gap-3 rounded-[40px] bg-neutral-white p-3 opacity-0 shadow-[var(--shadow-baodaozai-card)] transition-all duration-300 ease-in-out',
             {
-              'pointer-events-auto translate-x-0 opacity-100': isSharePanelOpen,
+              'pointer-events-auto opacity-100': isSharePanelOpen,
             }
           )}
         >
@@ -253,7 +253,7 @@ function DesktopToolbar({ topicURL, onCheckAnswerClick }: DesktopToolbarProp) {
           </div>
           <span
             className={cn(
-              'absolute z-0 w-4 text-start prose-p3-bold text-nowrap text-neutral-black opacity-0 transition-all duration-200 [text-shadow:0_0_6px_white,0_0_12px_white] group-hover:translate-x-12 group-hover:opacity-100',
+              'pointer-events-none absolute left-15 z-0 w-4 text-start prose-p3-bold text-nowrap text-neutral-black opacity-0 transition-opacity duration-200 [text-shadow:0_0_6px_white,0_0_12px_white] group-hover:pointer-events-auto group-hover:opacity-100',
               {
                 'group-hover:opacity-0': isSharePanelOpen,
               }

--- a/packages/frontend/src/modules/article/components/toolbar.tsx
+++ b/packages/frontend/src/modules/article/components/toolbar.tsx
@@ -208,7 +208,7 @@ function DesktopToolbar({ topicURL, onCheckAnswerClick }: DesktopToolbarProp) {
         </button>
         <div
           className={cn(
-            'pointer-events-none absolute top-6 left-21 flex flex-col gap-3 rounded-[40px] bg-neutral-white p-3 opacity-0 shadow-[var(--shadow-baodaozai-card)] transition-all duration-300 ease-in-out',
+            'pointer-events-none absolute top-6 left-21 flex flex-col gap-3 rounded-[40px] bg-neutral-white p-3 opacity-0 shadow-[var(--shadow-baodaozai-card)] transition-opacity duration-300 ease-in-out',
             {
               'pointer-events-auto opacity-100': isSharePanelOpen,
             }

--- a/packages/frontend/src/modules/article/components/toolbar.tsx
+++ b/packages/frontend/src/modules/article/components/toolbar.tsx
@@ -278,7 +278,7 @@ function Toolbar({ topicURL, postSlug }: ToolbarProp) {
   return (
     <>
       {/* 148px is 1/2 of toolbar height */}
-      <div className="fixed bottom-6 left-6 z-1000 tablet:bottom-8 tablet:left-1/2 tablet:-translate-x-1/2 desktop:sticky desktop:top-[calc(50vh+148px)] desktop:left-12 desktop:z-[999] desktop:flex desktop:h-0 desktop:translate-x-0 desktop:items-end hd:left-20 print:hidden">
+      <div className="fixed bottom-6 left-6 z-999 tablet:bottom-8 tablet:left-1/2 tablet:-translate-x-1/2 desktop:sticky desktop:top-[calc(50vh+148px)] desktop:left-12 desktop:z-[999] desktop:flex desktop:h-0 desktop:translate-x-0 desktop:items-end hd:left-20 print:hidden">
         <div className="desktop:hidden">
           <MobileToolbar
             topicURL={topicURL}


### PR DESCRIPTION
## Summary

This PR addresses several UX improvements for the article toolbar and table of content side menu. The changes include fixing z-index layering issues, improving scroll behavior on mobile, enhancing hover interactions, and refining animation transitions.

## Changes

- **Table of Content Side Menu** (`table-of-content-side-menu.tsx`):
  - Added scroll-aware visibility: menu automatically hides when scrolling down on mobile devices (using `useScrollLevel` hook)
  - Adjusted z-index from `z-1002` to `z-1000` to prevent overlapping with header menu
  - Improved transition animations: changed duration from `100ms` to `300ms` and removed delay for smoother experience
  - Enhanced hover and active states: added `hover:bg-neutral-black/5` and `active:bg-neutral-black/10` to menu items
  - Removed redundant `desktop:font-medium` class from menu items (font-weight is already handled by active state)

- **Article Toolbar** (`toolbar.tsx`):
  - Fixed z-index layering: changed toolbar container from `z-1000` to `z-999` to ensure proper stacking order
  - Removed left-to-right slide animation from toolbar text labels (removed `translate-x-12` on hover)
  - Improved text label positioning: changed from translate-based to fixed `left-15` positioning
  - Optimized transitions: changed from `transition-all` to `transition-opacity` for better performance
  - Added proper pointer events handling: text labels use `pointer-events-none` by default and `group-hover:pointer-events-auto` on hover
  - Simplified share panel animation: removed `translate-x-[-15px]` transform, using opacity transition only

## Additional Notes

- The scroll-aware hiding behavior only applies to mobile devices when the menu is not expanded
- Z-index adjustments ensure the header menu (z-1001) appears above both the toolbar (z-999) and table of content menu (z-1000)
- Animation improvements provide smoother and more performant user interactions

## Screenshot(s)

## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/toolbar-4-2e98dbdca93280fea17ef63ee0d71e5d?source=copy_link)