### PR TITLE
fix(frontend): fix article page UI defects and layout issues

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/cms-core",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "",
   "main": "lib/index.js",
   "types": "src/index.ts",
@@ -36,7 +36,7 @@
     "@keystone-ui/button": "^7.0.2",
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",
-    "@kids-reporter/draft-editor": "^1.0.24",
+    "@kids-reporter/draft-editor": "^1.0.25",
     "@twreporter/errors": "^1.1.1",
     "axios": "^0.26.0",
     "draft-convert": "^2.1.12",

--- a/packages/draft-editor/package.json
+++ b/packages/draft-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/draft-editor",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -29,7 +29,7 @@
     "@keystone-ui/button": "^7.0.2",
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",
-    "@kids-reporter/draft-renderer": "^1.0.20",
+    "@kids-reporter/draft-renderer": "^1.0.21",
     "@twreporter/errors": "^1.1.2",
     "axios": "^1.12.2",
     "draft-js": "^0.11.7"

--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/draft-renderer",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/src/block-render-maps/article-content.tsx
+++ b/packages/draft-renderer/src/block-render-maps/article-content.tsx
@@ -83,13 +83,15 @@ export const Atomic = styled.div`
 
   ${mediaQuery.desktopAbove} {
     div:has(+ div [data-image-block-caption-alignment='default'])
-      [data-image-block-caption-alignment='default'] {
+      [data-image-block-caption-alignment='default'],
+    [data-image-slideshow-caption-alignment='default'] {
       position: relative !important;
     }
   }
   ${mediaQuery.largeOnly} {
     div:has(+ div [data-image-block-caption-alignment='default'])
-      [data-image-block-caption-alignment='default'] {
+      [data-image-block-caption-alignment='default'],
+    [data-image-slideshow-caption-alignment='default'] {
       position: relative !important;
     }
   }

--- a/packages/draft-renderer/src/block-render-maps/article-content.tsx
+++ b/packages/draft-renderer/src/block-render-maps/article-content.tsx
@@ -20,10 +20,7 @@ export const Paragraph = styled.div`
   }
 
   > div[data-block='true'] {
-    margin-bottom: 60px;
-    ${mediaQuery.smallOnly} {
-      margin-bottom: 40px;
-    }
+    margin-bottom: 38px;
   }
 `
 
@@ -56,7 +53,7 @@ export const Heading = styled.div`
 export const List = styled.ol`
   width: 100%;
   max-width: 512px;
-  margin: 0 auto 60px auto;
+  margin: 0 auto 38px auto;
   list-style-position: inside;
 
   > li > div {
@@ -64,7 +61,7 @@ export const List = styled.ol`
   }
 
   ${mediaQuery.smallOnly} {
-    margin-bottom: 40px;
+    margin-bottom: 38px;
     padding-left: 24px;
     padding-right: 24px;
   }
