### PR TITLE
refactor(cms+frontend): auto-connect member avatars and simplify profile updates

### DIFF
--- a/packages/cms/lists/member-avatar.ts
+++ b/packages/cms/lists/member-avatar.ts
@@ -9,7 +9,11 @@ import {
 
 import config from '../config'
 import type { ListType } from '../types/keystone-list-types'
-import { allowAllRoles } from './utils/access-control-list'
+import {
+  allowAllRoles,
+  allowRoles,
+  RoleEnum,
+} from './utils/access-control-list'
 import { memberOwnedOperationAccess } from './utils/member-owned-access'
 
 const ALLOWED_IMAGE_TYPES = [
@@ -73,7 +77,7 @@ export default list<ListType<'MemberAvatar'>>({
   access: {
     operation: {
       query: allowAllRoles(),
-      create: operationAccessControl,
+      create: allowRoles([RoleEnum.Member]),
       update: () => false,
       delete: operationAccessControl,
     },
@@ -106,6 +110,26 @@ export default list<ListType<'MemberAvatar'>>({
           }
         }
       }
+    },
+    resolveInput: async ({ resolvedData, context, operation }) => {
+      const sessionMemberId = context.session?.data?.memberId?.toString()
+
+      if (!sessionMemberId) {
+        throw new Error(
+          'You must be signed in as a member to upload a member avatar.'
+        )
+      }
+
+      if (operation === 'create') {
+        // connect the MemberAvatar record to the current member
+        resolvedData.member = {
+          connect: {
+            id: sessionMemberId,
+          },
+        }
+      }
+
+      return resolvedData
     },
   },
 })

--- a/packages/cms/lists/member-avatar.ts
+++ b/packages/cms/lists/member-avatar.ts
@@ -8,6 +8,7 @@ import {
 } from '@keystone-6/core/fields'
 
 import config from '../config'
+import type { ListType } from '../types/keystone-list-types'
 import { allowAllRoles } from './utils/access-control-list'
 import { memberOwnedOperationAccess } from './utils/member-owned-access'
 
@@ -22,7 +23,7 @@ const ALLOWED_IMAGE_TYPES = [
 const MAX_IMAGE_SIZE = 5 * 1024 * 1024 // 5MB
 
 const operationAccessControl = memberOwnedOperationAccess
-export default list({
+export default list<ListType<'MemberAvatar'>>({
   fields: {
     name: text({
       label: '標題',
@@ -83,11 +84,10 @@ export default list({
     },
   },
   hooks: {
-    validateInput: async ({ resolvedData, addValidationError, operation }) => {
+    validateInput: async ({ inputData, addValidationError, operation }) => {
       // Validate file upload on create and update
       if (operation === 'create' || operation === 'update') {
-        const imageFile = resolvedData.imageFile
-
+        const imageFile = inputData?.imageFile
         if (imageFile?.upload) {
           // Check file size
           const fileSize = imageFile.upload.size

--- a/packages/frontend/src/modules/membership/account/index.tsx
+++ b/packages/frontend/src/modules/membership/account/index.tsx
@@ -80,10 +80,9 @@ function Account() {
       try {
         const avatarUrlFieldState = getFieldState('avatarUrl')
         const isAvatarDirty = avatarUrlFieldState?.isDirty
-        let avatarId: string | undefined
         if (isAvatarDirty && avatarFileRef.current) {
           // upload new avatar first
-          const newAvatar = await uploadMemberAvatar({
+          await uploadMemberAvatar({
             file: avatarFileRef.current,
             fileName: data.name ?? '',
           })
@@ -93,15 +92,11 @@ function Account() {
           if (oldAvatarId) {
             await deleteMemberAvatar(oldAvatarId)
           }
-          avatarId = newAvatar?.id
           avatarFileRef.current = null
         }
 
         await updateMemberProfile({
           data: {
-            ...(isAvatarDirty
-              ? { avatar: { connect: { id: avatarId ?? '' } } }
-              : {}),
             name: data.name ?? '',
             nickname: data.nickname ?? '',
             contactEmail: data.contactEmail ?? '',


### PR DESCRIPTION
## Summary
Align avatar linking to be server-driven and clean up related client logic.

## Changes
- auto-connect new MemberAvatar to the signed-in member on create
- remove redundant avatar connect in updateMemberProfile
- fix MemberAvatar list typing to resolve TS errors

## Notes
- avatar linkage now relies on session member ID during create