### PR TITLE
refactor(api-gateway): print full error stacks

### DIFF
--- a/packages/api-gateway/src/routes/gql-rest-multipart.ts
+++ b/packages/api-gateway/src/routes/gql-rest-multipart.ts
@@ -81,10 +81,15 @@ export const createMultipartRewriteHandler = ({
         console.log(
           JSON.stringify({
             severity: 'ERROR',
-            message: errors.helpers.printAll(annotatedErr, {
-              withStack: true,
-              withPayload: true,
-            }),
+            message: errors.helpers.printAll(
+              annotatedErr,
+              {
+                withStack: true,
+                withPayload: true,
+              },
+              0,
+              0
+            ),
             ...res?.locals?.globalLogFields,
           })
         )

--- a/packages/api-gateway/src/routes/gql-rest.ts
+++ b/packages/api-gateway/src/routes/gql-rest.ts
@@ -198,10 +198,15 @@ export function createGqlRestRouter({
           console.log(
             JSON.stringify({
               severity: 'ERROR',
-              message: errors.helpers.printAll(annotatedErr, {
-                withStack: true,
-                withPayload: true,
-              }),
+              message: errors.helpers.printAll(
+                annotatedErr,
+                {
+                  withStack: true,
+                  withPayload: true,
+                },
+                0,
+                0
+              ),
               ...res?.locals?.globalLogFields,
             })
           )


### PR DESCRIPTION
- pass depth parameters to errors.helpers.printAll for full stack output
- improve log detail for error reporting