### PR TITLE
feat(frontend,routing-ui): add idea hub navigation bar and z-index utilities

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -19,7 +19,7 @@
     "@googleapis/customsearch": "^1.0.4",
     "@hookform/resolvers": "^5.2.2",
     "@kids-reporter/draft-renderer": "^1.0.13",
-    "@kids-reporter/routing-ui": "0.1.12",
+    "@kids-reporter/routing-ui": "0.1.13",
     "@next/third-parties": "^14.1.1",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/packages/frontend/src/components/dialog.tsx
+++ b/packages/frontend/src/components/dialog.tsx
@@ -38,7 +38,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        'fixed inset-0 z-1002 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
+        'fixed inset-0 z-modal bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
         className
       )}
       {...props}
@@ -60,7 +60,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'bg-background fixed z-1002 flex flex-col gap-4 duration-200',
+          'bg-background fixed z-modal flex flex-col gap-4 duration-200',
           // Mobile: full screen with 16px from top, extends to bottom for safe area insets
           'top-4 right-0 bottom-0 left-0 w-screen',
           'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-bottom data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-bottom',

--- a/packages/frontend/src/components/table-of-content/table-of-content-side-menu.tsx
+++ b/packages/frontend/src/components/table-of-content/table-of-content-side-menu.tsx
@@ -173,7 +173,7 @@ function TableOfContentSideMenu({
   return (
     <nav
       ref={menuContainerRef}
-      className="fixed top-0 left-0 z-1000 print:hidden"
+      className="fixed top-0 left-0 z-bar print:hidden"
       aria-label={ariaLabel}
     >
       <button

--- a/packages/frontend/src/globals.css
+++ b/packages/frontend/src/globals.css
@@ -128,6 +128,13 @@
   --mobile-header-height: 64px;
   --desktop-header-height: 122px;
 
+  /* Z-Index scale (999–1003) – generic layer names */
+  --z-index-sticky: 999;
+  --z-index-bar: 1000;
+  --z-index-nav: 1001;
+  --z-index-overlay: 1002;
+  --z-index-modal: 1003;
+
   /* Custom Shadows */
   --shadow-custom: 0 0 24px 0 rgba(0, 0, 0, 0.1);
   --shadow-baodaozai-card: 0 2px 16px 0 rgba(0, 0, 0, 0.15);
@@ -532,6 +539,23 @@
 }
 @utility theme-blue {
   --theme-color: var(--color-blue-400);
+}
+
+/* Z-Index utilities */
+@utility z-sticky {
+  z-index: var(--z-index-sticky);
+}
+@utility z-bar {
+  z-index: var(--z-index-bar);
+}
+@utility z-nav {
+  z-index: var(--z-index-nav);
+}
+@utility z-overlay {
+  z-index: var(--z-index-overlay);
+}
+@utility z-modal {
+  z-index: var(--z-index-modal);
 }
 
 ::selection {

--- a/packages/frontend/src/icons/arrow.tsx
+++ b/packages/frontend/src/icons/arrow.tsx
@@ -1,19 +1,25 @@
 export const ArrowLeft = () => {
   return (
     <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="11"
-      height="19"
-      viewBox="0 0 11 19"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
       fill="none"
+      xmlns="http://www.w3.org/2000/svg"
     >
-      <path
-        d="M9.42993 17.5L1.50005 9.5L9.42993 1.5"
-        stroke="currentColor"
-        strokeWidth="3"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
+      <g clipPath="url(#clip0_3400_15242)">
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M16.8839 3.11612C16.3957 2.62796 15.6043 2.62796 15.1161 3.11612L7.11612 11.1161C6.8817 11.3505 6.75 11.6685 6.75 12C6.75 12.3315 6.8817 12.6495 7.11612 12.8839L15.1161 20.8839C15.6043 21.372 16.3957 21.372 16.8839 20.8839C17.372 20.3957 17.372 19.6043 16.8839 19.1161L9.76777 12L16.8839 4.88388C17.372 4.39573 17.372 3.60427 16.8839 3.11612Z"
+          fill="currentColor"
+        />
+      </g>
+      <defs>
+        <clipPath id="clip0_3400_15242">
+          <rect width="24" height="24" fill="white" />
+        </clipPath>
+      </defs>
     </svg>
   )
 }
@@ -21,19 +27,25 @@ export const ArrowLeft = () => {
 export const ArrowRight = () => {
   return (
     <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="11"
-      height="19"
-      viewBox="0 0 11 19"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
       fill="none"
+      xmlns="http://www.w3.org/2000/svg"
     >
-      <path
-        d="M1.5 17.5L9.42988 9.5L1.5 1.5"
-        stroke="currentColor"
-        strokeWidth="3"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
+      <g clipPath="url(#clip0_3400_15283)">
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M7.11612 3.11612C7.60427 2.62796 8.39573 2.62796 8.88388 3.11612L16.8839 11.1161C17.1183 11.3505 17.25 11.6685 17.25 12C17.25 12.3315 17.1183 12.6495 16.8839 12.8839L8.88388 20.8839C8.39573 21.372 7.60427 21.372 7.11612 20.8839C6.62796 20.3957 6.62796 19.6043 7.11612 19.1161L14.2322 12L7.11612 4.88388C6.62796 4.39573 6.62796 3.60427 7.11612 3.11612Z"
+          fill="currentColor"
+        />
+      </g>
+      <defs>
+        <clipPath id="clip0_3400_15283">
+          <rect width="24" height="24" fill="white" />
+        </clipPath>
+      </defs>
     </svg>
   )
 }

--- a/packages/frontend/src/icons/miscellaneous.tsx
+++ b/packages/frontend/src/icons/miscellaneous.tsx
@@ -1589,3 +1589,30 @@ export const CheckIcon = () => {
     </svg>
   )
 }
+
+export const BackToTopIcon = () => {
+  return (
+    <svg
+      width="19"
+      height="20"
+      viewBox="0 0 19 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M17.5 18.4299L9.5 10.5L1.5 18.4299"
+        stroke="currentColor"
+        strokeWidth="3"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M17.5 9.42987L9.5 1.49999L1.5 9.42987"
+        stroke="currentColor"
+        strokeWidth="3"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}

--- a/packages/frontend/src/modules/article/components/image-modal.tsx
+++ b/packages/frontend/src/modules/article/components/image-modal.tsx
@@ -32,7 +32,7 @@ function ImageModal({ isOpen, imgProps, onImageModalClose }: ImageModalProps) {
 
   return (
     isOpen && (
-      <div className="fixed top-0 left-0 z-1001 hidden h-screen w-screen items-center justify-center bg-black/50 lg:flex lg:flex-col">
+      <div className="fixed top-0 left-0 z-overlay hidden h-screen w-screen items-center justify-center bg-black/50 lg:flex lg:flex-col">
         <div className="relative">
           <div
             className={cn(

--- a/packages/frontend/src/modules/article/components/toolbar.tsx
+++ b/packages/frontend/src/modules/article/components/toolbar.tsx
@@ -54,7 +54,7 @@ function MobileToolbar({ topicURL, onCheckAnswerClick }: MobileToolbarProp) {
   return (
     <div
       className={cn(
-        'z-1001 flex flex-col items-center transition-all duration-400 print:hidden',
+        'z-overlay flex flex-col items-center transition-all duration-400 print:hidden',
         {
           'pointer-events-none max-h-0 translate-y-10 opacity-0': isHidden,
           'max-h-50 translate-y-0 opacity-100': !isHidden,
@@ -293,7 +293,7 @@ function Toolbar({ topicURL, postSlug }: ToolbarProp) {
   return (
     <>
       {/* 148px is 1/2 of toolbar height */}
-      <div className="fixed bottom-6 left-6 z-999 tablet:bottom-8 tablet:left-1/2 tablet:-translate-x-1/2 desktop:sticky desktop:top-[calc(50vh+148px)] desktop:left-0 desktop:z-[999] desktop:ml-12 desktop:flex desktop:h-0 desktop:translate-x-0 desktop:items-end hd:ml-20 print:hidden">
+      <div className="fixed bottom-6 left-6 z-sticky tablet:bottom-8 tablet:left-1/2 tablet:-translate-x-1/2 desktop:sticky desktop:top-[calc(50vh+148px)] desktop:left-0 desktop:z-sticky desktop:ml-12 desktop:flex desktop:h-0 desktop:translate-x-0 desktop:items-end hd:ml-20 print:hidden">
         <div className="desktop:hidden">
           <MobileToolbar
             topicURL={topicURL}

--- a/packages/frontend/src/modules/idea-hub/all-answers/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/all-answers/index.tsx
@@ -26,7 +26,8 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
   const loadMoreRef = useRef<HTMLDivElement>(null)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const titleRef = useRef<HTMLDivElement>(null)
-  const [hasShownToast, setHasShownToast] = useState(false)
+  const hasShownToastRef = useRef(false)
+  const showNavBarRef = useRef(false)
   const [showNavBar, setShowNavBar] = useState(false)
   const {
     data: posts,
@@ -79,23 +80,25 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
   }, [hasNextPage, isFetchingNextPage, fetchNextPage])
 
   useEffect(() => {
-    if (!titleRef.current) return
-    const title = titleRef.current
     const handleScroll = () => {
+      const title = titleRef.current
+      if (!title) return
       const titleRect = title.getBoundingClientRect()
       const threshold = 120
-      if (titleRect.top < threshold && !hasShownToast) {
+      if (titleRect.top < threshold && !hasShownToastRef.current) {
         toast.success('向左滑動可以看到更多文章喔！', {
           className: 'desktop:!bottom-19',
         })
-        setHasShownToast(true)
+        hasShownToastRef.current = true
       }
 
-      if (titleRect.top < threshold && !showNavBar) {
+      if (titleRect.top < threshold && !showNavBarRef.current) {
+        showNavBarRef.current = true
         setShowNavBar(true)
       }
 
-      if (titleRect.top > threshold && showNavBar) {
+      if (titleRect.top > threshold && showNavBarRef.current) {
+        showNavBarRef.current = false
         setShowNavBar(false)
       }
     }
@@ -105,7 +108,7 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
     return () => {
       window.removeEventListener('scroll', handleScroll)
     }
-  }, [hasShownToast, showNavBar])
+  }, [])
 
   const showLoading = isLoading || isFetchingNextPage
   const handleScrollToTop = () => {
@@ -157,7 +160,7 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
               <div
                 key={`skeleton-${index}`}
                 className="shrink-0 snap-start"
-                data-card-index={index - 1}
+                data-card-index={(posts?.length ?? 0) + index - 1}
               >
                 <PostAnswerCardSkeleton />
               </div>

--- a/packages/frontend/src/modules/idea-hub/all-answers/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/all-answers/index.tsx
@@ -10,6 +10,7 @@ import { toast } from 'sonner'
 import { DEFAULT_PAGE_ITEM_COUNT } from '@/api-utils/react-query/constants'
 import { usePostsEssayAnswersWithLikesInfinityQuery } from '@/api-utils/react-query/hooks/post'
 
+import NavBar from './nav-bar'
 import PostAnswerCard from './post-answer-card'
 import PostAnswerCardSkeleton from './post-answer-card-skeleton'
 import { transformInfinitePostsEssayAnswersWithLikesDataToPosts } from './utils'
@@ -26,7 +27,7 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const titleRef = useRef<HTMLDivElement>(null)
   const [hasShownToast, setHasShownToast] = useState(false)
-
+  const [showNavBar, setShowNavBar] = useState(false)
   const {
     data: posts,
     isLoading,
@@ -78,16 +79,24 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
   }, [hasNextPage, isFetchingNextPage, fetchNextPage])
 
   useEffect(() => {
-    if (hasShownToast || !titleRef.current) return
-
+    if (!titleRef.current) return
+    const title = titleRef.current
     const handleScroll = () => {
-      if (hasShownToast || !titleRef.current) return
-
-      const titleRect = titleRef.current.getBoundingClientRect()
+      const titleRect = title.getBoundingClientRect()
       const threshold = 120
-      if (titleRect.top < threshold) {
-        toast.success('向左滑動可以看到更多文章喔！')
+      if (titleRect.top < threshold && !hasShownToast) {
+        toast.success('向左滑動可以看到更多文章喔！', {
+          className: 'desktop:!bottom-19',
+        })
         setHasShownToast(true)
+      }
+
+      if (titleRect.top < threshold && !showNavBar) {
+        setShowNavBar(true)
+      }
+
+      if (titleRect.top > threshold && showNavBar) {
+        setShowNavBar(false)
       }
     }
 
@@ -96,12 +105,18 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
     return () => {
       window.removeEventListener('scroll', handleScroll)
     }
-  }, [hasShownToast])
+  }, [hasShownToast, showNavBar])
 
   const showLoading = isLoading || isFetchingNextPage
-
+  const handleScrollToTop = () => {
+    titleRef.current?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'start',
+      inline: 'start',
+    })
+  }
   return (
-    <div className="flex w-[calc(100%+48px)] flex-col gap-6 bg-neutral-100 pt-10 pb-12 tablet:w-[calc(100%+64px)] tablet:gap-8 tablet:pt-12 tablet:pb-14 desktop:w-screen desktop:gap-10 desktop:pt-18 desktop:pb-22 hd:w-screen hd:pt-24 hd:pb-28">
+    <div className="relative flex w-[calc(100%+48px)] flex-col gap-6 bg-neutral-100 pt-10 pb-12 tablet:w-[calc(100%+64px)] tablet:gap-8 tablet:pt-12 tablet:pb-14 desktop:w-screen desktop:gap-10 desktop:pt-18 desktop:pb-22 hd:w-screen hd:pt-24 hd:pb-28">
       <div
         ref={titleRef}
         className="flex items-center gap-3 pl-6 tablet:pl-8 desktop:pl-12 hd:pl-[calc(50vw-600px+64px)]"
@@ -115,15 +130,19 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
         ref={scrollContainerRef}
         className="flex scrollbar-thin snap-x snap-mandatory scroll-px-6 gap-6 overflow-x-auto px-6 pb-2 tablet:scroll-px-8 tablet:px-8 desktop:scroll-px-12 desktop:gap-8 desktop:px-12 hd:scroll-pr-14 hd:scroll-pl-[calc(50vw-600px+64px)] hd:pr-14 hd:pl-[calc(50vw-600px+64px)]"
       >
-        {posts?.map((post) => (
-          <div key={post.id} className="flex-shrink-0 snap-start">
+        {posts?.map((post, index) => (
+          <div
+            key={post.id}
+            className="shrink-0 snap-start"
+            data-card-index={index}
+          >
             <PostAnswerCard post={post} onOpenModal={onOpenModal} />
           </div>
         ))}
         {hasNextPage && (
           <div
             ref={loadMoreRef}
-            className="h-1 w-1 flex-shrink-0"
+            className="h-1 w-1 shrink-0"
             aria-hidden="true"
           />
         )}
@@ -137,7 +156,8 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
             {[1, 2, 3].map((index) => (
               <div
                 key={`skeleton-${index}`}
-                className="flex-shrink-0 snap-start"
+                className="shrink-0 snap-start"
+                data-card-index={index - 1}
               >
                 <PostAnswerCardSkeleton />
               </div>
@@ -145,6 +165,11 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
           </>
         )}
       </div>
+      <NavBar
+        scrollContainerRef={scrollContainerRef}
+        onScrollToTop={handleScrollToTop}
+        showNavBar={showNavBar}
+      />
     </div>
   )
 }

--- a/packages/frontend/src/modules/idea-hub/all-answers/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/all-answers/index.tsx
@@ -101,7 +101,7 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
   const showLoading = isLoading || isFetchingNextPage
 
   return (
-    <div className="flex w-[calc(100%+48px)] flex-col gap-6 bg-neutral-100 pt-10 pb-12 tablet:w-[calc(100%+64px)] tablet:gap-8 tablet:pt-12 tablet:pb-14 desktop:w-[calc(100%+96px)] desktop:gap-10 desktop:pt-18 desktop:pb-22 hd:w-screen hd:pt-24 hd:pb-28">
+    <div className="flex w-[calc(100%+48px)] flex-col gap-6 bg-neutral-100 pt-10 pb-12 tablet:w-[calc(100%+64px)] tablet:gap-8 tablet:pt-12 tablet:pb-14 desktop:w-screen desktop:gap-10 desktop:pt-18 desktop:pb-22 hd:w-screen hd:pt-24 hd:pb-28">
       <div
         ref={titleRef}
         className="flex items-center gap-3 pl-6 tablet:pl-8 desktop:pl-12 hd:pl-[calc(50vw-600px+64px)]"

--- a/packages/frontend/src/modules/idea-hub/all-answers/nav-bar.tsx
+++ b/packages/frontend/src/modules/idea-hub/all-answers/nav-bar.tsx
@@ -14,6 +14,18 @@ type NavBarProps = {
 
 const CARD_DATA_INDEX_ATTR = 'data-card-index'
 
+const getScrollAmount = (container: HTMLDivElement): number => {
+  const firstCard = container.querySelector<HTMLElement>(
+    `[${CARD_DATA_INDEX_ATTR}="0"]`
+  )
+  if (!firstCard) return 0
+
+  const cardWidth = firstCard.offsetWidth
+  const gap =
+    parseInt(window.getComputedStyle(container).gap.replace('px', ''), 10) || 24
+  return cardWidth + gap
+}
+
 function NavBar({
   scrollContainerRef,
   onScrollToTop,
@@ -22,18 +34,10 @@ function NavBar({
   const scrollLeft = useCallback(() => {
     const container = scrollContainerRef.current
     if (!container) return
-    const firstCard = container.querySelector<HTMLElement>(
-      `[${CARD_DATA_INDEX_ATTR}="0"]`
-    )
-    if (firstCard) {
-      const cardWidth = firstCard.offsetWidth
-      const gap =
-        parseInt(
-          window.getComputedStyle(container).gap.replace('px', ''),
-          10
-        ) || 24
+    const scrollAmount = getScrollAmount(container)
+    if (scrollAmount > 0) {
       container.scrollBy({
-        left: -(cardWidth + gap),
+        left: -scrollAmount,
         behavior: 'smooth',
       })
     }
@@ -42,18 +46,10 @@ function NavBar({
   const scrollRight = useCallback(() => {
     const container = scrollContainerRef.current
     if (!container) return
-    const firstCard = container.querySelector<HTMLElement>(
-      `[${CARD_DATA_INDEX_ATTR}="0"]`
-    )
-    if (firstCard) {
-      const cardWidth = firstCard.offsetWidth
-      const gap =
-        parseInt(
-          window.getComputedStyle(container).gap.replace('px', ''),
-          10
-        ) || 24
+    const scrollAmount = getScrollAmount(container)
+    if (scrollAmount > 0) {
       container.scrollBy({
-        left: cardWidth + gap,
+        left: scrollAmount,
         behavior: 'smooth',
       })
     }

--- a/packages/frontend/src/modules/idea-hub/all-answers/nav-bar.tsx
+++ b/packages/frontend/src/modules/idea-hub/all-answers/nav-bar.tsx
@@ -21,8 +21,7 @@ const getScrollAmount = (container: HTMLDivElement): number => {
   if (!firstCard) return 0
 
   const cardWidth = firstCard.offsetWidth
-  const gap =
-    parseInt(window.getComputedStyle(container).gap.replace('px', ''), 10) || 24
+  const gap = parseInt(window.getComputedStyle(container).gap, 10) || 24
   return cardWidth + gap
 }
 
@@ -58,8 +57,8 @@ function NavBar({
   return (
     <div
       className={cn(
-        'sticky bottom-0 left-0 z-nav opacity-0 transition-opacity duration-200',
-        showNavBar && 'opacity-100'
+        'pointer-events-none sticky bottom-0 left-0 z-nav opacity-0 transition-opacity duration-200',
+        showNavBar && 'pointer-events-auto opacity-100'
       )}
     >
       <div

--- a/packages/frontend/src/modules/idea-hub/all-answers/nav-bar.tsx
+++ b/packages/frontend/src/modules/idea-hub/all-answers/nav-bar.tsx
@@ -62,7 +62,7 @@ function NavBar({
   return (
     <div
       className={cn(
-        'sticky bottom-0 left-0 z-1001 opacity-0 transition-opacity duration-200',
+        'sticky bottom-0 left-0 z-nav opacity-0 transition-opacity duration-200',
         showNavBar && 'opacity-100'
       )}
     >

--- a/packages/frontend/src/modules/idea-hub/all-answers/nav-bar.tsx
+++ b/packages/frontend/src/modules/idea-hub/all-answers/nav-bar.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { cn } from '@kids-reporter/routing-ui'
+import { type RefObject, useCallback } from 'react'
+
+import { ArrowLeft, ArrowRight } from '@/icons/arrow'
+import { BackToTopIcon } from '@/icons/miscellaneous'
+
+type NavBarProps = {
+  scrollContainerRef: RefObject<HTMLDivElement | null>
+  onScrollToTop: () => void
+  showNavBar: boolean
+}
+
+const CARD_DATA_INDEX_ATTR = 'data-card-index'
+
+function NavBar({
+  scrollContainerRef,
+  onScrollToTop,
+  showNavBar,
+}: NavBarProps) {
+  const scrollLeft = useCallback(() => {
+    const container = scrollContainerRef.current
+    if (!container) return
+    const firstCard = container.querySelector<HTMLElement>(
+      `[${CARD_DATA_INDEX_ATTR}="0"]`
+    )
+    if (firstCard) {
+      const cardWidth = firstCard.offsetWidth
+      const gap =
+        parseInt(
+          window.getComputedStyle(container).gap.replace('px', ''),
+          10
+        ) || 24
+      container.scrollBy({
+        left: -(cardWidth + gap),
+        behavior: 'smooth',
+      })
+    }
+  }, [scrollContainerRef])
+
+  const scrollRight = useCallback(() => {
+    const container = scrollContainerRef.current
+    if (!container) return
+    const firstCard = container.querySelector<HTMLElement>(
+      `[${CARD_DATA_INDEX_ATTR}="0"]`
+    )
+    if (firstCard) {
+      const cardWidth = firstCard.offsetWidth
+      const gap =
+        parseInt(
+          window.getComputedStyle(container).gap.replace('px', ''),
+          10
+        ) || 24
+      container.scrollBy({
+        left: cardWidth + gap,
+        behavior: 'smooth',
+      })
+    }
+  }, [scrollContainerRef])
+
+  return (
+    <div
+      className={cn(
+        'sticky bottom-0 left-0 z-1001 opacity-0 transition-opacity duration-200',
+        showNavBar && 'opacity-100'
+      )}
+    >
+      <div
+        className="absolute bottom-8 left-[50vw] hidden w-min -translate-x-1/2 items-center rounded-full bg-white p-2 shadow-md desktop:inline-flex"
+        role="group"
+        aria-label="捲動導覽"
+      >
+        <button
+          type="button"
+          onClick={scrollLeft}
+          className="flex h-7 w-[50px] cursor-pointer items-center justify-center text-neutral-400 transition-colors duration-200 hover:text-neutral-600"
+          aria-label="向左捲動"
+        >
+          <ArrowLeft />
+        </button>
+        <button
+          type="button"
+          onClick={scrollRight}
+          className="flex h-7 w-[50px] cursor-pointer items-center justify-center text-neutral-400 transition-colors duration-200 hover:text-neutral-600"
+          aria-label="向右捲動"
+        >
+          <ArrowRight />
+        </button>
+      </div>
+      <button
+        type="button"
+        onClick={onScrollToTop}
+        className="absolute bottom-8 left-[100vw] flex h-11 w-11 -translate-x-[calc(100%+24px)] cursor-pointer items-center justify-center rounded-full bg-white text-neutral-400 shadow-md transition-colors duration-200 hover:text-neutral-600 tablet:-translate-x-[calc(100%+32px)]"
+        aria-label="回到頂部"
+      >
+        <BackToTopIcon />
+      </button>
+    </div>
+  )
+}
+
+export default NavBar

--- a/packages/frontend/src/modules/idea-hub/latest-answers/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/latest-answers/index.tsx
@@ -37,7 +37,7 @@ function LatestAnswers({ onOpenModal }: LatestAnswersProps) {
   }
 
   return (
-    <div className="mt-10 mb-14 flex w-[calc(100%+48px)] flex-col gap-6 tablet:mt-12 tablet:mb-16 tablet:w-full tablet:gap-8 desktop:mt-18 desktop:mb-24 desktop:gap-10 hd:mt-24 hd:mb-30">
+    <div className="mt-10 mb-14 flex w-[calc(100%+48px)] flex-col gap-6 tablet:mt-12 tablet:mb-16 tablet:w-full tablet:gap-8 desktop:mt-18 desktop:mb-24 desktop:w-screen desktop:gap-10 desktop:pl-12 hd:mt-24 hd:mb-30 hd:pl-[calc(50vw-600px+64px)]">
       <div className="flex items-center gap-3 pl-6 tablet:pl-0">
         <div className="h-8 w-1.5 rounded-md bg-yellow-400" />
         <h3 className="prose-h3-small font-swei text-neutral-900 desktop:prose-h3-large">

--- a/packages/frontend/src/services/call-baodaozai/components/baodaozai.tsx
+++ b/packages/frontend/src/services/call-baodaozai/components/baodaozai.tsx
@@ -72,7 +72,7 @@ function Baodaozai() {
   return (
     <div
       className={cn(
-        'fixed right-0 bottom-0 z-1000 w-full tablet:right-0 tablet:bottom-0',
+        'fixed right-0 bottom-0 z-bar w-full tablet:right-0 tablet:bottom-0',
         hide ? 'opacity-0' : 'opacity-100 transition-opacity duration-1000'
       )}
     >

--- a/packages/frontend/src/services/call-baodaozai/components/qa-modal/index.tsx
+++ b/packages/frontend/src/services/call-baodaozai/components/qa-modal/index.tsx
@@ -501,7 +501,7 @@ function QAModal({
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 z-1002 flex scrollbar-thin items-end justify-center tablet:items-center">
+    <div className="fixed inset-0 z-modal flex scrollbar-thin items-end justify-center tablet:items-center">
       <div className="absolute inset-0 z-0 bg-neutral-black/20" />
       <div
         className={cn(

--- a/packages/routing-ui/package.json
+++ b/packages/routing-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kids-reporter/routing-ui",
   "license": "MIT",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Routing UI for Kids Reporter",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/routing-ui/src/header/desktop-header.tsx
+++ b/packages/routing-ui/src/header/desktop-header.tsx
@@ -42,7 +42,7 @@ export function DesktopHeader({
       <div className="hidden h-(--desktop-header-height) desktop:block"></div>
       <div
         className={cn(
-          'top-0 ease-in-out fixed left-1/2 z-1000 hidden w-full -translate-x-1/2 transform transition-all duration-500 desktop:block',
+          'top-0 ease-in-out fixed left-1/2 z-bar hidden w-full -translate-x-1/2 transform transition-all duration-500 desktop:block',
           compactMode && 'bg-white',
           hide
             ? 'pointer-events-none -translate-y-full opacity-0'

--- a/packages/routing-ui/src/header/menu/index.tsx
+++ b/packages/routing-ui/src/header/menu/index.tsx
@@ -77,7 +77,7 @@ function Menu({
       {/* Overlay */}
       <div
         className={cn(
-          'inset-0 fixed z-1001 bg-neutral-500/50 transition-opacity duration-300',
+          'inset-0 fixed z-overlay bg-neutral-500/50 transition-opacity duration-300',
           isOpen ? 'opacity-100' : 'pointer-events-none opacity-0'
         )}
         onClick={onClose}
@@ -86,7 +86,7 @@ function Menu({
       {/* Menu */}
       <div
         className={cn(
-          'top-0 left-0 tablet:w-80 bg-white shadow-2xl ease-in-out tablet:pt-0 fixed z-1001 h-full scrollbar-thin w-full transform pt-(--mobile-header-height) transition-transform duration-300',
+          'top-0 left-0 tablet:w-80 bg-white shadow-2xl ease-in-out tablet:pt-0 fixed z-overlay h-full scrollbar-thin w-full transform pt-(--mobile-header-height) transition-transform duration-300',
           isOpen ? 'translate-x-0' : '-translate-x-full'
         )}
       >

--- a/packages/routing-ui/src/header/mobile-header.tsx
+++ b/packages/routing-ui/src/header/mobile-header.tsx
@@ -39,7 +39,7 @@ export function MobileHeader({
       ></div>
       <div
         className={cn(
-          'px-6 tablet:px-8 ease-in-out top-0 translate-y-0 pointer-events-auto fixed z-1002 w-full opacity-100 transition-all duration-300 tablet:z-1000 desktop:hidden',
+          'px-6 tablet:px-8 ease-in-out top-0 translate-y-0 pointer-events-auto fixed z-modal w-full opacity-100 transition-all duration-300 tablet:z-bar desktop:hidden',
           hide && 'pointer-events-none -translate-y-full opacity-0',
           showBackgroundColor && 'bg-neutral-white'
         )}

--- a/packages/routing-ui/src/styles.css
+++ b/packages/routing-ui/src/styles.css
@@ -116,6 +116,13 @@
   /* Header */
   --mobile-header-height: 64px;
 
+  /* Z-Index scale (999–1003) – generic layer names */
+  --z-index-sticky: 999;
+  --z-index-bar: 1000;
+  --z-index-nav: 1001;
+  --z-index-overlay: 1002;
+  --z-index-modal: 1003;
+
   /* Legacy variables for backward compatibility */
   --fontFamily: var(--font-family-noto);
   --max-width: 1100px;
@@ -362,4 +369,21 @@
 }
 @utility theme-blue {
   --theme-color: var(--color-blue-400);
+}
+
+/* Z-Index utilities */
+@utility z-sticky {
+  z-index: var(--z-index-sticky);
+}
+@utility z-bar {
+  z-index: var(--z-index-bar);
+}
+@utility z-nav {
+  z-index: var(--z-index-nav);
+}
+@utility z-overlay {
+  z-index: var(--z-index-overlay);
+}
+@utility z-modal {
+  z-index: var(--z-index-modal);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5166,7 +5166,7 @@ __metadata:
     "@graphql-codegen/typescript-operations": "npm:^5.0.2"
     "@hookform/resolvers": "npm:^5.2.2"
     "@kids-reporter/draft-renderer": "npm:^1.0.13"
-    "@kids-reporter/routing-ui": "npm:0.1.12"
+    "@kids-reporter/routing-ui": "npm:0.1.13"
     "@next/bundle-analyzer": "npm:^14.2.33"
     "@next/eslint-plugin-next": "npm:^14.2.33"
     "@next/third-parties": "npm:^14.1.1"
@@ -5233,7 +5233,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/routing-ui@npm:0.1.12, @kids-reporter/routing-ui@workspace:packages/routing-ui":
+"@kids-reporter/routing-ui@npm:0.1.13, @kids-reporter/routing-ui@workspace:packages/routing-ui":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/routing-ui@workspace:packages/routing-ui"
   dependencies:


### PR DESCRIPTION
## Summary

Adds a sticky bottom navigation bar to the Idea Hub (小讀者觀點大集合頁) with left/right scroll controls for the all-answers card carousel and a back-to-top button. Introduces a shared z-index scale and utility classes in the frontend and `routing-ui` packages, and updates arrow icons to match design. Bumps `@kids-reporter/routing-ui` to 0.1.13.

## Changes

- **Idea Hub – Navigation bar**: New `nav-bar.tsx` in `modules/idea-hub/all-answers/` with:
  - Sticky bottom bar that fades in when the user scrolls (`showNavBar` from scroll position).
  - Left/right buttons that scroll the answer cards by one card width (with gap).
  - Back-to-top button; both controls use semantic `aria-label`s.
- **Idea Hub – All answers**: Wired in `NavBar`, `scrollContainerRef`, and lRight` callbacks; `showNavBar` state driven by scroll.
- **Idea Hub – Latest answers layout**: Desktop width and padding updated (`desktop:w-screen`, `desktop:pl-12`, `hd:pl-[calc(50vw-600px+64px)]`) for alignment with the new nav.
- **Icons**: `ArrowLeft` and `ArrowRight` updated to 24×24 filled style (from stroke). New `BackToTopIcon` in `icons/miscellaneous.tsx`.
- **Z-index utilities**: Semantic scale (999–1003) in `globals.css` and `routing-ui/src/styles.css` with `z-sticky`, `z-bar`, `z-nav`, `z-overlay`, `z-modal`. Replaced raw `z-1000`/`z-1001`/`z-1002` in dialog, table-of-content, image-modal, toolbar, baodaozai, qa-modal, and routing-ui header/menu with these classes.
- **routing-ui**: Version bump to 0.1.13; frontend `package.json` and `yarn.lock` updated to depend on 0.1.13.

## Additional Notes

- Nav bar is hidden on desktop for the horizontal card strip (`hidden ... desktop:inline-flex`); back-to-top remains visible. Verify behavior on target vrts.
- Scroll step uses the first card’s `offsetWidth` and container `gap`; if card size or gap change, scroll distance may need adjustment.
- Z-index layering is now centralized; any new fixed/sticky UI should use the same utility classes to avoid stacking issues.

## Screenshot(s)
<img width="1244" height="854" alt="image" src="https://github.com/user-attachments/assets/f1447a6e-83e1-4355-86e6-b90c5219c3cc" />

## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/btn-2f78dbdca93280069affd8ccdfc15391?source=copy_link)
- [Figma – 小讀者觀點大集合頁](https://www.figma.com/design/jKXceVhx5seAXU9A93znbK/%E5%B0%8F%E8%AE%80%E8%80%85%E8%A7%80%E9%BB%9E%E5%A4%A7%E9%9B%86%E5%90%88%E9%A0%81?node-id=614-152791&m=dev)