### PR TITLE
feat(frontend,cms,api-gateway): add /health endpoints for probes

### DIFF
--- a/packages/api-gateway/src/app.ts
+++ b/packages/api-gateway/src/app.ts
@@ -8,6 +8,7 @@ import consts from './constants.js'
 import middlewareCreator from './middlewares/index.js'
 import { createAuthRouter } from './routes/auth.js'
 import { createGqlRestRouter } from './routes/gql-rest.js'
+import { createHealthRouter } from './routes/health.js'
 
 // @twreporter/errors is a cjs module, therefore, we need to use its default property
 const errors = _errors.default
@@ -55,6 +56,9 @@ export function createApp({
 
   // Set the global JSON body limit to 1MB to support typical GraphQL payloads
   app.use(express.json({ limit: '1mb' }))
+
+  // Health check route
+  app.use(createHealthRouter())
 
   // RESTful GraphQL routes
   app.use(createGqlRestRouter(gql))

--- a/packages/api-gateway/src/routes/auth.ts
+++ b/packages/api-gateway/src/routes/auth.ts
@@ -176,7 +176,7 @@ export function createAuthRouter() {
         }
       }
 
-      console.log(
+      console.error(
         JSON.stringify({
           severity: 'ERROR',
           message:

--- a/packages/api-gateway/src/routes/gql-rest-multipart.ts
+++ b/packages/api-gateway/src/routes/gql-rest-multipart.ts
@@ -78,7 +78,7 @@ export const createMultipartRewriteHandler = ({
           'GraphQLRestMultipartServerError',
           'GraphQL REST multipart server error'
         )
-        console.log(
+        console.error(
           JSON.stringify({
             severity: 'ERROR',
             message: errors.helpers.printAll(

--- a/packages/api-gateway/src/routes/gql-rest.ts
+++ b/packages/api-gateway/src/routes/gql-rest.ts
@@ -195,7 +195,7 @@ export function createGqlRestRouter({
             'GraphQLRestError',
             'Failed to call CMS GraphQL'
           )
-          console.log(
+          console.error(
             JSON.stringify({
               severity: 'ERROR',
               message: errors.helpers.printAll(

--- a/packages/api-gateway/src/routes/health.ts
+++ b/packages/api-gateway/src/routes/health.ts
@@ -1,0 +1,17 @@
+import express from 'express'
+
+/**
+ * Health check endpoint for Cloud Run readiness and liveness probes
+ */
+export function createHealthRouter() {
+  const router = express.Router()
+
+  router.get('/health', (req, res) => {
+    res.status(200).json({
+      status: 'success',
+      timestamp: new Date().toISOString(),
+    })
+  })
+
+  return router
+}

--- a/packages/cms/express-mini-apps/two-factor-auth/route.ts
+++ b/packages/cms/express-mini-apps/two-factor-auth/route.ts
@@ -94,7 +94,7 @@ export function twoFactorAuthRoute(
           'get2faSetup',
           'Failed to save tempSecret to user table'
         )
-        console.log(
+        console.error(
           JSON.stringify({
             severity: 'ERROR',
             message: errors.helpers.printAll(
@@ -189,7 +189,7 @@ export function twoFactorAuthRoute(
             'post2faSetup',
             'Failed to save 2fa setup to user table'
           )
-          console.log(
+          console.error(
             JSON.stringify({
               severity: 'ERROR',
               message: errors.helpers.printAll(
@@ -270,7 +270,7 @@ export function twoFactorAuthRoute(
             'post2faClear',
             'Failed to clear 2fa token in user table'
           )
-          console.log(
+          console.error(
             JSON.stringify({
               severity: 'ERROR',
               message: errors.helpers.printAll(

--- a/packages/cms/graphql/extend-schema.ts
+++ b/packages/cms/graphql/extend-schema.ts
@@ -188,7 +188,7 @@ export const extendGraphqlSchema = graphql.extend(() => {
             }
 
             // GCP structured logging
-            console.log(
+            console.error(
               JSON.stringify({
                 severity: 'ERROR',
                 message: errorMessage,
@@ -327,7 +327,7 @@ export const extendGraphqlSchema = graphql.extend(() => {
             }
 
             // GCP structured logging
-            console.log(
+            console.error(
               JSON.stringify({
                 severity: 'ERROR',
                 message: errorMessage,
@@ -561,7 +561,7 @@ export const extendGraphqlSchema = graphql.extend(() => {
               })
             }
 
-            console.log(
+            console.error(
               JSON.stringify({
                 severity: 'ERROR',
                 message: errorMessage,
@@ -696,7 +696,7 @@ export const extendGraphqlSchema = graphql.extend(() => {
               })
             }
 
-            console.log(
+            console.error(
               JSON.stringify({
                 severity: 'ERROR',
                 message: errorMessage,

--- a/packages/cms/keystone.ts
+++ b/packages/cms/keystone.ts
@@ -129,7 +129,7 @@ async function getSessionFromGoApiJwt({
   } catch (_err) {
     const err = _err instanceof Error ? _err : new Error(String(_err))
 
-    console.log(
+    console.error(
       JSON.stringify({
         severity: 'ERROR',
         context: {
@@ -204,7 +204,7 @@ const compositeSession: SessionStrategy<Session, TypeInfo> = {
       } catch (_err) {
         const err = _err instanceof Error ? _err : new Error(String(_err))
 
-        console.log(
+        console.error(
           JSON.stringify({
             severity: 'ERROR',
             context: {

--- a/packages/cms/keystone.ts
+++ b/packages/cms/keystone.ts
@@ -306,9 +306,30 @@ const authConfig = withAuth(
     },
     server: {
       extendExpressApp: (app, commonContext) => {
-        // Health check endpoint
-        app.get('/health_check', (req, res) => {
-          res.status(200).json({ status: 'healthy' })
+        // Health check endpoint for Cloud Run readiness and liveness probes
+        app.get('/health', async (req, res) => {
+          try {
+            // Check database connectivity
+            await commonContext.prisma.$queryRaw`SELECT 1`
+            res.status(200).json({
+              status: 'success',
+              timestamp: new Date().toISOString(),
+            })
+          } catch (e) {
+            const err = e instanceof Error ? e : new Error(String(e))
+            // Log with stack trace for Error Reporting integration
+            console.log(
+              JSON.stringify({
+                severity: 'ERROR',
+                message: err.stack || err.message,
+              })
+            )
+            res.status(503).json({
+              status: 'error',
+              timestamp: new Date().toISOString(),
+              error: 'Database connection failed',
+            })
+          }
         })
 
         if (envVar.nodeEnv !== 'production') {

--- a/packages/frontend/src/app/api/health/route.ts
+++ b/packages/frontend/src/app/api/health/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  return NextResponse.json(
+    {
+      status: 'success',
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 }
+  )
+}


### PR DESCRIPTION
## Summary
Introduce consistent health check endpoints across frontend, CMS, and API gateway for readiness/liveness probes.

## Changes
- add /health route to api-gateway with JSON status + timestamp
- update CMS health check to /health with the same response shape
- add Next.js /api/health endpoint for frontend checks
- replace console.log with console.error for ERROR severity logs

## Notes
- intended for Cloud Run readiness/liveness probes
- replaces legacy CMS /health_check naming for consistency

## FollowUps
- reconfigure CMS cloud run readiness probes, and add liveness probes.
- configure frontend, api-gateway readiness and liveness probes