@@ -83,11 +80,24 @@ export const Atomic = styled.div`
   > figure {
     margin: 0;
   }
+
+  ${mediaQuery.desktopAbove} {
+    div:has(+ div [data-image-block-caption-alignment='default'])
+      [data-image-block-caption-alignment='default'] {
+      position: relative !important;
+    }
+  }
+  ${mediaQuery.largeOnly} {
+    div:has(+ div [data-image-block-caption-alignment='default'])
+      [data-image-block-caption-alignment='default'] {
+      position: relative !important;
+    }
+  }
 `
 
 const _blockRenderMap = Immutable.Map({
   atomic: {
-    element: 'figure',
+    element: 'div',
     wrapper: <Atomic />,
   },
   'header-two': {

--- a/packages/draft-renderer/src/block-renderers/blockquote.tsx
+++ b/packages/draft-renderer/src/block-renderers/blockquote.tsx
@@ -8,7 +8,7 @@ const BorderLeftContainer = styled.blockquote`
 `
 
 const BorderLeftLine = styled.div`
-  width: 3px;
+  width: 4px;
   border-radius: 10px;
   background-color: #c6c6c6;
   align-self: stretch;
@@ -79,10 +79,10 @@ export function QuoteLeftBlockquote({ text }: { text: string }) {
 
 const ArticleBodyContainer = styled.div`
   max-width: 512px;
-  margin: 0 auto 60px auto;
+  margin: 0 auto 38px auto;
 
   ${mediaQuery.smallOnly} {
-    margin-bottom: 40px;
+    margin-bottom: 38px;
   }
 
   ${mediaQuery.largeOnly} {

--- a/packages/draft-renderer/src/block-renderers/divider.tsx
+++ b/packages/draft-renderer/src/block-renderers/divider.tsx
@@ -8,7 +8,7 @@ const Hr = styled.hr`
   border-top: 3px solid ${({ theme }) => getColorHex(theme?.themeColor)};
   width: 385px;
   height: 3px;
-  margin: 40px auto 60px auto;
+  margin: 38px auto 38px auto;
 
   ${mediaQuery.smallOnly} {
     width: 55%;

--- a/packages/draft-renderer/src/block-renderers/image-block.tsx
+++ b/packages/draft-renderer/src/block-renderers/image-block.tsx
@@ -58,7 +58,7 @@ const FigureCaption = styled.figcaption<{ $alignment?: string }>`
           ${mediaQuery.mediumAbove} {
             max-width: 340px;
             margin-left: auto;
-            margin-right: 0px;
+            margin-right: 32px;
           }
 
           ${mediaQuery.desktopAbove} {
@@ -79,6 +79,14 @@ const FigureCaption = styled.figcaption<{ $alignment?: string }>`
         `
       case 'paragraph-width':
         return `
+          ${mediaQuery.smallOnly} {
+            width: 100%;
+            text-align: left;
+          }
+          ${mediaQuery.mediumAbove} {
+            width: 100%;
+            text-align: left;
+          }
           ${mediaQuery.desktopAbove} {
             position: absolute;
             left: calc(100% + 32px);
@@ -133,7 +141,9 @@ const FigureCaption = styled.figcaption<{ $alignment?: string }>`
 
 const Img = styled.img<{ $isDesktopAndAbove: boolean }>`
   width: 100%;
-  object-fit: contain;
+  height: 100%;
+  display: block;
+  object-fit: cover;
   ${(props) => (props.$isDesktopAndAbove ? 'cursor: zoom-in;' : '')};
 `
 

--- a/packages/draft-renderer/src/block-renderers/image-block.tsx
+++ b/packages/draft-renderer/src/block-renderers/image-block.tsx
@@ -205,7 +205,13 @@ function ImageBlockInner({ className = '', data }: ImageBlockProps) {
         }
       />
       {desc && (
-        <FigureCaption $alignment={data.alignment}>{desc}</FigureCaption>
+        <FigureCaption
+          data-image-block-caption="true"
+          data-image-block-caption-alignment={data.alignment}
+          $alignment={data.alignment}
+        >
+          {desc}
+        </FigureCaption>
       )}
     </Figure>
   )
@@ -253,6 +259,7 @@ const ArticleBodyContainer = styled.div<{ $alignment?: string }>`
           ${mediaQuery.largeOnly} {
             max-width: 1000px;
           }
+
         `
       case 'paragraph-width':
         return `
@@ -305,7 +312,11 @@ export function ImageInArticleBody({
   data,
 }: ImageBlockInArticleBodyProps) {
   return (
-    <ArticleBodyContainer $alignment={data.alignment} className={className}>
+    <ArticleBodyContainer
+      data-image-block-container="true"
+      $alignment={data.alignment}
+      className={className}
+    >
       <ImageBlock data={data} />
     </ArticleBodyContainer>
   )

--- a/packages/draft-renderer/src/block-renderers/image-link.tsx
+++ b/packages/draft-renderer/src/block-renderers/image-link.tsx
@@ -143,8 +143,9 @@ const FigureCaption = styled.figcaption<{ $alignment?: string }>`
 `
 
 const Img = styled.img<{ $isDesktopAndAbove: boolean }>`
+  display: block;
   width: 100%;
-  object-fit: contain;
+  object-fit: cover;
   ${(props) => (props.$isDesktopAndAbove ? 'cursor: zoom-in;' : '')};
 `
 

--- a/packages/draft-renderer/src/block-renderers/slideshow-block.tsx
+++ b/packages/draft-renderer/src/block-renderers/slideshow-block.tsx
@@ -33,11 +33,11 @@ const mockup = {
   },
   desktop: {
     container: {
-      width: 788, // px
+      width: 768, // px
     },
     slide: {
-      width: 696, // px
-      height: 391, // px
+      width: 676, // px
+      height: 370, // px
       paddingRight: 4, // px
     },
     offset: {
@@ -46,11 +46,11 @@ const mockup = {
   },
   hd: {
     container: {
-      width: 1034, // px
+      width: 1000, // px
     },
     slide: {
-      width: 944, // px
-      height: 531, // px
+      width: 910, // px
+      height: 500, // px
       paddingRight: 4, // px
     },
     offset: {
@@ -300,7 +300,7 @@ const SlideshowFlexBox = styled.div`
 
   ${mediaQuery.desktopAbove} {
     width: ${mockup.desktop.container.width}px;
-    transform: translateX(70px);
+    transform: translateX(80px);
   }
 
   ${mediaQuery.largeOnly} {
@@ -587,7 +587,7 @@ export function SlideshowBlock({ className = '', data }: SlideshowBlockProps) {
             <NextArrowSvg />
           </IconButton>
         </PrevNextSection>
-        <CaptionContainer>
+        <CaptionContainer data-image-slideshow-caption-alignment="default">
           <SequenceNumberContainer>
             <ImageSequenceNumber>
               <ImageNumber>{curSlideIndex + 1}</ImageNumber>

--- a/packages/draft-renderer/src/entity-decorators/link-decorator.tsx
+++ b/packages/draft-renderer/src/entity-decorators/link-decorator.tsx
@@ -10,6 +10,7 @@ const LinkWrapper = styled.a`
   transition: text-decoration-color 0.1s ease-in;
   cursor: pointer;
   text-decoration-color: #c6c6c6;
+  text-underline-offset: 3px;
 
   &:hover {
     text-decoration-color: #27b3f5;

--- a/packages/frontend/src/modules/article/components/article-summary.tsx
+++ b/packages/frontend/src/modules/article/components/article-summary.tsx
@@ -2,6 +2,7 @@ import { ArticleIntroductionDraftRenderer } from '@kids-reporter/draft-renderer'
 import { cn } from '@kids-reporter/routing-ui'
 import { RawDraftContentState } from 'draft-js'
 import Link from 'next/link'
+import { useEffect, useState } from 'react'
 
 import Divider from '@/components/divider'
 import { FontSizeLevel } from '@/constants'
@@ -38,6 +39,10 @@ function ArticleSummary({
   authors,
   fontSizeLevel,
 }: ArticleSummaryProps) {
+  const [isMounted, setIsMounted] = useState(false)
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
   return (
     <div className="relative mx-4 mt-10 mb-10 flex flex-col gap-4 rounded-3xl bg-neutral-100 p-6 tablet:mx-[93px] tablet:mt-20 tablet:mb-15 tablet:gap-6 tablet:p-9 desktop:p-12">
       <div className="flex items-center justify-between gap-6">
@@ -61,7 +66,7 @@ function ArticleSummary({
           ]
         )}
       >
-        {content && (
+        {content && isMounted && (
           <ArticleIntroductionDraftRenderer rawContentState={content} />
         )}
       </div>

--- a/packages/frontend/src/modules/article/components/authors.tsx
+++ b/packages/frontend/src/modules/article/components/authors.tsx
@@ -36,16 +36,16 @@ function AuthorCard({ author }: { author: Author }) {
     <>
       <div
         onClick={handleClick}
-        className="group relative block min-w-62 cursor-pointer snap-start [perspective:1000px] desktop:hidden"
+        className="group relative block min-w-62 cursor-pointer snap-start perspective-[1000px] desktop:hidden"
         ref={ref}
       >
         <div
           className={cn(
-            'relative h-[270px] w-full transition-transform duration-500 [transform-style:preserve-3d]',
-            isClicked && '[transform:rotateY(180deg)]'
+            'relative h-[270px] w-full transition-transform duration-500 transform-3d',
+            isClicked && 'transform-[rotateY(180deg)]'
           )}
         >
-          <div className="absolute inset-0 flex [transform:rotateY(0deg)] flex-col items-center justify-center gap-5 rounded-[20px] border-2 border-neutral-200 bg-neutral-white p-6 [backface-visibility:hidden]">
+          <div className="absolute inset-0 flex transform-[rotateY(0deg)] flex-col items-center justify-center gap-5 rounded-[20px] border-2 border-neutral-200 bg-neutral-white p-6 backface-hidden">
             <div className="h-30 w-30 overflow-hidden rounded-full">
               <Image
                 className="h-full w-full object-cover"
@@ -67,7 +67,7 @@ function AuthorCard({ author }: { author: Author }) {
             </div>
           </div>
 
-          <div className="absolute inset-0 flex h-[270px] [transform:rotateY(180deg)] flex-col gap-4 rounded-[20px] bg-neutral-300 p-6 [backface-visibility:hidden]">
+          <div className="absolute inset-0 flex h-[270px] transform-[rotateY(180deg)] flex-col gap-4 rounded-[20px] bg-neutral-300 p-6 backface-hidden">
             <div className="flex flex-1 flex-col gap-1">
               <span className="prose-p1-bold text-neutral-900">
                 {author.name}｜{roleText}
@@ -130,7 +130,7 @@ function AuthorCard({ author }: { author: Author }) {
           </div>
 
           <div className="flex justify-end">
-            <div className="flex h-11 w-11 items-center justify-center rounded-full bg-neutral-white">
+            <div className="flex h-11 w-11 items-center justify-center rounded-full bg-neutral-white transition-colors duration-200 hover:bg-red-500 hover:text-neutral-white">
               <ArrowRight />
             </div>
           </div>
@@ -163,11 +163,11 @@ function Authors({ authors }: AuthorsProp) {
   }, [])
 
   return (
-    <div className="flex flex-col gap-6 pt-14 tablet:pt-20">
+    <div className="flex flex-col gap-6 pt-14 tablet:gap-8 tablet:pt-20 desktop:gap-10">
       <div className="mx-auto flex w-[min(100vw,1200px)] items-center gap-2 px-6 tablet:px-8 desktop:px-12 hd:px-14">
         <OurTeamIcon className="desktop:hidden" />
         <OurTeamIconLarge className="hidden desktop:block" />
-        <h2 className="mr-auto prose-h2-small font-swei text-neutral-900 desktop:prose-h2-large">
+        <h2 className="mr-auto prose-h2-small font-swei! text-neutral-900 desktop:prose-h2-large">
           誰幫我們完成這篇文章
         </h2>
         <Button

--- a/packages/frontend/src/modules/article/components/popular-keywords.tsx
+++ b/packages/frontend/src/modules/article/components/popular-keywords.tsx
@@ -10,12 +10,12 @@ type PopularKeywordsProp = {
 
 function PopularKeywords({ keywords }: PopularKeywordsProp) {
   return (
-    <div className="mt-14 flex w-[min(100vw,512px)] flex-col items-start gap-5 px-6 tablet:mt-20 tablet:px-0 hd:w-[584px]">
+    <div className="-mt-1 flex w-[min(100vw,512px)] flex-col items-start gap-5 px-6 tablet:mt-4 tablet:px-0 hd:w-[584px]">
       <div className="flex flex-row items-center gap-2">
         <PopularKeywordsIcon />
         <h5 className="prose-h5-small desktop:prose-h5-large">常用關鍵字</h5>
       </div>
-      <ul className="flex flex-wrap gap-2.5">
+      <ul className="flex flex-wrap gap-x-2.5 gap-y-3.5">
         {keywords.map((keyword) => (
           <li key={keyword.name} className="h-max list-none">
             <Link

--- a/packages/frontend/src/modules/article/components/post-renderer.tsx
+++ b/packages/frontend/src/modules/article/components/post-renderer.tsx
@@ -4,6 +4,7 @@ import 'react-loading-skeleton/dist/skeleton.css'
 import { ArticleBodyDraftRenderer } from '@kids-reporter/draft-renderer'
 import { cn } from '@kids-reporter/routing-ui'
 import { RawDraftContentState } from 'draft-js'
+import { useEffect, useState } from 'react'
 
 import { FontSizeLevel, STICKY_HEADER_HEIGHT } from '@/constants'
 
@@ -31,6 +32,10 @@ type PostProp = {
 
 function PostRenderer({ content }: PostProp) {
   const { onImageModalOpen, fontSize } = useArticleContext()
+  const [isMounted, setIsMounted] = useState(false)
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
   return (
     <div
       className={cn(
@@ -41,14 +46,16 @@ function PostRenderer({ content }: PostProp) {
         ]
       )}
     >
-      <ArticleBodyDraftRenderer
-        rawContentState={trimEmptyBlocks(content)}
-        onImageModalOpen={onImageModalOpen}
-        initiallyScrollTo={
-          typeof window !== 'undefined' ? window.location.hash : undefined
-        }
-        offsetTop={STICKY_HEADER_HEIGHT}
-      />
+      {isMounted && (
+        <ArticleBodyDraftRenderer
+          rawContentState={trimEmptyBlocks(content)}
+          onImageModalOpen={onImageModalOpen}
+          initiallyScrollTo={
+            typeof window !== 'undefined' ? window.location.hash : undefined
+          }
+          offsetTop={STICKY_HEADER_HEIGHT}
+        />
+      )}
     </div>
   )
 }

--- a/packages/frontend/src/modules/article/components/post-renderer.tsx
+++ b/packages/frontend/src/modules/article/components/post-renderer.tsx
@@ -13,21 +13,16 @@ import {
 } from '../constants'
 import { useArticleContext } from '../context'
 
-function trimFinalEmptyBlocks(raw: RawDraftContentState): RawDraftContentState {
+function trimEmptyBlocks(raw: RawDraftContentState): RawDraftContentState {
   const { blocks, entityMap } = raw
   if (blocks.length === 0) return raw
 
-  let end = blocks.length
-  while (
-    end > 0 &&
-    blocks[end - 1].type === 'unstyled' &&
-    blocks[end - 1].text.trim() === ''
-  ) {
-    end--
-  }
-  if (end === blocks.length) return raw
+  const filtered = blocks.filter(
+    (block) => !(block.type === 'unstyled' && block.text.trim() === '')
+  )
+  if (filtered.length === blocks.length) return raw
 
-  return { blocks: blocks.slice(0, end), entityMap }
+  return { blocks: filtered, entityMap }
 }
 
 type PostProp = {
@@ -47,7 +42,7 @@ function PostRenderer({ content }: PostProp) {
       )}
     >
       <ArticleBodyDraftRenderer
-        rawContentState={trimFinalEmptyBlocks(content)}
+        rawContentState={trimEmptyBlocks(content)}
         onImageModalOpen={onImageModalOpen}
         initiallyScrollTo={
           typeof window !== 'undefined' ? window.location.hash : undefined

--- a/packages/frontend/src/modules/article/components/related-articles.tsx
+++ b/packages/frontend/src/modules/article/components/related-articles.tsx
@@ -54,13 +54,13 @@ function RelatedArticles({
 
   return (
     <div className="mx-auto flex w-full max-w-300 flex-col items-center justify-center px-6 py-10 tablet:px-8 tablet:py-12 desktop:px-12 desktop:py-18 hd:px-14 hd:py-24">
-      <div className="mb-6 flex w-full flex-col items-start justify-between gap-6 tablet:flex-row tablet:items-center">
+      <div className="mb-6 flex w-full flex-col items-start justify-between gap-6 tablet:mb-8 tablet:flex-row tablet:items-center desktop:mb-10">
         <div className="flex items-center gap-2">
           <div className="flex size-11 items-center justify-center desktop:size-16">
             <RelatedPostsIcon className="desktop:hidden" />
             <RelatedPostsIconLarge className="hidden desktop:block" />
           </div>
-          <span className="prose-h2-small font-swei text-neutral-900 desktop:prose-h2-large">
+          <span className="prose-h2-small font-swei! text-neutral-900 desktop:prose-h2-large">
             相關文章
           </span>
         </div>

--- a/packages/frontend/src/modules/article/components/title-hero/hero-image.tsx
+++ b/packages/frontend/src/modules/article/components/title-hero/hero-image.tsx
@@ -39,7 +39,7 @@ function HeroImage({
   }
 
   return (
-    <figure className="mx-auto pt-10 tablet:mx-8 hd:w-[1058px]">
+    <figure className="mx-auto pt-10 hd:w-[1058px]">
       <div
         className="relative inline-flex w-full overflow-hidden hd:!aspect-video"
         style={{
@@ -55,7 +55,8 @@ function HeroImage({
         {image && (
           <ImageWithFallback
             className={cn(
-              'max-w-full object-contain',
+              'max-w-full object-fill',
+
               isLoading && 'opacity-0'
             )}
             {...commonImgProps}
@@ -77,7 +78,7 @@ function HeroImage({
       </div>
       <figcaption
         className={cn(
-          'mx-4 mt-1 max-w-[1058px] pt-2.5 text-center prose-p2 text-neutral-700',
+          'mx-4 mt-1 max-w-[1058px] pt-2.5 text-center prose-p2 text-neutral-700 tablet:mx-8',
           fontSizeLevel === FontSizeLevel.LARGE && 'text-[17.5px]'
         )}
       >

--- a/packages/frontend/src/modules/article/components/title-hero/index.tsx
+++ b/packages/frontend/src/modules/article/components/title-hero/index.tsx
@@ -75,7 +75,7 @@ function TitleHero({
           )}
           <h1
             className={cn(
-              'prose-h2-small text-neutral-900 desktop:prose-h2-large',
+              'prose-h2-small font-swei! text-neutral-900 desktop:prose-h2-large',
               fontSizeLevel === FontSizeLevel.LARGE &&
                 'text-[35px] desktop:text-[50px]'
             )}

--- a/packages/frontend/src/modules/article/index.tsx
+++ b/packages/frontend/src/modules/article/index.tsx
@@ -234,7 +234,7 @@ const ArticleModule = ({
           }}
         >
           <Toolbar topicURL={topicURL} postSlug={slug} />
-          <div className="flex w-full max-w-256 flex-col items-center desktop:mx-auto desktop:px-12 hd:max-w-344">
+          <div className="flex w-full max-w-256 flex-col items-center desktop:mx-auto desktop:px-12 hd:max-w-354.5">
             {isDesktop && (
               <ImageModal
                 isOpen={isImgModalOpen}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5030,7 +5030,7 @@ __metadata:
     "@keystone-ui/button": "npm:^7.0.2"
     "@keystone-ui/fields": "npm:^7.2.0"
     "@keystone-ui/modals": "npm:^6.0.3"
-    "@kids-reporter/draft-editor": "npm:^1.0.24"
+    "@kids-reporter/draft-editor": "npm:^1.0.25"
     "@twreporter/errors": "npm:^1.1.1"
     axios: "npm:^0.26.0"
     draft-convert: "npm:^2.1.12"
@@ -5094,7 +5094,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/draft-editor@npm:^1.0.24, @kids-reporter/draft-editor@workspace:packages/draft-editor":
+"@kids-reporter/draft-editor@npm:^1.0.25, @kids-reporter/draft-editor@workspace:packages/draft-editor":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/draft-editor@workspace:packages/draft-editor"
   dependencies:
@@ -5107,7 +5107,7 @@ __metadata:
     "@keystone-ui/button": "npm:^7.0.2"
     "@keystone-ui/fields": "npm:^7.2.0"
     "@keystone-ui/modals": "npm:^6.0.3"
-    "@kids-reporter/draft-renderer": "npm:^1.0.20"
+    "@kids-reporter/draft-renderer": "npm:^1.0.21"
     "@twreporter/errors": "npm:^1.1.2"
     axios: "npm:^1.12.2"
     babel-loader: "npm:^8.3.0"
@@ -5126,7 +5126,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/draft-renderer@npm:^1.0.13, @kids-reporter/draft-renderer@npm:^1.0.20, @kids-reporter/draft-renderer@workspace:packages/draft-renderer":
+"@kids-reporter/draft-renderer@npm:^1.0.13, @kids-reporter/draft-renderer@npm:^1.0.21, @kids-reporter/draft-renderer@workspace:packages/draft-renderer":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/draft-renderer@workspace:packages/draft-renderer"
   dependencies:


### PR DESCRIPTION
## Summary

Fix multiple UI defects on the article page, including layout spacing, image rendering, hydration issues, and styling inconsistencies across both the `draft-renderer` and `frontend` packages.

## Changes

### `packages/draft-renderer`
- Standardize paragraph, list, blockquote, and divider bottom margins to `38px` for consistent spacing
- Change image `object-fit` from `contain` to `cover` and add `display: block` in image-block and image-link renderers
- Add responsive caption alignment styles for image blocks and slideshows with data attributes
- Adjust slideshow container/slide dimensions for desktop and HD breakpoints
- Update blockquote left border width from `3px` to `4px`
- Add `text-underline-offset: 3px` to link decorator
- Change atomic block wrapper element from `<figure>` to `<div>`
- Fix image block caption `margin-right` for medium screens with default alignment

### `packages/frontend`
- Add `isMounted` guard in `PostRenderer` and `ArticleSummary` to prevent SSR hydration mismatch with draft renderer
- Rename `trimFinalEmptyBlocks` to `trimEmptyBlocks` to filter all empty unstyled blocks (not just trailing ones)
- Fix Tailwind CSS classes in author cards (`backface-visibility`, `transform`, hover effects)
- Update section heading font class to `font-swei!` for title hero, related articles, and authors
- Adjust spacing and gaps in popular keywords, related articles, and authors sections
- Fix hero image `object-fit` to `fill` and adjust figcaption responsive margins
- Update article container max-width from `344` to `354.5` for HD breakpoint

## Additional Notes

- The hydration fix wraps draft renderers in a client-only guard to avoid SSR/CSR mismatch caused by `window` usage
- The empty block trimming now removes all empty unstyled blocks from article content instead of only trailing ones

## Screenshot(s)

## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/defect-UI-2f68dbdca932807ba99ccbbcddc48061?source=copy_link)