### PR TITLE
fix(frontend): reset scrolling state when closing post essay questions modal

### DIFF
--- a/packages/frontend/src/modules/idea-hub/post-essay-questions-modal/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/post-essay-questions-modal/index.tsx
@@ -108,8 +108,13 @@ function PostEssayQuestionsModal({
     )
   }, [post?.postEssayQuestions])
 
+  const handleClose = () => {
+    onClose()
+    setScrolledQuestionIds(new Set())
+  }
+
   return (
-    <Dialog open={open} onOpenChange={onClose}>
+    <Dialog open={open} onOpenChange={handleClose}>
       <DialogContent
         className="gap-0 overflow-hidden bg-neutral-100"
         showCloseButton={false}

--- a/packages/frontend/src/modules/idea-hub/post-essay-questions-modal/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/post-essay-questions-modal/index.tsx
@@ -108,13 +108,18 @@ function PostEssayQuestionsModal({
     )
   }, [post?.postEssayQuestions])
 
-  const handleClose = () => {
-    onClose()
-    setScrolledQuestionIds(new Set())
-  }
+  const handleOpenChange = useCallback(
+    (isOpen: boolean) => {
+      if (!isOpen) {
+        onClose()
+        setScrolledQuestionIds(new Set())
+      }
+    },
+    [onClose]
+  )
 
   return (
-    <Dialog open={open} onOpenChange={handleClose}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
         className="gap-0 overflow-hidden bg-neutral-100"
         showCloseButton={false}


### PR DESCRIPTION
## Summary

This PR fixes an issue where the scrolling state of question cards in the post essay questions modal was not being reset when the modal was closed. This could cause the modal to display incorrect UI states (such as collapsed title) when reopened if questions had been scrolled previously.

## Changes

- Added `handleClose` function that resets `scrolledQuestionIds` state to an empty Set when the modal closes
- Updated Dialog `onOpenChange` prop to use `handleClose` instead of calling `onClose` directly
- Ensures clean state when the modal is reopened, preventing stale scrolling state from affecting the UI

## Additional Notes

The `scrolledQuestionIds` state tracks which question cards have been scrolled, which affects the title display (collapsing from 3 lines to 1 line when any card is scrolled). Without resetting this state on close, the modal could reopen with the title already in the collapsed state even if no scrolling had occurred in the new session.

## Screenshot(s)

https://github.com/user-attachments/assets/deda48a1-c10f-4182-af1f-4090eb15f280


## Reference(s)

