### PR TITLE
feat(frontend): add article redirect page

### DIFF
--- a/packages/frontend/src/app/[postSlug]/page.tsx
+++ b/packages/frontend/src/app/[postSlug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound, permanentRedirect } from 'next/navigation'
 
 import { getPostMeta } from '@/api/post'
+import { log, LogLevel } from '@/utils/log'
 
 async function PostPage({ params }: { params: { postSlug: string } }) {
   const { postSlug } = params
@@ -9,6 +10,7 @@ async function PostPage({ params }: { params: { postSlug: string } }) {
   })
 
   if (!post) {
+    log(LogLevel.WARNING, `Post not found! ${postSlug}`)
     notFound()
   }
 

--- a/packages/frontend/src/app/[postSlug]/page.tsx
+++ b/packages/frontend/src/app/[postSlug]/page.tsx
@@ -1,0 +1,18 @@
+import { notFound, permanentRedirect } from 'next/navigation'
+
+import { getPostMeta } from '@/api/post'
+
+async function PostPage({ params }: { params: { postSlug: string } }) {
+  const { postSlug } = params
+  const post = await getPostMeta({
+    where: { slug: postSlug },
+  })
+
+  if (!post) {
+    notFound()
+  }
+
+  permanentRedirect(`/article/${postSlug}`)
+}
+
+export default PostPage


### PR DESCRIPTION
## Summary

Adds a Next.js dynamic route `[postSlug]` that redirects legacy root-level article URLs (`/{slug}`) to the canonical article URL (`/article/{slug}`). Requests to a valid post slug are validated via `getPost` and then redirected; invalid slugs return 404.

## Changes

- **New:** `packages/frontend/src/app/[postSlug]/page.tsx` — Server component that reads `postSlug` from route params, fetches the post with `getPostMeta`, returns `notFound()` when no post exists, and calls `redirect(`/article/${postSlug}`)` for valid slugs.

## Additional Notes

- **Purpose:** Supports URL migration and SEO: old links to `/{postSlug}` now redirect to `/article/{postSlug}` instead of 404.
- **Behavior:** Redirect is server-side (Next.js `permanentRedirect()`). Only slugs that match an existing post redirect; unknown slugs get 404.

## Screenshot(s)

## Reference(s)
- [Notion Page](https://www.notion.so/twreporter/2fb8dbdca932805aa422de5a1a87d7fc?source=copy_link)
