### PR TITLE
fix(frontend): fix idea hub navigation button defects and layout issues

### DIFF
--- a/packages/frontend/src/modules/idea-hub/all-answers/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/all-answers/index.tsx
@@ -124,11 +124,17 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
     const container = scrollContainerRef.current
     if (!container) return
 
+    const handleUpdate = () => updateScrollEdges()
+
     updateScrollEdges()
 
-    container.addEventListener('scroll', updateScrollEdges, { passive: true })
+    container.addEventListener('scroll', handleUpdate, { passive: true })
+    const resizeObserver = new ResizeObserver(handleUpdate)
+    resizeObserver.observe(container)
+
     return () => {
-      container.removeEventListener('scroll', updateScrollEdges)
+      container.removeEventListener('scroll', handleUpdate)
+      resizeObserver.disconnect()
     }
   }, [updateScrollEdges])
 

--- a/packages/frontend/src/modules/idea-hub/all-answers/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/all-answers/index.tsx
@@ -4,7 +4,7 @@ import {
   PostEssayAnswerOrderByInput,
   PostOrderByInput,
 } from '__generated__/types'
-import { memo, useEffect, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
 import { DEFAULT_PAGE_ITEM_COUNT } from '@/api-utils/react-query/constants'
@@ -29,6 +29,8 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
   const hasShownToastRef = useRef(false)
   const showNavBarRef = useRef(false)
   const [showNavBar, setShowNavBar] = useState(false)
+  const [isAtStart, setIsAtStart] = useState(true)
+  const [isAtEnd, setIsAtEnd] = useState(false)
   const {
     data: posts,
     isLoading,
@@ -110,6 +112,26 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
     }
   }, [])
 
