### PR TITLE
feat(frontend): add anchor TOC and menu link for About page

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -19,7 +19,7 @@
     "@googleapis/customsearch": "^1.0.4",
     "@hookform/resolvers": "^5.2.2",
     "@kids-reporter/draft-renderer": "^1.0.13",
-    "@kids-reporter/routing-ui": "0.1.9",
+    "@kids-reporter/routing-ui": "0.1.10",
     "@next/third-parties": "^14.1.1",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/packages/frontend/src/components/table-of-content/constants.ts
+++ b/packages/frontend/src/components/table-of-content/constants.ts
@@ -1,0 +1,5 @@
+export const DEFAULT_ANCHOR_ID_PREFIX = 'toc-anchor-'
+export const TABLE_OF_CONTENT_INDEX_PREFIX = 'toc-index'
+export const TABLE_OF_CONTENT_BACK_TO_TOP_KEY = 'back-to-top'
+/** Default scroll distance (px) before TOC hides on mobile when scrolling down. */
+export const DEFAULT_SCROLL_DOWN_DISTANCE = 220

--- a/packages/frontend/src/components/table-of-content/index.ts
+++ b/packages/frontend/src/components/table-of-content/index.ts
@@ -1,7 +1,7 @@
-export { default as TableOfContentSideMenu } from './table-of-content-side-menu'
 export {
   DEFAULT_ANCHOR_ID_PREFIX,
   DEFAULT_SCROLL_DOWN_DISTANCE,
   TABLE_OF_CONTENT_BACK_TO_TOP_KEY,
   TABLE_OF_CONTENT_INDEX_PREFIX,
 } from './constants'
+export { default as TableOfContentSideMenu } from './table-of-content-side-menu'

--- a/packages/frontend/src/components/table-of-content/index.ts
+++ b/packages/frontend/src/components/table-of-content/index.ts
@@ -1,0 +1,7 @@
+export { default as TableOfContentSideMenu } from './table-of-content-side-menu'
+export {
+  DEFAULT_ANCHOR_ID_PREFIX,
+  DEFAULT_SCROLL_DOWN_DISTANCE,
+  TABLE_OF_CONTENT_BACK_TO_TOP_KEY,
+  TABLE_OF_CONTENT_INDEX_PREFIX,
+} from './constants'

