### PR TITLE
fix(frontend): home page layout and styling defects

### DIFF
--- a/packages/frontend/src/components/article-grid.tsx
+++ b/packages/frontend/src/components/article-grid.tsx
@@ -19,7 +19,7 @@ function ArticleGrid({
 
   return (
     <>
-      <div className="grid w-full grid-cols-1 gap-6 tablet:grid-cols-2">
+      <div className="grid w-full grid-cols-1 gap-6 tablet:grid-cols-2 tablet:gap-x-8 desktop:gap-x-12 hd:gap-x-14">
         {displayedArticles.map((article) => (
           <ArticleCard
             key={article.title}

--- a/packages/frontend/src/modules/home/components/category-post-cards/category-post-card.tsx
+++ b/packages/frontend/src/modules/home/components/category-post-cards/category-post-card.tsx
@@ -26,13 +26,13 @@ function CategoryPostCard({ post, className }: CategoryPostCardProps) {
       )}
     >
       <Link href={post.url} className="group relative flex h-full flex-col">
-        <div className="flex h-full flex-col overflow-hidden rounded-xl bg-white shadow-[0px_4px_10px_rgba(0,0,0,0.05)]">
+        <div className="flex h-full flex-col overflow-hidden rounded-[30px] bg-white shadow-[0px_4px_10px_rgba(0,0,0,0.05)]">
           {/* Image */}
-          <div className="relative h-[156px] w-full overflow-hidden rounded-t-xl tablet:h-[123px] desktop:h-[162px] hd:h-[191px]">
+          <div className="relative aspect-video w-full overflow-hidden rounded-t-[30px]">
             <ImageWithFallback
               src={post.image ?? FALLBACK_IMG}
               alt={post.title}
-              className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+              className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-120"
             />
           </div>
 

--- a/packages/frontend/src/modules/home/components/category-post-cards/index.tsx
+++ b/packages/frontend/src/modules/home/components/category-post-cards/index.tsx
@@ -64,7 +64,7 @@ function CategoryPostCards({
           />
           {categoryName}
         </h2>
-        <div className="flex scrollbar-thin w-full snap-x snap-mandatory scroll-px-12 gap-6 overflow-x-auto px-12 tablet:grid tablet:grid-cols-3 tablet:px-8 desktop:scroll-px-12 desktop:gap-10 desktop:px-12">
+        <div className="flex scrollbar-thin w-full snap-x snap-mandatory scroll-px-12 gap-6 overflow-x-auto px-12 pb-2 tablet:grid tablet:grid-cols-3 tablet:px-6 desktop:scroll-px-8 desktop:gap-8 desktop:px-12 hd:px-14">
           {!isLoading ? (
             posts.map((post) => <CategoryPostCard key={post.url} post={post} />)
           ) : (
@@ -75,7 +75,7 @@ function CategoryPostCards({
           variant="secondary"
           size={44}
           asChild
-          className="mx-auto mt-6 flex w-max tablet:mt-8 desktop:mt-12"
+          className="mx-auto mt-6 flex w-max tablet:mt-6 desktop:mt-8"
         >
           <Link href={`/category/${category}`}>看全部</Link>
         </Button>

--- a/packages/frontend/src/modules/home/components/editor-recommendation/index.tsx
+++ b/packages/frontend/src/modules/home/components/editor-recommendation/index.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { cn } from '@kids-reporter/routing-ui'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { useRef } from 'react'
@@ -33,16 +34,16 @@ function EditorRecommendationCard({
 
   return (
     <div className="w-[280px] flex-shrink-0 snap-start tablet:w-[320px] desktop:w-[360px]">
-      <span className="prose-h2-small leading-none text-neutral-900 desktop:prose-h3-large">
+      <span className="prose-h4-small leading-none text-neutral-900 desktop:prose-h4-large">
         {formattedIndex}
       </span>
 
       <Link href={post.url} className="group relative mt-2 flex flex-col">
-        <div className="relative h-[200px] w-full overflow-hidden rounded-xl tablet:h-[220px] desktop:h-[240px]">
+        <div className="relative aspect-video w-full overflow-hidden rounded-[20px]">
           <ImageWithFallback
             src={post.image ?? FALLBACK_IMG}
             alt={post.title}
-            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-120"
           />
         </div>
 
@@ -115,16 +116,18 @@ function EditorRecommendation({ posts }: EditorRecommendationProps) {
   }
 
   return (
-    <div className="relative w-full bg-yellow-100 pt-10 pb-14 tablet:pt-12 tablet:pb-16 desktop:pt-18 desktop:pb-24 hd:pt-24 hd:pb-40">
-      <div className="mb-6 flex max-w-300 items-center gap-2 px-6 tablet:mb-8 tablet:px-8 desktop:mb-10 desktop:px-12 hd:mx-auto hd:px-14">
+    <div className="relative w-full bg-yellow-100 pt-10 pb-14 tablet:pt-12 tablet:pb-16 desktop:pt-18 desktop:pb-24 hd:pt-24 hd:pb-30">
+      <div className="mx-auto mb-6 flex max-w-300 items-center gap-2 px-6 tablet:mb-8 tablet:px-8 desktop:mb-10 hd:px-14">
         <EditorRecommendationIcon className="desktop:hidden" />
         <EditorRecommendationIconLarge className="hidden desktop:block" />
-        <h2 className="prose-h2-small desktop:prose-h2-large">編輯推薦</h2>
+        <h2 className="prose-h2-small font-swei! desktop:prose-h2-large">
+          編輯推薦
+        </h2>
 
         <div className="ml-auto hidden gap-4 tablet:flex">
           <button
             onClick={scrollLeft}
-            className="flex size-11 cursor-pointer items-center justify-center rounded-full border-2 border-red-400 bg-white text-neutral-900 shadow-md transition-all duration-300 hover:bg-red-400 hover:text-white tablet:h-12 tablet:w-12 desktop:h-14 desktop:w-14"
+            className="flex size-11 cursor-pointer items-center justify-center rounded-full border-2 border-red-400 bg-white text-neutral-900 transition-all duration-300 hover:bg-red-400 hover:text-white tablet:h-12 tablet:w-12 desktop:h-14 desktop:w-14 [&>svg]:mr-1"
             aria-label="Scroll left"
             type="button"
           >
@@ -132,7 +135,7 @@ function EditorRecommendation({ posts }: EditorRecommendationProps) {
           </button>
           <button
             onClick={scrollRight}
-            className="flex size-11 cursor-pointer items-center justify-center rounded-full border-2 border-red-400 bg-white text-neutral-900 shadow-md transition-all duration-300 hover:bg-red-400 hover:text-white tablet:h-12 tablet:w-12 desktop:h-14 desktop:w-14"
+            className="flex size-11 cursor-pointer items-center justify-center rounded-full border-2 border-red-400 bg-white text-neutral-900 transition-all duration-300 hover:bg-red-400 hover:text-white tablet:h-12 tablet:w-12 desktop:h-14 desktop:w-14 [&>svg]:ml-1"
             aria-label="Scroll right"
             type="button"
           >
@@ -142,7 +145,12 @@ function EditorRecommendation({ posts }: EditorRecommendationProps) {
       </div>
       <div
         ref={scrollContainerRef}
-        className="flex scrollbar-thin snap-x snap-mandatory scroll-px-12 gap-6 overflow-x-auto px-12 tablet:scroll-px-8 tablet:gap-8 tablet:px-8 desktop:scroll-px-12 desktop:gap-10 desktop:px-12 hd:scroll-pl-[calc(50vw-600px+56px)] hd:pl-[calc(50vw-600px+56px)]"
+        className={cn(
+          'flex snap-x snap-mandatory scroll-px-6 gap-6 overflow-x-auto px-6 scrollbar-none',
+          'tablet:scroll-px-8 tablet:px-8',
+          'desktop:scroll-px-[max(48px,calc(50vw-600px+48px))] desktop:gap-8 desktop:px-[max(48px,calc(50vw-600px+48px))]',
+          'hd:scroll-pl-[calc(50vw-600px+56px)] hd:pl-[calc(50vw-600px+56px)]'
+        )}
       >
         {posts.map((post, index) => (
           <div key={post.title} data-card-index={index}>

--- a/packages/frontend/src/modules/home/components/latest-articles/index.tsx
+++ b/packages/frontend/src/modules/home/components/latest-articles/index.tsx
@@ -17,14 +17,14 @@ function LatestArticles({ posts }: LatestArticlesProps) {
   }
 
   return (
-    <div className="mx-auto flex w-full max-w-300 flex-col items-center justify-center px-6 py-10 tablet:px-8 tablet:py-12 desktop:px-12 desktop:py-18 hd:px-16 hd:py-24">
+    <div className="mx-auto flex w-full max-w-300 flex-col items-center justify-center px-6 py-10 pb-14 tablet:px-8 tablet:py-12 tablet:pb-16 desktop:px-12 desktop:py-18 desktop:pb-24 hd:px-14 hd:py-24 hd:pb-30">
       <div className="mb-6 flex w-full flex-col items-start justify-between gap-6 tablet:flex-row tablet:items-center">
         <div className="flex items-center gap-2">
           <div className="flex size-11 items-center justify-center desktop:size-16">
             <LatestArticlesIcon className="desktop:hidden" />
             <LatestArticlesIconLarge className="hidden desktop:block" />
           </div>
-          <span className="prose-h2-small font-swei text-neutral-900 desktop:prose-h2-large">
+          <span className="prose-h2-small font-swei! text-neutral-900 desktop:prose-h2-large">
             最新文章
           </span>
         </div>

--- a/packages/frontend/src/modules/home/components/subcategories-marquee/illustrations.tsx
+++ b/packages/frontend/src/modules/home/components/subcategories-marquee/illustrations.tsx
@@ -42,7 +42,7 @@ function Illustrations() {
         alt="subcategories marquee illustrations"
         width={272}
         height={200}
-        className="absolute right-30 bottom-8 z-1 hidden desktop:block hd:right-[calc(max(120px,10vw))]"
+        className="absolute right-30 bottom-8 z-1 hidden desktop:block hd:right-[calc(max(120px,50vw-600px))]"
       />
     </div>
   )

--- a/packages/frontend/src/modules/home/components/subcategories-marquee/index.tsx
+++ b/packages/frontend/src/modules/home/components/subcategories-marquee/index.tsx
@@ -21,12 +21,12 @@ function SubcategoriesMarquee() {
   return (
     <div className="mt-4 w-screen tablet:mt-6 desktop:mt-8 hd:mt-10">
       {!isLoading && subcategoriesWithLinks.length > 0 && (
-        <Marquee pauseOnHover pauseOnClick autoFill>
+        <Marquee pauseOnHover pauseOnClick autoFill className="pb-4">
           {subcategoriesWithLinks?.map((subcategory) => (
             <Link
               key={subcategory.id}
               href={subcategory.link}
-              className="px-6 py-4 prose-h3-small font-normal text-neutral-900 hover:text-red-400 hover:underline desktop:px-10 desktop:prose-h2-small desktop:font-normal"
+              className="px-4 py-4 prose-h3-small font-normal! text-neutral-900 hover:text-red-400 hover:underline desktop:prose-h2-small desktop:font-normal"
             >
               #{subcategory.name}
             </Link>

--- a/packages/frontend/src/modules/home/components/topic-slider/index.tsx
+++ b/packages/frontend/src/modules/home/components/topic-slider/index.tsx
@@ -40,7 +40,7 @@ function TopicSlider({ topics }: TopicSliderProp) {
             loop
             rewind
             slidesPerView={1}
-            spaceBetween={20}
+            // spaceBetween={20}
             centeredSlides
             breakpoints={{
               768: {
@@ -76,12 +76,12 @@ function TopicSlider({ topics }: TopicSliderProp) {
           <SwiperButton
             variant="prev"
             onClick={() => swiperRef.current?.slidePrev()}
-            className="absolute top-26 left-0 z-[900] -translate-y-1/2 scale-[0.625] tablet:top-42 tablet:left-[calc(50%-320px)] tablet:-translate-x-1/2 desktop:top-56 desktop:left-[calc(50%-416px)] desktop:scale-100 hd:top-64 hd:left-[calc(50%-544px)] hd:scale-100"
+            className="absolute top-26 left-0 z-[900] -translate-y-1/2 scale-[0.625] tablet:top-42 tablet:left-[calc(50%-320px)] tablet:-translate-x-1/2 desktop:top-48 desktop:left-[calc(50%-416px)] desktop:scale-100 hd:top-64 hd:left-[calc(50%-544px)] hd:scale-100"
           />
           <SwiperButton
             variant="next"
             onClick={() => swiperRef.current?.slideNext()}
-            className="absolute top-26 right-0 z-[900] -translate-y-1/2 scale-[0.625] tablet:top-42 tablet:right-[calc(50%-320px)] tablet:translate-x-1/2 desktop:top-56 desktop:right-[calc(50%-416px)] desktop:scale-100 hd:top-64 hd:right-[calc(50%-544px)] hd:scale-100"
+            className="absolute top-26 right-0 z-[900] -translate-y-1/2 scale-[0.625] tablet:top-42 tablet:right-[calc(50%-320px)] tablet:translate-x-1/2 desktop:top-48 desktop:right-[calc(50%-416px)] desktop:scale-100 hd:top-64 hd:right-[calc(50%-544px)] hd:scale-100"
           />
         </div>
         <WaveIllustrations />
@@ -90,28 +90,28 @@ function TopicSlider({ topics }: TopicSliderProp) {
           alt="topic baodaozai illustration"
           width={200}
           height={100}
-          className="absolute right-4 bottom-10 z-4 tablet:hidden"
+          className="absolute right-2 bottom-10 z-4 tablet:hidden"
         />
         <Image
           src="/assets/images/home/topic_baodaozai_illustration_m.svg"
           alt="topic baodaozai illustration"
           width={256}
           height={128}
-          className="absolute bottom-0 left-22 z-4 hidden tablet:block desktop:hidden"
+          className="absolute bottom-0 left-1/2 z-4 hidden -translate-x-[calc(50%+168px)] tablet:block desktop:hidden"
         />
         <Image
           src="/assets/images/home/topic_baodaozai_illustration_l.svg"
           alt="topic baodaozai illustration"
           width={336}
           height={168}
-          className="absolute bottom-0 left-34 z-4 hidden desktop:block hd:hidden"
+          className="absolute bottom-0 left-1/2 z-4 hidden -translate-x-[calc(50%+208px)] desktop:block hd:hidden"
         />
         <Image
           src="/assets/images/home/topic_baodaozai_illustration_l.svg"
           alt="topic baodaozai illustration"
           width={336}
           height={168}
-          className="absolute bottom-0 left-[max(232px,10vw)] z-4 hidden hd:block"
+          className="absolute bottom-0 left-1/2 z-4 hidden -translate-x-[calc(50%+320px)] hd:block"
         />
       </div>
     </div>

--- a/packages/frontend/src/modules/home/components/topic-slider/topic-card.tsx
+++ b/packages/frontend/src/modules/home/components/topic-slider/topic-card.tsx
@@ -14,14 +14,14 @@ type TopicCardProp = {
 
 function TopicCard({ url, image, title, subtitle }: TopicCardProp) {
   return (
-    <div className="relative flex h-full w-[calc(100%-48px)] flex-col overflow-hidden rounded-[40px] bg-neutral-white px-5 pt-5 pb-20 tablet:w-160 tablet:flex-row tablet:gap-6 tablet:rounded-[64px] tablet:px-12 tablet:py-10 desktop:w-208 desktop:gap-10 desktop:rounded-[80px] desktop:px-14 desktop:py-18 hd:w-272 hd:rounded-[96px] hd:px-16 hd:py-24">
+    <div className="relative mx-auto flex h-full w-[calc(100%-48px)] flex-col overflow-hidden rounded-[40px] bg-neutral-white px-5 pt-5 pb-20 tablet:w-160 tablet:flex-row tablet:gap-6 tablet:rounded-[64px] tablet:px-12 tablet:py-10 desktop:w-208 desktop:gap-10 desktop:rounded-[80px] desktop:px-14 desktop:py-18 hd:w-272 hd:rounded-[96px] hd:px-16 hd:py-24">
       <ImageWithFallback
         className="aspect-[287/162] w-full rounded-[24px] object-cover tablet:h-[171px] tablet:w-[304px] desktop:h-[234px] desktop:w-[416px] desktop:rounded-[32px] hd:h-[300px] hd:w-[533px]"
         src={image}
       />
 
-      <div className="mt-5 flex flex-1 flex-col gap-2 tablet:mt-0 desktop:gap-3">
-        <div className="flex items-center gap-2 desktop:gap-3">
+      <div className="mt-5 flex flex-1 flex-col tablet:mt-0 tablet:h-59">
+        <div className="mb-2 flex items-center gap-2 desktop:mb-3 desktop:gap-3">
           <Image
             className="desktop:hidden"
             src={'/assets/images/home/topic_icon.svg'}
@@ -43,13 +43,19 @@ function TopicCard({ url, image, title, subtitle }: TopicCardProp) {
           </h6>
         </div>
 
-        <h3 className="prose-h3-small text-neutral-900 desktop:prose-h4-large">
+        <h3 className="mb-2 line-clamp-2 prose-h3-small font-swei! text-neutral-900 desktop:mb-3 desktop:prose-h4-large hd:prose-h3-large">
           {title}
         </h3>
+        <p className="line-clamp-2 prose-p1-bold desktop:prose-h6-large">
+          {subtitle}
+        </p>
 
-        <p className="mb-4 desktop:prose-p1">{subtitle}</p>
-
-        <Button variant="secondary" size={44} asChild className="mt-auto w-max">
+        <Button
+          variant="secondary"
+          size={44}
+          asChild
+          className="mt-4 w-max desktop:mt-6 hd:mt-auto"
+        >
           <Link href={url}>了解更多</Link>
         </Button>
       </div>

--- a/packages/frontend/src/modules/home/components/topic-slider/wave-illustrations.tsx
+++ b/packages/frontend/src/modules/home/components/topic-slider/wave-illustrations.tsx
@@ -17,27 +17,27 @@ function WaveIllustrations() {
           src="/assets/images/home/topic_wave_front_s.svg"
           alt="topic wave front"
           fill
-          className="object-cover object-center"
+          className="object-cover object-top"
           sizes="100vw"
         />
       </div>
       <div
-        className="absolute bottom-0 left-1/2 z-1 hidden h-[120px] w-full -translate-x-1/2 bg-[url(/assets/images/home/topic_wave_back_m.svg)] bg-[length:768px_120px] bg-center bg-repeat-x tablet:block desktop:hidden"
+        className="absolute bottom-0 left-1/2 z-1 hidden h-[108px] w-full -translate-x-1/2 bg-[url(/assets/images/home/topic_wave_back_m.svg)] bg-[length:768px_108px] bg-center bg-repeat-x tablet:block desktop:hidden"
         aria-label="topic wave back"
         role="presentation"
       />
       <div
-        className="absolute -bottom-2 left-1/2 z-3 hidden h-[120px] w-full -translate-x-1/2 bg-[url(/assets/images/home/topic_wave_front_m.svg)] bg-[length:768px_120px] bg-center bg-repeat-x tablet:block desktop:hidden"
+        className="absolute -bottom-2 left-1/2 z-3 hidden h-[108px] w-full -translate-x-1/2 bg-[url(/assets/images/home/topic_wave_front_m.svg)] bg-[length:768px_108px] bg-center bg-repeat-x tablet:block desktop:hidden"
         aria-label="topic wave front"
         role="presentation"
       />
       <div
-        className="absolute bottom-0 left-1/2 z-1 hidden h-[160px] w-full -translate-x-1/2 bg-[url(/assets/images/home/topic_wave_back_l.svg)] bg-[length:1024px_160px] bg-center bg-repeat-x desktop:block hd:hidden"
+        className="absolute bottom-0 left-1/2 z-1 hidden h-[144px] w-full -translate-x-1/2 bg-[url(/assets/images/home/topic_wave_back_l.svg)] bg-[length:1024px_144px] bg-center bg-repeat-x desktop:block hd:hidden"
         aria-label="topic wave back"
         role="presentation"
       />
       <div
-        className="absolute -bottom-2 left-1/2 z-3 hidden h-[160px] w-full -translate-x-1/2 bg-[url(/assets/images/home/topic_wave_front_l.svg)] bg-[length:1024px_160px] bg-center bg-repeat-x desktop:block hd:hidden"
+        className="absolute -bottom-2 left-1/2 z-3 hidden h-[144px] w-full -translate-x-1/2 bg-[url(/assets/images/home/topic_wave_front_l.svg)] bg-[length:1024px_144px] bg-center bg-repeat-x desktop:block hd:hidden"
         aria-label="topic wave front"
         role="presentation"
       />


### PR DESCRIPTION
## Summary

Fixes home page layout and styling defects: grid spacing, card radii and aspect ratios, typography (including font-swei!), scroll/padding alignment, and topic slider / wave positioning so the UI matches design across breakpoints.

## Changes

- **article-grid**: Add responsive horizontal gaps (tablet:gap-x-8, desktop:gap-x-12, hd:gap-x-14).
- **category-post-cards**: Card rounded-[30px], image aspect-video, hover scale-120; container padding/gaps and "看全部" button margins updated.
- **editor-recommendation**: Index typography (prose-hh4-small / prose-h4-large), image aspect-video + rounded-[20px], scroll area with cn() and scrollbar-none, nav button icon alignment, font-swei! on heading; padding/layout tweaks.
- **latest-articles**: Explicit bottom padding per breakpoint, font-swei! on heading, hd:px-14.
- **subcategories-marquee**: Illustration hd:right-[calc(max(120px,50vw-600px))], marquee pb-4, link padding and font-normal!.
- **topic-slider**: Commented spaceBetween={20}, baodaozai positions (translate-based centering), wave heights 120→108 / 160→144 and object-top.
- **topic-card**: mx-auto, content height tablet:h-59, title/subtitle line-clamp-2 and typography, button margin adjustments.

## Additional Notes

Layout and typography updates only; no API or data changes. Recommend checking home page at tablet, desktop, and hd breakpoints for spacing and alignment.

## Screenshot(s)

## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/defect-2fc8dbdca93280c68f5ae60f633b8b3e?source=copy_link)