+  const updateScrollEdges = useCallback(() => {
+    const container = scrollContainerRef.current
+    if (!container) return
+    const { scrollLeft, clientWidth, scrollWidth } = container
+    setIsAtStart(scrollLeft <= 0)
+    setIsAtEnd(Math.abs(scrollLeft + clientWidth - scrollWidth) < 1)
+  }, [])
+
+  useEffect(() => {
+    const container = scrollContainerRef.current
+    if (!container) return
+
+    updateScrollEdges()
+
+    container.addEventListener('scroll', updateScrollEdges, { passive: true })
+    return () => {
+      container.removeEventListener('scroll', updateScrollEdges)
+    }
+  }, [updateScrollEdges])
+
   const showLoading = isLoading || isFetchingNextPage
   const handleScrollToTop = () => {
     titleRef.current?.scrollIntoView({
@@ -119,10 +141,10 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
     })
   }
   return (
-    <div className="relative flex w-[calc(100%+48px)] flex-col gap-6 bg-neutral-100 pt-10 pb-12 tablet:w-[calc(100%+64px)] tablet:gap-8 tablet:pt-12 tablet:pb-14 desktop:w-screen desktop:gap-10 desktop:pt-18 desktop:pb-22 hd:w-screen hd:pt-24 hd:pb-28">
+    <div className="relative flex w-[calc(100%+48px)] flex-col bg-neutral-100 pt-10 tablet:w-[calc(100%+64px)] tablet:pt-12 desktop:w-screen desktop:pt-18 hd:w-screen hd:pt-24">
       <div
         ref={titleRef}
-        className="flex items-center gap-3 pl-6 tablet:pl-8 desktop:pl-12 hd:pl-[calc(50vw-600px+64px)]"
+        className="mb-6 flex items-center gap-3 pl-6 tablet:mb-8 tablet:pl-8 desktop:mb-10 desktop:pl-12 hd:pl-[calc(50vw-600px+64px)]"
       >
         <div className="h-8 w-1.5 rounded-md bg-blue-400" />
         <h3 className="prose-h3-small font-swei text-neutral-900 desktop:prose-h3-large">
@@ -131,12 +153,12 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
       </div>
       <div
         ref={scrollContainerRef}
-        className="flex scrollbar-thin snap-x snap-mandatory scroll-px-6 gap-6 overflow-x-auto px-6 pb-2 tablet:scroll-px-8 tablet:px-8 desktop:scroll-px-12 desktop:gap-8 desktop:px-12 hd:scroll-pr-14 hd:scroll-pl-[calc(50vw-600px+64px)] hd:pr-14 hd:pl-[calc(50vw-600px+64px)]"
+        className="flex snap-x snap-mandatory scroll-px-6 gap-6 overflow-x-auto px-6 pb-10 scrollbar-none tablet:scroll-px-8 tablet:px-8 tablet:pb-12 desktop:scroll-px-12 desktop:gap-8 desktop:px-12 desktop:pb-20 hd:scroll-pr-14 hd:scroll-pl-[calc(50vw-600px+64px)] hd:pr-14 hd:pb-26 hd:pl-[calc(50vw-600px+64px)]"
       >
         {posts?.map((post, index) => (
           <div
             key={post.id}
-            className="shrink-0 snap-start"
+            className="shrink-0 snap-start pb-px"
             data-card-index={index}
           >
             <PostAnswerCard post={post} onOpenModal={onOpenModal} />
@@ -159,7 +181,7 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
             {[1, 2, 3].map((index) => (
               <div
                 key={`skeleton-${index}`}
-                className="shrink-0 snap-start"
+                className="shrink-0 snap-start pb-px"
                 data-card-index={(posts?.length ?? 0) + index - 1}
               >
                 <PostAnswerCardSkeleton />
@@ -172,6 +194,8 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
         scrollContainerRef={scrollContainerRef}
         onScrollToTop={handleScrollToTop}
         showNavBar={showNavBar}
+        isAtStart={isAtStart}
+        isAtEnd={isAtEnd}
       />
     </div>
   )

--- a/packages/frontend/src/modules/idea-hub/all-answers/nav-bar.tsx
+++ b/packages/frontend/src/modules/idea-hub/all-answers/nav-bar.tsx
@@ -10,6 +10,8 @@ type NavBarProps = {
   scrollContainerRef: RefObject<HTMLDivElement | null>
   onScrollToTop: () => void
   showNavBar: boolean
+  isAtStart: boolean
+  isAtEnd: boolean
 }
 
 const CARD_DATA_INDEX_ATTR = 'data-card-index'
@@ -29,6 +31,8 @@ function NavBar({
   scrollContainerRef,
   onScrollToTop,
   showNavBar,
+  isAtStart,
+  isAtEnd,
 }: NavBarProps) {
   const scrollLeft = useCallback(() => {
     const container = scrollContainerRef.current
@@ -62,23 +66,25 @@ function NavBar({
       )}
     >
       <div
-        className="absolute bottom-8 left-[50vw] hidden w-min -translate-x-1/2 items-center rounded-full bg-white p-2 shadow-md desktop:inline-flex"
+        className="absolute bottom-6 left-[50vw] hidden w-min -translate-x-1/2 items-center rounded-full bg-white p-2 shadow-md tablet:bottom-8 desktop:inline-flex"
         role="group"
         aria-label="捲動導覽"
       >
         <button
           type="button"
           onClick={scrollLeft}
-          className="flex h-7 w-[50px] cursor-pointer items-center justify-center text-neutral-400 transition-colors duration-200 hover:text-neutral-600"
+          className="flex h-7 w-[50px] cursor-pointer items-center justify-center text-neutral-600 transition-colors duration-200 hover:text-neutral-900 disabled:cursor-not-allowed disabled:text-neutral-400"
           aria-label="向左捲動"
+          disabled={isAtStart}
         >
           <ArrowLeft />
         </button>
         <button
           type="button"
           onClick={scrollRight}
-          className="flex h-7 w-[50px] cursor-pointer items-center justify-center text-neutral-400 transition-colors duration-200 hover:text-neutral-600"
+          className="flex h-7 w-[50px] cursor-pointer items-center justify-center text-neutral-600 transition-colors duration-200 hover:text-neutral-900 disabled:cursor-not-allowed disabled:text-neutral-400"
           aria-label="向右捲動"
+          disabled={isAtEnd}
         >
           <ArrowRight />
         </button>
@@ -86,7 +92,7 @@ function NavBar({
       <button
         type="button"
         onClick={onScrollToTop}
-        className="absolute bottom-8 left-[100vw] flex h-11 w-11 -translate-x-[calc(100%+24px)] cursor-pointer items-center justify-center rounded-full bg-white text-neutral-400 shadow-md transition-colors duration-200 hover:text-neutral-600 tablet:-translate-x-[calc(100%+32px)]"
+        className="absolute bottom-6 left-[100vw] flex h-11 w-11 -translate-x-[calc(100%+24px)] cursor-pointer items-center justify-center rounded-full bg-white text-neutral-600 shadow-md transition-colors duration-200 hover:text-neutral-900 tablet:bottom-8 tablet:-translate-x-[calc(100%+32px)]"
         aria-label="回到頂部"
       >
         <BackToTopIcon />

--- a/packages/frontend/src/modules/idea-hub/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/index.tsx
@@ -21,7 +21,7 @@ function IdeaHub() {
 
   return (
     <>
-      <div className="mx-auto flex w-full max-w-300 flex-col items-center px-6 py-10 tablet:px-8 tablet:py-12 desktop:px-12 desktop:py-18 hd:px-14 hd:py-24">
+      <div className="mx-auto flex w-full max-w-300 flex-col items-center px-6 pt-10 tablet:px-8 tablet:pt-12 desktop:px-12 desktop:pt-18 hd:px-14 hd:pt-24">
         <div className="mb-4 flex items-center gap-2 desktop:mb-6">
           <div className="flex size-11 items-center justify-center desktop:size-16">
             <IdeaHubIcon className="desktop:hidden" />

--- a/packages/frontend/src/modules/idea-hub/latest-answers/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/latest-answers/index.tsx
@@ -37,7 +37,7 @@ function LatestAnswers({ onOpenModal }: LatestAnswersProps) {
   }
 
   return (
-    <div className="mt-10 mb-14 flex w-[calc(100%+48px)] flex-col gap-6 tablet:mt-12 tablet:mb-16 tablet:w-full tablet:gap-8 desktop:mt-18 desktop:mb-24 desktop:w-screen desktop:gap-10 desktop:pl-12 hd:mt-24 hd:mb-30 hd:pl-[calc(50vw-600px+64px)]">
+    <div className="mt-10 mb-14 flex w-[calc(100%+48px)] flex-col gap-6 tablet:mt-12 tablet:mb-16 tablet:w-full tablet:gap-8 desktop:mt-18 desktop:mb-24 desktop:w-screen desktop:gap-10 desktop:pl-12 hd:mt-24 hd:mb-30 hd:px-[calc(50vw-600px+64px)]">
       <div className="flex items-center gap-3 pl-6 tablet:pl-0">
         <div className="h-8 w-1.5 rounded-md bg-yellow-400" />
         <h3 className="prose-h3-small font-swei text-neutral-900 desktop:prose-h3-large">


### PR DESCRIPTION
## Summary

- Fix navigation arrow buttons in the idea hub `AllAnswers` section by adding disabled states when scrolled to the start/end edges, and improve overall layout spacing and styling.

## Changes

- Added scroll edge detection (`isAtStart`, `isAtEnd`) in `AllAnswers` to track whether the horizontal scroll container is at its start or end boundary
- Passed `isAtStart` and `isAtEnd` props to `NavBar` to disable left/right scroll buttons accordingly with `disabled` attribute and styling (`disabled:cursor-not-allowed disabled:text-neutral-400`)
- Updated navigation button colors from `neutral-400` to `neutral-600` (default) and `neutral-600` to `neutral-900` (hover) for better visibility
- Adjusted bottom positioning of the nav bar and back-to-top button for responsive breakpoints (`bottom-6` base, `tablet:bottom-8`)
- Changed scrollbar style from `scrollbar-thin` to `scrollbar-none` and adjusted bottom padding on the scroll container
- Fixed layout spacing: removed redundant bottom padding from the idea hub container (`py-*` → `pt-*`), moved gap/margin to appropriate child elements
- Fixed latest answers horizontal padding at `hd` breakpoint (`hd:pl-*` → `hd:px-*`)

## Additional Notes

- Scroll edge state is updated via a passive scroll event listener for performance
- Added `pb-px` to card wrappers to preserve any bottom box-shadow rendering

## Screenshot(s)

## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/defect-btn-3038dbdca9328095a74fe9e703ae705c?source=copy_link)