--- a/packages/frontend/src/components/table-of-content/table-of-content-side-menu.tsx
+++ b/packages/frontend/src/components/table-of-content/table-of-content-side-menu.tsx
@@ -195,7 +195,7 @@ function TableOfContentSideMenu({
         aria-label={isExpanded ? '關閉目錄' : '開啟目錄'}
         aria-expanded={isExpanded}
         className={cn(
-          'fixed top-[144px] left-0 w-8 cursor-pointer transition-transform delay-100 duration-100 ease-in-out desktop:top-1/2 desktop:-translate-y-1/2',
+          'fixed top-[144px] left-0 w-8 cursor-pointer transition-transform duration-300 ease-in-out desktop:top-1/2 desktop:-translate-y-1/2',
           isExpanded
             ? 'translate-x-[200px] desktop:translate-x-0'
             : 'translate-x-0',

--- a/packages/frontend/src/components/table-of-content/table-of-content-side-menu.tsx
+++ b/packages/frontend/src/components/table-of-content/table-of-content-side-menu.tsx
@@ -11,56 +11,73 @@ import { STICKY_HEADER_HEIGHT } from '@/constants'
 import useClickOutside from '@/hooks/use-click-outside'
 
 import {
-  ARTICLE_WIDGET_SCROLL_DOWN_DISTANCE,
-  TABLE_OF_CONTENT_ANCHOR_PREFIX,
+  DEFAULT_ANCHOR_ID_PREFIX,
+  DEFAULT_SCROLL_DOWN_DISTANCE,
   TABLE_OF_CONTENT_BACK_TO_TOP_KEY,
   TABLE_OF_CONTENT_INDEX_PREFIX,
-} from '../constants'
+} from './constants'
 
 type TableOfContentSideMenuProps = {
   indexes: { key: string; label: string }[]
+  /** Prefix for section element ids. Empty string means section ids are the raw keys (e.g. id="mission"). Default preserves article/draft-renderer convention. */
+  anchorIdPrefix?: string
+  /** Px to scroll down before TOC hides on mobile. */
+  scrollDownDistance?: number
+  /** Aria-label for the nav element. */
+  ariaLabel?: string
 }
 
 function makeAnchorIndexKey(key: string) {
   return `${TABLE_OF_CONTENT_INDEX_PREFIX}-${key}`
 }
 
-function makeAnchorKey(key: string) {
-  return `${TABLE_OF_CONTENT_ANCHOR_PREFIX}-${key}`
+function makeAnchorKey(
+  key: string,
+  anchorIdPrefix: string = DEFAULT_ANCHOR_ID_PREFIX
+) {
+  return anchorIdPrefix ? `${anchorIdPrefix}${key}` : key
 }
 
-function TableOfContentSideMenu({ indexes }: TableOfContentSideMenuProps) {
+function TableOfContentSideMenu({
+  indexes,
+  anchorIdPrefix = DEFAULT_ANCHOR_ID_PREFIX,
+  scrollDownDistance = DEFAULT_SCROLL_DOWN_DISTANCE,
+  ariaLabel = '文章目錄',
+}: TableOfContentSideMenuProps) {
   const [currentActiveIndex, setCurrentActiveIndex] = useState<string | null>(
-    makeAnchorKey(TABLE_OF_CONTENT_BACK_TO_TOP_KEY)
+    makeAnchorKey(TABLE_OF_CONTENT_BACK_TO_TOP_KEY, anchorIdPrefix)
   )
   const [isExpanded, setIsExpanded] = useState(false)
-  const anchorRefs = useRef<HTMLSpanElement[]>([])
+  const anchorRefs = useRef<HTMLElement[]>([])
   const menuContainerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     anchorRefs.current = indexes
       .map(({ key }) => {
+        const id = makeAnchorKey(key, anchorIdPrefix)
         const element = document.querySelector(
-          `#${makeAnchorKey(key)}`
-        ) as HTMLSpanElement | null
+          `#${CSS.escape(id)}`
+        ) as HTMLElement | null
         return element
       })
-      .filter((anchor): anchor is HTMLSpanElement => anchor !== null)
-  }, [indexes])
+      .filter((anchor): anchor is HTMLElement => anchor !== null)
+  }, [indexes, anchorIdPrefix])
 
-  const handleClickAnchorIndex = useCallback((key: string) => {
-    const anchor = anchorRefs.current.find(
-      (anchor) => anchor.id === makeAnchorKey(key)
-    )
-    if (!anchor) return
-    const elementPosition = anchor.getBoundingClientRect().top
-    const offsetPosition =
-      elementPosition + window.scrollY - STICKY_HEADER_HEIGHT
-    window.scrollTo({
-      top: offsetPosition,
-      behavior: 'smooth',
-    })
-  }, [])
+  const handleClickAnchorIndex = useCallback(
+    (key: string) => {
+      const targetId = makeAnchorKey(key, anchorIdPrefix)
+      const anchor = anchorRefs.current.find((anchor) => anchor.id === targetId)
+      if (!anchor) return
+      const elementPosition = anchor.getBoundingClientRect().top
+      const offsetPosition =
+        elementPosition + window.scrollY - STICKY_HEADER_HEIGHT
+      window.scrollTo({
+        top: offsetPosition,
+        behavior: 'smooth',
+      })
+    },
+    [anchorIdPrefix]
+  )
 
   useEffect(() => {
     const anchors = anchorRefs.current
@@ -69,7 +86,9 @@ function TableOfContentSideMenu({ indexes }: TableOfContentSideMenuProps) {
 
     const elementToKeyMap = new Map<HTMLElement, string>()
     anchors.forEach((anchor) => {
-      const key = anchor.id.replace(`${TABLE_OF_CONTENT_ANCHOR_PREFIX}-`, '')
+      const key = anchorIdPrefix
+        ? anchor.id.replace(anchorIdPrefix, '')
+        : anchor.id
       elementToKeyMap.set(anchor, key)
     })
 
@@ -84,7 +103,9 @@ function TableOfContentSideMenu({ indexes }: TableOfContentSideMenuProps) {
 
       if (visibleEntries.length === 0) {
         if (window.scrollY < STICKY_HEADER_HEIGHT) {
-          setCurrentActiveIndex(makeAnchorKey(TABLE_OF_CONTENT_BACK_TO_TOP_KEY))
+          setCurrentActiveIndex(
+            makeAnchorKey(TABLE_OF_CONTENT_BACK_TO_TOP_KEY, anchorIdPrefix)
+          )
         }
         return
       }
@@ -105,7 +126,7 @@ function TableOfContentSideMenu({ indexes }: TableOfContentSideMenuProps) {
       const element = nearestEntry.target as HTMLElement
       const key = elementToKeyMap.get(element)
       if (!key) return
-      setCurrentActiveIndex(makeAnchorKey(key))
+      setCurrentActiveIndex(makeAnchorKey(key, anchorIdPrefix))
     }
 
     const observer = new IntersectionObserver(observerCallback, observerOptions)
@@ -116,7 +137,9 @@ function TableOfContentSideMenu({ indexes }: TableOfContentSideMenuProps) {
 
     const handleScroll = () => {
       if (window.scrollY < STICKY_HEADER_HEIGHT) {
-        setCurrentActiveIndex(makeAnchorKey(TABLE_OF_CONTENT_BACK_TO_TOP_KEY))
+        setCurrentActiveIndex(
+          makeAnchorKey(TABLE_OF_CONTENT_BACK_TO_TOP_KEY, anchorIdPrefix)
+        )
       }
     }
 
@@ -126,7 +149,7 @@ function TableOfContentSideMenu({ indexes }: TableOfContentSideMenuProps) {
       observer.disconnect()
       window.removeEventListener('scroll', handleScroll)
     }
-  }, [indexes])
+  }, [indexes, anchorIdPrefix])
 
   const handleClickOutside = useCallback(() => {
     if (isExpanded) {
@@ -138,7 +161,7 @@ function TableOfContentSideMenu({ indexes }: TableOfContentSideMenuProps) {
 
   const isDesktop = useMediaQuery('(min-width: 1024px)')
   const scrollLevel = useScrollLevel({
-    scrollDownDistance: ARTICLE_WIDGET_SCROLL_DOWN_DISTANCE,
+    scrollDownDistance,
   })
   const isHidden =
     scrollLevel === ScrollLevel.DOWN_HIDDEN && !isDesktop && !isExpanded
@@ -151,7 +174,7 @@ function TableOfContentSideMenu({ indexes }: TableOfContentSideMenuProps) {
     <nav
       ref={menuContainerRef}
       className="fixed top-0 left-0 z-1000 print:hidden"
-      aria-label="文章目錄"
+      aria-label={ariaLabel}
     >
       <button
         type="button"
@@ -195,7 +218,8 @@ function TableOfContentSideMenu({ indexes }: TableOfContentSideMenuProps) {
                 key={key}
                 className={cn(
                   'h-[3px] w-4 rounded-sm bg-neutral-black/10',
-                  currentActiveIndex === makeAnchorKey(key) && 'bg-red-400'
+                  currentActiveIndex === makeAnchorKey(key, anchorIdPrefix) &&
+                    'bg-red-400'
                 )}
               ></div>
             )
@@ -228,16 +252,15 @@ function TableOfContentSideMenu({ indexes }: TableOfContentSideMenuProps) {
           }}
           aria-current={
             currentActiveIndex ===
-            makeAnchorKey(TABLE_OF_CONTENT_BACK_TO_TOP_KEY)
+            makeAnchorKey(TABLE_OF_CONTENT_BACK_TO_TOP_KEY, anchorIdPrefix)
               ? 'location'
               : undefined
           }
           className={cn(
             'w-full cursor-pointer rounded bg-transparent px-1 py-[1px] text-start prose-p2 break-words text-neutral-600 transition-colors duration-300 ease-in-out hover:bg-neutral-black/5 hover:text-neutral-900 active:bg-neutral-black/10',
-            // Desktop/HD: match Figma design
             'desktop:rounded desktop:px-1 desktop:py-[1px]',
             currentActiveIndex ===
-              makeAnchorKey(TABLE_OF_CONTENT_BACK_TO_TOP_KEY) &&
+              makeAnchorKey(TABLE_OF_CONTENT_BACK_TO_TOP_KEY, anchorIdPrefix) &&
               'font-bold text-red-400 hover:text-red-400'
           )}
         >
@@ -253,13 +276,14 @@ function TableOfContentSideMenu({ indexes }: TableOfContentSideMenuProps) {
               handleClickAnchorIndex(key)
             }}
             aria-current={
-              currentActiveIndex === makeAnchorKey(key) ? 'location' : undefined
+              currentActiveIndex === makeAnchorKey(key, anchorIdPrefix)
+                ? 'location'
+                : undefined
             }
             className={cn(
               'w-full cursor-pointer rounded bg-transparent px-1 py-[1px] text-start prose-p2 break-words text-neutral-600 transition-colors duration-300 ease-in-out hover:bg-neutral-black/5 hover:text-neutral-900 active:bg-neutral-black/10',
-              // Desktop/HD: match Figma design
               'desktop:rounded desktop:px-1 desktop:py-[1px]',
-              currentActiveIndex === makeAnchorKey(key) &&
+              currentActiveIndex === makeAnchorKey(key, anchorIdPrefix) &&
                 'font-bold text-red-400 hover:text-red-400'
             )}
           >

--- a/packages/frontend/src/globals.css
+++ b/packages/frontend/src/globals.css
@@ -268,6 +268,11 @@
     overflow: hidden;
   }
 
+  /* Article table-of-content anchors: offset scroll position for sticky header on hash navigation */
+  [id^='toc-anchor-'] {
+    scroll-margin-top: var(--content-margin-top, 64px);
+  }
+
   a {
     color: inherit;
     text-decoration: none;

--- a/packages/frontend/src/globals.css
+++ b/packages/frontend/src/globals.css
@@ -538,3 +538,7 @@
   background-color: var(--color-red-400);
   color: var(--color-neutral-white);
 }
+
+@utility scroll-margin-anchor {
+  scroll-margin-top: 64px;
+}

--- a/packages/frontend/src/modules/about/components/awards/index.tsx
+++ b/packages/frontend/src/modules/about/components/awards/index.tsx
@@ -26,7 +26,7 @@ function Awards() {
   return (
     <section
       id="awards"
-      style={{ scrollMarginTop: '62px' }}
+      style={{ scrollMarginTop: '64px' }}
       className="mx-auto flex w-full max-w-300 flex-col px-6 pt-10 pb-14 tablet:px-17 tablet:pt-12 tablet:pb-16 desktop:px-24 desktop:pt-18 desktop:pb-24 hd:px-26 hd:pt-24 hd:pb-30"
     >
       <h2 className="mb-6 flex items-center gap-2 self-start prose-h2-small !font-swei text-neutral-900 tablet:mx-auto tablet:mb-8 desktop:mb-10 desktop:prose-h2-large">

--- a/packages/frontend/src/modules/about/components/awards/index.tsx
+++ b/packages/frontend/src/modules/about/components/awards/index.tsx
@@ -26,8 +26,7 @@ function Awards() {
   return (
     <section
       id="awards"
-      style={{ scrollMarginTop: '64px' }}
-      className="mx-auto flex w-full max-w-300 flex-col px-6 pt-10 pb-14 tablet:px-17 tablet:pt-12 tablet:pb-16 desktop:px-24 desktop:pt-18 desktop:pb-24 hd:px-26 hd:pt-24 hd:pb-30"
+      className="mx-auto flex w-full max-w-300 scroll-margin-anchor flex-col px-6 pt-10 pb-14 tablet:px-17 tablet:pt-12 tablet:pb-16 desktop:px-24 desktop:pt-18 desktop:pb-24 hd:px-26 hd:pt-24 hd:pb-30"
     >
       <h2 className="mb-6 flex items-center gap-2 self-start prose-h2-small !font-swei text-neutral-900 tablet:mx-auto tablet:mb-8 desktop:mb-10 desktop:prose-h2-large">
         <Image

--- a/packages/frontend/src/modules/about/components/cross-border-collaboration/index.tsx
+++ b/packages/frontend/src/modules/about/components/cross-border-collaboration/index.tsx
@@ -8,8 +8,7 @@ function CrossBorderCollaboration() {
   return (
     <section
       id="partner"
-      style={{ scrollMarginTop: '64px' }}
-      className="mx-auto flex w-full max-w-300 flex-col items-center justify-center px-6 pt-10 pb-20 tablet:px-8 tablet:pt-12 tablet:pb-24 desktop:px-12 desktop:pt-18 desktop:pb-32 hd:px-30 hd:pt-24 hd:pb-36"
+      className="mx-auto flex w-full max-w-300 scroll-margin-anchor flex-col items-center justify-center px-6 pt-10 pb-20 tablet:px-8 tablet:pt-12 tablet:pb-24 desktop:px-12 desktop:pt-18 desktop:pb-32 hd:px-30 hd:pt-24 hd:pb-36"
     >
       <h2 className="mb-6 flex items-center gap-2 self-start prose-h2-small !font-swei text-neutral-900 desktop:mb-10 desktop:prose-h2-large">
         <Image

--- a/packages/frontend/src/modules/about/components/cross-border-collaboration/index.tsx
+++ b/packages/frontend/src/modules/about/components/cross-border-collaboration/index.tsx
@@ -8,7 +8,7 @@ function CrossBorderCollaboration() {
   return (
     <section
       id="partner"
-      style={{ scrollMarginTop: '62px' }}
+      style={{ scrollMarginTop: '64px' }}
       className="mx-auto flex w-full max-w-300 flex-col items-center justify-center px-6 pt-10 pb-20 tablet:px-8 tablet:pt-12 tablet:pb-24 desktop:px-12 desktop:pt-18 desktop:pb-32 hd:px-30 hd:pt-24 hd:pb-36"
     >
       <h2 className="mb-6 flex items-center gap-2 self-start prose-h2-small !font-swei text-neutral-900 desktop:mb-10 desktop:prose-h2-large">

--- a/packages/frontend/src/modules/about/components/cross-border-collaboration/index.tsx
+++ b/packages/frontend/src/modules/about/components/cross-border-collaboration/index.tsx
@@ -6,7 +6,11 @@ import { COLLABORATIONS } from './constants'
 
 function CrossBorderCollaboration() {
   return (
-    <section className="mx-auto flex w-full max-w-300 flex-col items-center justify-center px-6 pt-10 pb-20 tablet:px-8 tablet:pt-12 tablet:pb-24 desktop:px-12 desktop:pt-18 desktop:pb-32 hd:px-30 hd:pt-24 hd:pb-36">
+    <section
+      id="partner"
+      style={{ scrollMarginTop: '62px' }}
+      className="mx-auto flex w-full max-w-300 flex-col items-center justify-center px-6 pt-10 pb-20 tablet:px-8 tablet:pt-12 tablet:pb-24 desktop:px-12 desktop:pt-18 desktop:pb-32 hd:px-30 hd:pt-24 hd:pb-36"
+    >
       <h2 className="mb-6 flex items-center gap-2 self-start prose-h2-small !font-swei text-neutral-900 desktop:mb-10 desktop:prose-h2-large">
         <Image
           src="/assets/images/about/cross-border-collaboration/icon.svg"

--- a/packages/frontend/src/modules/about/components/discover-news/index.tsx
+++ b/packages/frontend/src/modules/about/components/discover-news/index.tsx
@@ -24,7 +24,7 @@ function DiscoverNews() {
   return (
     <div
       id="explore"
-      style={{ scrollMarginTop: '62px' }}
+      style={{ scrollMarginTop: '64px' }}
       className="flex w-full flex-col items-center justify-center bg-yellow-100 px-6 pt-10 pb-14 tablet:px-8 tablet:pt-12 tablet:pb-16 desktop:px-12 desktop:pt-18 desktop:pb-24 hd:px-30 hd:pt-24 hd:pb-30"
     >
       <h2 className="mb-4 flex items-center gap-1 prose-h2-small !font-swei text-neutral-900 desktop:mb-6 desktop:prose-h2-large">

--- a/packages/frontend/src/modules/about/components/discover-news/index.tsx
+++ b/packages/frontend/src/modules/about/components/discover-news/index.tsx
@@ -24,8 +24,7 @@ function DiscoverNews() {
   return (
     <div
       id="explore"
-      style={{ scrollMarginTop: '64px' }}
-      className="flex w-full flex-col items-center justify-center bg-yellow-100 px-6 pt-10 pb-14 tablet:px-8 tablet:pt-12 tablet:pb-16 desktop:px-12 desktop:pt-18 desktop:pb-24 hd:px-30 hd:pt-24 hd:pb-30"
+      className="flex w-full scroll-margin-anchor flex-col items-center justify-center bg-yellow-100 px-6 pt-10 pb-14 tablet:px-8 tablet:pt-12 tablet:pb-16 desktop:px-12 desktop:pt-18 desktop:pb-24 hd:px-30 hd:pt-24 hd:pb-30"
     >
       <h2 className="mb-4 flex items-center gap-1 prose-h2-small !font-swei text-neutral-900 desktop:mb-6 desktop:prose-h2-large">
         <Image

--- a/packages/frontend/src/modules/about/components/discover-news/index.tsx
+++ b/packages/frontend/src/modules/about/components/discover-news/index.tsx
@@ -22,7 +22,11 @@ function DiscoverNews() {
   }, [selectedSegment])
 
   return (
-    <div className="flex w-full flex-col items-center justify-center bg-yellow-100 px-6 pt-10 pb-14 tablet:px-8 tablet:pt-12 tablet:pb-16 desktop:px-12 desktop:pt-18 desktop:pb-24 hd:px-30 hd:pt-24 hd:pb-30">
+    <div
+      id="explore"
+      style={{ scrollMarginTop: '62px' }}
+      className="flex w-full flex-col items-center justify-center bg-yellow-100 px-6 pt-10 pb-14 tablet:px-8 tablet:pt-12 tablet:pb-16 desktop:px-12 desktop:pt-18 desktop:pb-24 hd:px-30 hd:pt-24 hd:pb-30"
+    >
       <h2 className="mb-4 flex items-center gap-1 prose-h2-small !font-swei text-neutral-900 desktop:mb-6 desktop:prose-h2-large">
         <Image
           src="/assets/images/about/discover-news/icon.svg"

--- a/packages/frontend/src/modules/about/components/intro/index.tsx
+++ b/packages/frontend/src/modules/about/components/intro/index.tsx
@@ -6,8 +6,7 @@ function Intro() {
   return (
     <section
       id="mission"
-      style={{ scrollMarginTop: '64px' }}
-      className="relative w-full max-w-300 bg-neutral-white"
+      className="relative w-full max-w-300 scroll-margin-anchor bg-neutral-white"
     >
       <div className="relative z-1 flex w-full flex-col gap-6 px-6 pt-6 pb-[45.5px] tablet:flex-row tablet:items-start tablet:justify-center tablet:px-8 tablet:pt-8 tablet:pb-[85px] desktop:items-center desktop:gap-8 desktop:px-12 desktop:pt-12 desktop:pb-[90px] hd:translate-x-[55px] hd:gap-28 hd:pb-25">
         <div className="flex w-full flex-1 flex-col gap-6 tablet:gap-8">

--- a/packages/frontend/src/modules/about/components/intro/index.tsx
+++ b/packages/frontend/src/modules/about/components/intro/index.tsx
@@ -6,7 +6,7 @@ function Intro() {
   return (
     <section
       id="mission"
-      style={{ scrollMarginTop: '62px' }}
+      style={{ scrollMarginTop: '64px' }}
       className="relative w-full max-w-300 bg-neutral-white"
     >
       <div className="relative z-1 flex w-full flex-col gap-6 px-6 pt-6 pb-[45.5px] tablet:flex-row tablet:items-start tablet:justify-center tablet:px-8 tablet:pt-8 tablet:pb-[85px] desktop:items-center desktop:gap-8 desktop:px-12 desktop:pt-12 desktop:pb-[90px] hd:translate-x-[55px] hd:gap-28 hd:pb-25">

--- a/packages/frontend/src/modules/about/components/intro/index.tsx
+++ b/packages/frontend/src/modules/about/components/intro/index.tsx
@@ -4,7 +4,11 @@ import WaveIllustrations from './wave-illustrations'
 
 function Intro() {
   return (
-    <section className="relative w-full max-w-300 bg-neutral-white">
+    <section
+      id="mission"
+      style={{ scrollMarginTop: '62px' }}
+      className="relative w-full max-w-300 bg-neutral-white"
+    >
       <div className="relative z-1 flex w-full flex-col gap-6 px-6 pt-6 pb-[45.5px] tablet:flex-row tablet:items-start tablet:justify-center tablet:px-8 tablet:pt-8 tablet:pb-[85px] desktop:items-center desktop:gap-8 desktop:px-12 desktop:pt-12 desktop:pb-[90px] hd:translate-x-[55px] hd:gap-28 hd:pb-25">
         <div className="flex w-full flex-1 flex-col gap-6 tablet:gap-8">
           <h1 className="prose-h2-small !font-swei text-neutral-900 desktop:prose-h2-large hd:prose-h1-large">

--- a/packages/frontend/src/modules/about/components/join-us/index.tsx
+++ b/packages/frontend/src/modules/about/components/join-us/index.tsx
@@ -9,8 +9,7 @@ function JoinUs() {
   return (
     <section
       id="join"
-      style={{ scrollMarginTop: '64px' }}
-      className="mx-auto flex w-full max-w-300 flex-col items-center justify-center px-6 pt-41 pb-14 tablet:px-8 tablet:pt-49.5 tablet:pb-16 desktop:px-12 desktop:pt-76 desktop:pb-24 hd:px-30 hd:pt-82 hd:pb-30"
+      className="mx-auto flex w-full max-w-300 scroll-margin-anchor flex-col items-center justify-center px-6 pt-41 pb-14 tablet:px-8 tablet:pt-49.5 tablet:pb-16 desktop:px-12 desktop:pt-76 desktop:pb-24 hd:px-30 hd:pt-82 hd:pb-30"
     >
       <div className="relative w-full grid-cols-1 gap-6 rounded-[40px] bg-neutral-100 p-6 pt-20 tablet:p-8 tablet:pt-20 desktop:p-14 desktop:pt-20">
         <Image

--- a/packages/frontend/src/modules/about/components/join-us/index.tsx
+++ b/packages/frontend/src/modules/about/components/join-us/index.tsx
@@ -7,7 +7,11 @@ import JoinUsCard from './join-us-card'
 
 function JoinUs() {
   return (
-    <section className="mx-auto flex w-full max-w-300 flex-col items-center justify-center px-6 pt-41 pb-14 tablet:px-8 tablet:pt-49.5 tablet:pb-16 desktop:px-12 desktop:pt-76 desktop:pb-24 hd:px-30 hd:pt-82 hd:pb-30">
+    <section
+      id="join"
+      style={{ scrollMarginTop: '62px' }}
+      className="mx-auto flex w-full max-w-300 flex-col items-center justify-center px-6 pt-41 pb-14 tablet:px-8 tablet:pt-49.5 tablet:pb-16 desktop:px-12 desktop:pt-76 desktop:pb-24 hd:px-30 hd:pt-82 hd:pb-30"
+    >
       <div className="relative w-full grid-cols-1 gap-6 rounded-[40px] bg-neutral-100 p-6 pt-20 tablet:p-8 tablet:pt-20 desktop:p-14 desktop:pt-20">
         <Image
           src="/assets/images/about/join-us/illustration.svg"

--- a/packages/frontend/src/modules/about/components/join-us/index.tsx
+++ b/packages/frontend/src/modules/about/components/join-us/index.tsx
@@ -9,7 +9,7 @@ function JoinUs() {
   return (
     <section
       id="join"
-      style={{ scrollMarginTop: '62px' }}
+      style={{ scrollMarginTop: '64px' }}
       className="mx-auto flex w-full max-w-300 flex-col items-center justify-center px-6 pt-41 pb-14 tablet:px-8 tablet:pt-49.5 tablet:pb-16 desktop:px-12 desktop:pt-76 desktop:pb-24 hd:px-30 hd:pt-82 hd:pb-30"
     >
       <div className="relative w-full grid-cols-1 gap-6 rounded-[40px] bg-neutral-100 p-6 pt-20 tablet:p-8 tablet:pt-20 desktop:p-14 desktop:pt-20">

--- a/packages/frontend/src/modules/about/components/join-us/join-us-card.tsx
+++ b/packages/frontend/src/modules/about/components/join-us/join-us-card.tsx
@@ -51,7 +51,7 @@ function JoinUsCard({ card }: JoinUsCardProps) {
     <div
       id={card.anchorId}
       className="flex h-full flex-col overflow-hidden rounded-3xl bg-neutral-white shadow-custom"
-      style={card.anchorId ? { scrollMarginTop: '80px' } : undefined}
+      style={card.anchorId ? { scrollMarginTop: '64px' } : undefined}
     >
       <div className="flex flex-1 flex-col gap-3 p-6 desktop:gap-4 desktop:p-8">
         <h3 className="flex items-center gap-3 prose-p1-bold text-neutral-900 desktop:prose-h6-large">

--- a/packages/frontend/src/modules/about/components/join-us/join-us-card.tsx
+++ b/packages/frontend/src/modules/about/components/join-us/join-us-card.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Button } from '@kids-reporter/routing-ui'
+import { Button, cn } from '@kids-reporter/routing-ui'
 import Image from 'next/image'
 
 import { useFeatureIntroDialogContext } from '@/services/feature-intro/context'
@@ -50,8 +50,10 @@ function JoinUsCard({ card }: JoinUsCardProps) {
   return (
     <div
       id={card.anchorId}
-      className="flex h-full flex-col overflow-hidden rounded-3xl bg-neutral-white shadow-custom"
-      style={card.anchorId ? { scrollMarginTop: '64px' } : undefined}
+      className={cn(
+        'flex h-full flex-col overflow-hidden rounded-3xl bg-neutral-white shadow-custom',
+        card.anchorId && 'scroll-margin-anchor'
+      )}
     >
       <div className="flex flex-1 flex-col gap-3 p-6 desktop:gap-4 desktop:p-8">
         <h3 className="flex items-center gap-3 prose-p1-bold text-neutral-900 desktop:prose-h6-large">

--- a/packages/frontend/src/modules/about/components/join-us/join-us-card.tsx
+++ b/packages/frontend/src/modules/about/components/join-us/join-us-card.tsx
@@ -51,7 +51,7 @@ function JoinUsCard({ card }: JoinUsCardProps) {
     <div
       id={card.anchorId}
       className="flex h-full flex-col overflow-hidden rounded-3xl bg-neutral-white shadow-custom"
-      style={card.anchorId ? { scrollMarginTop: '62px' } : undefined}
+      style={card.anchorId ? { scrollMarginTop: '80px' } : undefined}
     >
       <div className="flex flex-1 flex-col gap-3 p-6 desktop:gap-4 desktop:p-8">
         <h3 className="flex items-center gap-3 prose-p1-bold text-neutral-900 desktop:prose-h6-large">

--- a/packages/frontend/src/modules/about/components/reader-recommendations/recommendations-section.tsx
+++ b/packages/frontend/src/modules/about/components/reader-recommendations/recommendations-section.tsx
@@ -17,7 +17,11 @@ import VideoPlayer from './video-player'
 function RecommendationsSection() {
   const swiperRef = useRef<SwiperCore>()
   return (
-    <section className="w-full bg-yellow-200">
+    <section
+      id="voices"
+      style={{ scrollMarginTop: '62px' }}
+      className="w-full bg-yellow-200"
+    >
       <div className="mx-auto flex w-full max-w-300 flex-col items-center justify-center pt-10 pb-14 tablet:pt-12 tablet:pb-16 desktop:px-12 desktop:pt-18 desktop:pb-24 hd:px-30 hd:pt-24 hd:pb-30">
         <h2 className="mb-6 flex items-center gap-2 px-6 prose-h2-small !font-swei text-neutral-900 tablet:mb-8 tablet:px-8 desktop:mb-10 desktop:px-0 desktop:prose-h2-large">
           <Image

--- a/packages/frontend/src/modules/about/components/reader-recommendations/recommendations-section.tsx
+++ b/packages/frontend/src/modules/about/components/reader-recommendations/recommendations-section.tsx
@@ -17,11 +17,7 @@ import VideoPlayer from './video-player'
 function RecommendationsSection() {
   const swiperRef = useRef<SwiperCore>()
   return (
-    <section
-      id="voices"
-      style={{ scrollMarginTop: '64px' }}
-      className="w-full bg-yellow-200"
-    >
+    <section id="voices" className="w-full scroll-margin-anchor bg-yellow-200">
       <div className="mx-auto flex w-full max-w-300 flex-col items-center justify-center pt-10 pb-14 tablet:pt-12 tablet:pb-16 desktop:px-12 desktop:pt-18 desktop:pb-24 hd:px-30 hd:pt-24 hd:pb-30">
         <h2 className="mb-6 flex items-center gap-2 px-6 prose-h2-small !font-swei text-neutral-900 tablet:mb-8 tablet:px-8 desktop:mb-10 desktop:px-0 desktop:prose-h2-large">
           <Image

--- a/packages/frontend/src/modules/about/components/reader-recommendations/recommendations-section.tsx
+++ b/packages/frontend/src/modules/about/components/reader-recommendations/recommendations-section.tsx
@@ -19,7 +19,7 @@ function RecommendationsSection() {
   return (
     <section
       id="voices"
-      style={{ scrollMarginTop: '62px' }}
+      style={{ scrollMarginTop: '64px' }}
       className="w-full bg-yellow-200"
     >
       <div className="mx-auto flex w-full max-w-300 flex-col items-center justify-center pt-10 pb-14 tablet:pt-12 tablet:pb-16 desktop:px-12 desktop:pt-18 desktop:pb-24 hd:px-30 hd:pt-24 hd:pb-30">

--- a/packages/frontend/src/modules/about/components/related-products/index.tsx
+++ b/packages/frontend/src/modules/about/components/related-products/index.tsx
@@ -8,8 +8,7 @@ function RelatedProducts() {
   return (
     <section
       id="products"
-      style={{ scrollMarginTop: '64px' }}
-      className="mx-auto flex w-full max-w-300 flex-col items-center justify-center px-6 pt-10 pb-20 tablet:px-8 tablet:pt-12 tablet:pb-24 desktop:px-12 desktop:pt-18 desktop:pb-32 hd:px-30 hd:pt-24 hd:pb-36"
+      className="mx-auto flex w-full max-w-300 scroll-margin-anchor flex-col items-center justify-center px-6 pt-10 pb-20 tablet:px-8 tablet:pt-12 tablet:pb-24 desktop:px-12 desktop:pt-18 desktop:pb-32 hd:px-30 hd:pt-24 hd:pb-36"
     >
       <h2 className="mb-6 flex items-center gap-2 self-start prose-h2-small !font-swei text-neutral-900 desktop:mb-10 desktop:prose-h2-large">
         <Image

--- a/packages/frontend/src/modules/about/components/related-products/index.tsx
+++ b/packages/frontend/src/modules/about/components/related-products/index.tsx
@@ -6,7 +6,11 @@ import { PRODUCTS } from './constants'
 
 function RelatedProducts() {
   return (
-    <section className="mx-auto flex w-full max-w-300 flex-col items-center justify-center px-6 pt-10 pb-20 tablet:px-8 tablet:pt-12 tablet:pb-24 desktop:px-12 desktop:pt-18 desktop:pb-32 hd:px-30 hd:pt-24 hd:pb-36">
+    <section
+      id="products"
+      style={{ scrollMarginTop: '62px' }}
+      className="mx-auto flex w-full max-w-300 flex-col items-center justify-center px-6 pt-10 pb-20 tablet:px-8 tablet:pt-12 tablet:pb-24 desktop:px-12 desktop:pt-18 desktop:pb-32 hd:px-30 hd:pt-24 hd:pb-36"
+    >
       <h2 className="mb-6 flex items-center gap-2 self-start prose-h2-small !font-swei text-neutral-900 desktop:mb-10 desktop:prose-h2-large">
         <Image
           src="/assets/images/about/related-products/icon.svg"

--- a/packages/frontend/src/modules/about/components/related-products/index.tsx
+++ b/packages/frontend/src/modules/about/components/related-products/index.tsx
@@ -8,7 +8,7 @@ function RelatedProducts() {
   return (
     <section
       id="products"
-      style={{ scrollMarginTop: '62px' }}
+      style={{ scrollMarginTop: '64px' }}
       className="mx-auto flex w-full max-w-300 flex-col items-center justify-center px-6 pt-10 pb-20 tablet:px-8 tablet:pt-12 tablet:pb-24 desktop:px-12 desktop:pt-18 desktop:pb-32 hd:px-30 hd:pt-24 hd:pb-36"
     >
       <h2 className="mb-6 flex items-center gap-2 self-start prose-h2-small !font-swei text-neutral-900 desktop:mb-10 desktop:prose-h2-large">

--- a/packages/frontend/src/modules/about/components/team-member-and-consultant/index.tsx
+++ b/packages/frontend/src/modules/about/components/team-member-and-consultant/index.tsx
@@ -21,8 +21,7 @@ function TeamMemberAndConsultant({
       <div className="mx-auto flex w-full max-w-full flex-col gap-10 tablet:w-max">
         <div
           id="team"
-          style={{ scrollMarginTop: '64px' }}
-          className="my-10 flex flex-col gap-6 tablet:my-24 desktop:my-32 desktop:gap-8 hd:my-36 hd:gap-10"
+          className="my-10 flex scroll-margin-anchor flex-col gap-6 tablet:my-24 desktop:my-32 desktop:gap-8 hd:my-36 hd:gap-10"
         >
           <div className="flex items-center gap-3 px-6 tablet:mx-auto tablet:px-8">
             <Image
@@ -51,8 +50,7 @@ function TeamMemberAndConsultant({
 
         <div
           id="advisors"
-          style={{ scrollMarginTop: '64px' }}
-          className="flex flex-col gap-6 desktop:gap-8 hd:gap-10"
+          className="flex scroll-margin-anchor flex-col gap-6 desktop:gap-8 hd:gap-10"
         >
           <div className="flex items-center gap-3 px-6 tablet:mx-auto tablet:px-8">
             <Image

--- a/packages/frontend/src/modules/about/components/team-member-and-consultant/index.tsx
+++ b/packages/frontend/src/modules/about/components/team-member-and-consultant/index.tsx
@@ -3,6 +3,7 @@
 import Image from 'next/image'
 
 import { Author } from '@/components/author-card'
+import { AuthorRole } from '@/constants'
 
 import MemberCard from './team-member-card'
 
@@ -39,7 +40,10 @@ function TeamMemberAndConsultant({
           <div className="flex scrollbar-thin min-w-0 snap-x snap-mandatory scroll-px-6 gap-6 overflow-x-auto px-6 pb-2 tablet:grid tablet:snap-none tablet:grid-cols-2 desktop:grid-cols-3 desktop:gap-8 hd:grid-cols-4">
             {teamMembers.map((member) => (
               <div key={member.id} className="w-[248px] shrink-0 snap-start">
-                <MemberCard member={member} isTeamMember />
+                <MemberCard
+                  member={member}
+                  isTeamMember={member.role !== AuthorRole.LITTLE_HELPER}
+                />
               </div>
             ))}
           </div>

--- a/packages/frontend/src/modules/about/components/team-member-and-consultant/index.tsx
+++ b/packages/frontend/src/modules/about/components/team-member-and-consultant/index.tsx
@@ -46,7 +46,7 @@ function TeamMemberAndConsultant({
         </div>
 
         <div
-          id="consultants"
+          id="advisors"
           style={{ scrollMarginTop: '62px' }}
           className="flex flex-col gap-6 desktop:gap-8 hd:gap-10"
         >

--- a/packages/frontend/src/modules/about/components/team-member-and-consultant/index.tsx
+++ b/packages/frontend/src/modules/about/components/team-member-and-consultant/index.tsx
@@ -20,7 +20,7 @@ function TeamMemberAndConsultant({
       <div className="mx-auto flex w-full max-w-full flex-col gap-10 tablet:w-max">
         <div
           id="team"
-          style={{ scrollMarginTop: '62px' }}
+          style={{ scrollMarginTop: '64px' }}
           className="my-10 flex flex-col gap-6 tablet:my-24 desktop:my-32 desktop:gap-8 hd:my-36 hd:gap-10"
         >
           <div className="flex items-center gap-3 px-6 tablet:mx-auto tablet:px-8">
@@ -47,7 +47,7 @@ function TeamMemberAndConsultant({
 
         <div
           id="advisors"
-          style={{ scrollMarginTop: '62px' }}
+          style={{ scrollMarginTop: '64px' }}
           className="flex flex-col gap-6 desktop:gap-8 hd:gap-10"
         >
           <div className="flex items-center gap-3 px-6 tablet:mx-auto tablet:px-8">

--- a/packages/frontend/src/modules/about/constants.ts
+++ b/packages/frontend/src/modules/about/constants.ts
@@ -1,5 +1,16 @@
 import { AuthorRole } from '@/constants'
 
+export const ABOUT_TOC_INDEXES: { key: string; label: string }[] = [
+  { key: 'explore', label: '內容特色' },
+  { key: 'products', label: '相關產品' },
+  { key: 'partner', label: '跨界合作' },
+  { key: 'voices', label: '讀者推薦' },
+  { key: 'join', label: '參與我們' },
+  { key: 'team', label: '團隊成員' },
+  { key: 'awards', label: '外界肯定' },
+  { key: 'support', label: '贊助我們' },
+]
+
 export const tellYouItems = [
   { image: '/assets/images/about_tell_pic1.svg', desc: '重要的議題' },
   { image: '/assets/images/about_tell_pic2.svg', desc: '多元的社會' },

--- a/packages/frontend/src/modules/about/index.tsx
+++ b/packages/frontend/src/modules/about/index.tsx
@@ -2,6 +2,7 @@
 
 import { Author } from '@/components/author-card'
 import SupportAction from '@/components/support-action'
+import { TableOfContentSideMenu } from '@/components/table-of-content'
 
 import Awards from './components/awards'
 import CrossBorderCollaboration from './components/cross-border-collaboration'
@@ -12,6 +13,7 @@ import ReaderRecommendations from './components/reader-recommendations'
 import RelatedProducts from './components/related-products'
 import SupportActionContent from './components/support-action-content'
 import TeamMemberAndConsultant from './components/team-member-and-consultant'
+import { ABOUT_TOC_INDEXES } from './constants'
 
 type AboutModuleProps = {
   teamMembers: Author[]
@@ -21,6 +23,11 @@ type AboutModuleProps = {
 function AboutModule({ teamMembers, consultants }: AboutModuleProps) {
   return (
     <main className="flex w-full flex-col items-center justify-center overflow-x-hidden">
+      <TableOfContentSideMenu
+        indexes={ABOUT_TOC_INDEXES}
+        anchorIdPrefix=""
+        ariaLabel="關於我們目錄"
+      />
       <Intro />
       <DiscoverNews />
       <div className="w-screen bg-yellow-100">

--- a/packages/frontend/src/modules/article/components/toolbar.tsx
+++ b/packages/frontend/src/modules/article/components/toolbar.tsx
@@ -3,6 +3,7 @@ import { cn, ScrollLevel, useScrollLevel } from '@kids-reporter/routing-ui'
 import Link from 'next/link'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
+import { DEFAULT_SCROLL_DOWN_DISTANCE } from '@/components/table-of-content'
 import { FontSizeLevel } from '@/constants'
 import useClickOutside from '@/hooks/use-click-outside'
 import {
@@ -15,7 +16,7 @@ import {
 import { useArticleContext } from '@/modules/article/context'
 import PostEssayQuestionsModal from '@/modules/idea-hub/post-essay-questions-modal'
 
-import { ARTICLE_WIDGET_SCROLL_DOWN_DISTANCE, SHARE_ICONS } from '../constants'
+import { SHARE_ICONS } from '../constants'
 
 type MobileToolbarProp = {
   topicURL?: string
@@ -25,7 +26,7 @@ type MobileToolbarProp = {
 function MobileToolbar({ topicURL, onCheckAnswerClick }: MobileToolbarProp) {
   const [isSharePanelOpen, setIsSharePanelOpen] = useState(false)
   const scrollLevel = useScrollLevel({
-    scrollDownDistance: ARTICLE_WIDGET_SCROLL_DOWN_DISTANCE,
+    scrollDownDistance: DEFAULT_SCROLL_DOWN_DISTANCE,
   })
   const { onFontSizeChange } = useArticleContext()
   const toolbarRef = useRef<HTMLDivElement>(null)

--- a/packages/frontend/src/modules/article/constants.tsx
+++ b/packages/frontend/src/modules/article/constants.tsx
@@ -7,7 +7,6 @@ import {
   ThreadsIcon,
 } from '@/icons/miscellaneous'
 
-export const ARTICLE_WIDGET_SCROLL_DOWN_DISTANCE = 220
 export const SHARE_ICONS = [
   {
     icon: <FaceBookIcon />,

--- a/packages/frontend/src/modules/article/constants.tsx
+++ b/packages/frontend/src/modules/article/constants.tsx
@@ -7,10 +7,7 @@ import {
   ThreadsIcon,
 } from '@/icons/miscellaneous'
 
-export const TABLE_OF_CONTENT_ANCHOR_PREFIX = 'toc-anchor'
-export const TABLE_OF_CONTENT_INDEX_PREFIX = 'toc-index'
-export const TABLE_OF_CONTENT_BACK_TO_TOP_KEY = 'back-to-top'
-
+export const ARTICLE_WIDGET_SCROLL_DOWN_DISTANCE = 220
 export const SHARE_ICONS = [
   {
     icon: <FaceBookIcon />,
@@ -60,7 +57,6 @@ export const SHARE_ICONS = [
   },
 ]
 
-export const ARTICLE_WIDGET_SCROLL_DOWN_DISTANCE = 220
 export const ARTICLE_FONT_SIZE_CLASSNAMES = [
   '[&_h2]:prose-h2-small desktop:[&_h2]:prose-h2-large',
   '[&_h3]:prose-h3-small desktop:[&_h3]:prose-h3-large',

--- a/packages/frontend/src/modules/article/index.tsx
+++ b/packages/frontend/src/modules/article/index.tsx
@@ -10,6 +10,7 @@ import {
 import { useRouter } from 'next/navigation'
 import { useCallback, useMemo, useState } from 'react'
 
+import { TableOfContentSideMenu } from '@/components/table-of-content'
 import { FontSizeLevel } from '@/constants'
 import { BAODAOZAI_DEFAULT_ESSAY_QUESTION_COUNT } from '@/constants/baodaozai-question-count'
 import { SeparateIcon } from '@/icons'
@@ -25,7 +26,6 @@ import {
 } from '@/services/call-baodaozai'
 import getLoginUrl from '@/utils/get-login-url'
 
-import { TableOfContentSideMenu } from '@/components/table-of-content'
 import SupportAction from '../../components/support-action'
 import ArticleBaodaozaiEventTrigger from './components/article-baodaozai-event-trigger'
 import ArticleSummary from './components/article-summary'
@@ -39,10 +39,10 @@ import StartReadingBaodaozaiEventTrigger from './components/start-reading-baodao
 import SupportActionContent from './components/support-action-content'
 import TitleHero from './components/title-hero'
 import Toolbar from './components/toolbar'
+import { ARTICLE_WIDGET_SCROLL_DOWN_DISTANCE } from './constants'
 import { ArticleContext } from './context'
 import useBatchSubmitAnswers from './hooks/use-batch-submit-answers'
 import { Keyword } from './types'
-import { ARTICLE_WIDGET_SCROLL_DOWN_DISTANCE } from './constants'
 import parsePostToContent from './utils/parse-post-to-content'
 import parseTocIndexesFromEntityMap from './utils/parse-toc-indexes-from-entity-map'
 

--- a/packages/frontend/src/modules/article/index.tsx
+++ b/packages/frontend/src/modules/article/index.tsx
@@ -39,7 +39,6 @@ import StartReadingBaodaozaiEventTrigger from './components/start-reading-baodao
 import SupportActionContent from './components/support-action-content'
 import TitleHero from './components/title-hero'
 import Toolbar from './components/toolbar'
-import { ARTICLE_WIDGET_SCROLL_DOWN_DISTANCE } from './constants'
 import { ArticleContext } from './context'
 import useBatchSubmitAnswers from './hooks/use-batch-submit-answers'
 import { Keyword } from './types'
@@ -224,12 +223,7 @@ const ArticleModule = ({
     <>
       <BaodaozaiVisibilitySetter show={showBaodaozai} />
       <HeaderPostTitleSetter postTitle={post?.title} />
-      {tocIndexes.length > 0 && (
-        <TableOfContentSideMenu
-          indexes={tocIndexes}
-          scrollDownDistance={ARTICLE_WIDGET_SCROLL_DOWN_DISTANCE}
-        />
-      )}
+      {tocIndexes.length > 0 && <TableOfContentSideMenu indexes={tocIndexes} />}
       <div className="relative w-screen">
         <ArticleContext.Provider
           value={{

--- a/packages/frontend/src/modules/article/index.tsx
+++ b/packages/frontend/src/modules/article/index.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/services/call-baodaozai'
 import getLoginUrl from '@/utils/get-login-url'
 
+import { TableOfContentSideMenu } from '@/components/table-of-content'
 import SupportAction from '../../components/support-action'
 import ArticleBaodaozaiEventTrigger from './components/article-baodaozai-event-trigger'
 import ArticleSummary from './components/article-summary'
@@ -36,12 +37,12 @@ import PostRenderer from './components/post-renderer'
 import RelatedArticles from './components/related-articles'
 import StartReadingBaodaozaiEventTrigger from './components/start-reading-baodaozai-event-trigger'
 import SupportActionContent from './components/support-action-content'
-import TableOfContentSideMenu from './components/table-of-content-side-menu'
 import TitleHero from './components/title-hero'
 import Toolbar from './components/toolbar'
 import { ArticleContext } from './context'
 import useBatchSubmitAnswers from './hooks/use-batch-submit-answers'
 import { Keyword } from './types'
+import { ARTICLE_WIDGET_SCROLL_DOWN_DISTANCE } from './constants'
 import parsePostToContent from './utils/parse-post-to-content'
 import parseTocIndexesFromEntityMap from './utils/parse-toc-indexes-from-entity-map'
 
@@ -223,7 +224,12 @@ const ArticleModule = ({
     <>
       <BaodaozaiVisibilitySetter show={showBaodaozai} />
       <HeaderPostTitleSetter postTitle={post?.title} />
-      {tocIndexes.length > 0 && <TableOfContentSideMenu indexes={tocIndexes} />}
+      {tocIndexes.length > 0 && (
+        <TableOfContentSideMenu
+          indexes={tocIndexes}
+          scrollDownDistance={ARTICLE_WIDGET_SCROLL_DOWN_DISTANCE}
+        />
+      )}
       <div className="relative w-screen">
         <ArticleContext.Provider
           value={{

--- a/packages/routing-ui/package.json
+++ b/packages/routing-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kids-reporter/routing-ui",
   "license": "MIT",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Routing UI for Kids Reporter",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/routing-ui/src/constants/default-values.tsx
+++ b/packages/routing-ui/src/constants/default-values.tsx
@@ -4,6 +4,7 @@ import { MenuItem } from '../types'
 export const SUBSCRIBE_URL =
   'https://twreporter.us14.list-manage.com/subscribe?u=4da5a7d3b98dbc9fdad009e7e&id=2154ac40c3'
 export const DONATE_URL = 'https://support.twreporter.org/'
+export const JOIN_US_URL = 'https://kids.twreporter.org/article/about-join-us'
 export const PRIVACY_POLICY = 'https://www.twreporter.org/a/privacy-policy'
 export const SEARCH_PLACEHOLDER = '搜尋更多新聞、議題'
 

--- a/packages/routing-ui/src/constants/default-values.tsx
+++ b/packages/routing-ui/src/constants/default-values.tsx
@@ -93,12 +93,11 @@ export const ADDITIONAL_MENU_ITEMS: MenuItem[] = [
     href: '/about',
     subItems: [],
   },
-  // TODO: add back when about us page is ready
-  // {
-  //   label: '呼叫報導仔',
-  //   href: '/about#callkidsreporter',
-  //   subItems: [],
-  // },
+  {
+    label: '呼叫報導仔',
+    href: '/about#call',
+    subItems: [],
+  },
   {
     label: '小讀者觀點大集合',
     href: '/idea-hub',

--- a/packages/routing-ui/src/header/desktop-header.tsx
+++ b/packages/routing-ui/src/header/desktop-header.tsx
@@ -22,6 +22,7 @@ type DesktopHeaderProps = {
   isLoggedIn?: boolean
   loginUrl?: string
   readingSettingsUrl: string
+  joinUsUrl: string
 }
 
 export function DesktopHeader({
@@ -36,6 +37,7 @@ export function DesktopHeader({
   isLoggedIn,
   loginUrl,
   readingSettingsUrl,
+  joinUsUrl,
 }: DesktopHeaderProps) {
   return (
     <>
@@ -103,6 +105,7 @@ export function DesktopHeader({
                   searchPlaceholder={searchPlaceholder}
                   subscribeUrl={subscribeUrl}
                   readingSettingsUrl={readingSettingsUrl}
+                  joinUsUrl={joinUsUrl}
                 />
                 <a
                   href={isLoggedIn ? '/member' : (loginUrl ?? '/login')}

--- a/packages/routing-ui/src/header/index.tsx
+++ b/packages/routing-ui/src/header/index.tsx
@@ -2,6 +2,7 @@
 import {
   ADDITIONAL_MENU_ITEMS,
   DONATE_URL,
+  JOIN_US_URL,
   MENU_ITEMS,
   READING_SETTINGS_URL,
   SEARCH_PLACEHOLDER,
@@ -28,6 +29,7 @@ type HeaderProps = {
   subscribeUrl?: string
   donateUrl?: string
   readingSettingsUrl?: string
+  joinUsUrl?: string
 }
 
 function Header({
@@ -38,6 +40,7 @@ function Header({
   subscribeUrl = SUBSCRIBE_URL,
   donateUrl = DONATE_URL,
   readingSettingsUrl = READING_SETTINGS_URL,
+  joinUsUrl = JOIN_US_URL,
 }: HeaderProps) {
   const context = useHeaderContext()
   const postTitle = context?.postTitle
@@ -80,6 +83,7 @@ function Header({
         isLoggedIn={isLoggedIn}
         loginUrl={loginUrl}
         readingSettingsUrl={readingSettingsUrl}
+        joinUsUrl={joinUsUrl}
       />
       <MobileHeader
         onCloseMenu={onCloseMenu}

--- a/packages/routing-ui/src/header/shared-components.tsx
+++ b/packages/routing-ui/src/header/shared-components.tsx
@@ -197,12 +197,14 @@ export function ActionButtons({
   searchPlaceholder,
   subscribeUrl,
   readingSettingsUrl,
+  joinUsUrl,
 }: {
   hideCtaButtons?: boolean
   tags: string[]
   searchPlaceholder: string
   subscribeUrl: string
   readingSettingsUrl: string
+  joinUsUrl: string
 }) {
   const [isSearchOpen, setIsSearchOpen] = useState(false)
 
@@ -235,7 +237,7 @@ export function ActionButtons({
         {!hideCtaButtons && !isSearchOpen && (
           <div className="gap-4 flex items-center">
             <Button variant="secondary" size={32} asChild>
-              <a href="/about#post">投稿</a>
+              <a href={joinUsUrl}>加入我們</a>
             </Button>
             <Button variant="primary" size={32} asChild>
               <a href={subscribeUrl} target="_blank" rel="noopener noreferrer">

--- a/yarn.lock
+++ b/yarn.lock
@@ -4928,7 +4928,7 @@ __metadata:
     "@graphql-codegen/typescript-operations": "npm:^5.0.2"
     "@hookform/resolvers": "npm:^5.2.2"
     "@kids-reporter/draft-renderer": "npm:^1.0.13"
-    "@kids-reporter/routing-ui": "npm:0.1.9"
+    "@kids-reporter/routing-ui": "npm:0.1.10"
     "@next/bundle-analyzer": "npm:^14.2.33"
     "@next/eslint-plugin-next": "npm:^14.2.33"
     "@next/third-parties": "npm:^14.1.1"
@@ -4995,7 +4995,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/routing-ui@npm:0.1.9, @kids-reporter/routing-ui@workspace:packages/routing-ui":
+"@kids-reporter/routing-ui@npm:0.1.10, @kids-reporter/routing-ui@workspace:packages/routing-ui":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/routing-ui@workspace:packages/routing-ui"
   dependencies:


### PR DESCRIPTION
## Summary

Add table-of-contents (TOC) side menu and section anchors to the About page, reuse the article TOC as a shared configurable component, and re-enable the "呼叫報導仔" menu item linking to `/about#call`.

## Changes

- **Shared TableOfContent component**: Moved `TableOfContentSideMenu` from `modules/article/components/` to `components/table-of-content/` with a new `constants.ts`. Added props `anchorIdPrefix`, `scrollDownDistance`, `ariaLabel` so the same component works for article (prefix `toc-anchor-`) and about (raw section ids). Article module now imports the shared component and passes `scrollDownDistance`; TOC constants removed from `article/constants.tsx`.
- **About page TOC and anchors**: Added `ABOUT_TOC_INDEXES` and render `TableOfContentSideMenu` on About with `anchorIdPrefix=""`, `ariaLabel="關於我們目錄"`. Gave each section a stable `id` and `scrollMarginTop: 64px` (explore, products, partner, voices, join, team, advisors, awards, support). Renamed consultants anchor id to `advisors` and aligned `scrollMarginTop` to 64px.
- **Menu/Footer (routing-ui)**: Bumped `@kids-reporter/routing-ui` to 0.1.10; re-enabled "呼叫報導仔" in `ADDITIONAL_MENU_ITEMS` with `href: '/about#call'`.
- **Article anchor scroll**: Added `[id^='toc-anchor-'] { scroll-margin-top: var(--content-margin-top, 64px); }` in `globals.css` for hash navigation with sticky header.

## Additional Notes

About section ids align with TOC keys and menu links. `/about#call` targets the join-us block via `anchorId: 'call'` in join-us constants.

## Screenshot(s)

## Reference(s)

- [Menu/Footer](https://www.notion.so/twreporter/menu-footer-2f68dbdca93280e7b710c8f2699448e6?source=copy_link)
- [About Page (Anchor)](https://www.notion.so/twreporter/anchor-2f68dbe=copy_link)
- [Join Us URL](https://www.notion.so/twreporter/header-2f78dbdca93280cab85fcd24123c7ece?source=copy_link)