### PR TITLE
fix(cms): align Member avatar relation to one-to-one

### DIFF
--- a/packages/cms/lists/member-avatar.ts
+++ b/packages/cms/lists/member-avatar.ts
@@ -32,7 +32,7 @@ export default list({
       storage: 'images',
     }),
     member: relationship({
-      ref: 'Member',
+      ref: 'Member.avatar',
       many: false,
       label: 'Member',
     }),

--- a/packages/cms/lists/member.ts
+++ b/packages/cms/lists/member.ts
@@ -113,7 +113,7 @@ export default list<ListType<'Member'>>({
       },
     }),
     avatar: relationship({
-      ref: 'MemberAvatar',
+      ref: 'MemberAvatar.member',
       many: false,
       label: '大頭照',
     }),

--- a/packages/cms/migrations/20260202060049_update_member_and_member_avatar_1_to_1_relationship/migration.sql
+++ b/packages/cms/migrations/20260202060049_update_member_and_member_avatar_1_to_1_relationship/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `member` on the `MemberAvatar` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[avatar]` on the table `Member` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropForeignKey
+ALTER TABLE "MemberAvatar" DROP CONSTRAINT "MemberAvatar_member_fkey";
+
+-- DropIndex
+DROP INDEX "Member_avatar_idx";
+
+-- DropIndex
+DROP INDEX "MemberAvatar_member_idx";
+
+-- AlterTable
+ALTER TABLE "MemberAvatar" DROP COLUMN "member";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Member_avatar_key" ON "Member"("avatar");

--- a/packages/cms/schema.graphql
+++ b/packages/cms/schema.graphql
@@ -1702,6 +1702,7 @@ type Member {
 input MemberWhereUniqueInput {
   id: ID
   twreporter_user_id: String
+  avatar: MemberAvatarWhereUniqueInput
 }
 
 input MemberWhereInput {
@@ -1792,6 +1793,7 @@ type MemberAvatar {
 
 input MemberAvatarWhereUniqueInput {
   id: ID
+  member: MemberWhereUniqueInput
 }
 
 input MemberAvatarWhereInput {

--- a/packages/cms/schema.prisma
+++ b/packages/cms/schema.prisma
@@ -339,16 +339,14 @@ model Member {
   showBaodaozai                   Boolean               @default(true)
   essayQuestionCount              Int?                  @default(1)
   avatar                          MemberAvatar?         @relation("Member_avatar", fields: [avatarId], references: [id])
-  avatarId                        Int?                  @map("avatar")
+  avatarId                        Int?                  @unique @map("avatar")
   createdAt                       DateTime?             @default(now())
   updatedAt                       DateTime?             @updatedAt
-  from_MemberAvatar_member        MemberAvatar[]        @relation("MemberAvatar_member")
   from_PostChoiceAnswer_member    PostChoiceAnswer[]    @relation("PostChoiceAnswer_member")
   from_PostEssayAnswer_member     PostEssayAnswer[]     @relation("PostEssayAnswer_member")
   from_PostEssayAnswerLike_member PostEssayAnswerLike[] @relation("PostEssayAnswerLike_member")
 
   @@index([email])
-  @@index([avatarId])
 }
 
 model MemberAvatar {
@@ -359,13 +357,9 @@ model MemberAvatar {
   imageFile_width     Int?
   imageFile_height    Int?
   imageFile_extension String?
-  member              Member?   @relation("MemberAvatar_member", fields: [memberId], references: [id])
-  memberId            String?   @map("member")
+  member              Member?   @relation("Member_avatar")
   createdAt           DateTime? @default(now())
   updatedAt           DateTime? @updatedAt
-  from_Member_avatar  Member[]  @relation("Member_avatar")
-
-  @@index([memberId])
 }
 
 model PostChoiceAnswer {


### PR DESCRIPTION
### Changes
- Wire the Keystone relationships so Member.avatar and MemberAvatar.member are the same 1:1 relation.
- Enforce uniqueness on Member.avatarId and remove the redundant member relation fields/indexes.
- Add migrations/20260202060049_update_member_and_member_avatar_1_to_1_relationship/migration.sql

### Reason
- Ensure the CMS models reflect a strict 1:1 avatar relationship and avoid dual/ambiguous links.

### Notes
- Migration drops MemberAvatar.member and adds a unique index on Member.avatar; existing data in MemberAvatar.member will be lost unless backfilled.