### PR TITLE
fix(frontend): resolve article page UI defects (layout, spacing, images, copy)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/cms-core",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "",
   "main": "lib/index.js",
   "types": "src/index.ts",
@@ -36,7 +36,7 @@
     "@keystone-ui/button": "^7.0.2",
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",
-    "@kids-reporter/draft-editor": "^1.0.25",
+    "@kids-reporter/draft-editor": "^1.0.26",
     "@twreporter/errors": "^1.1.1",
     "axios": "^0.26.0",
     "draft-convert": "^2.1.12",

--- a/packages/draft-editor/package.json
+++ b/packages/draft-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/draft-editor",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -29,7 +29,7 @@
     "@keystone-ui/button": "^7.0.2",
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",
-    "@kids-reporter/draft-renderer": "^1.0.21",
+    "@kids-reporter/draft-renderer": "^1.0.22",
     "@twreporter/errors": "^1.1.2",
     "axios": "^1.12.2",
     "draft-js": "^0.11.7"

--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/draft-renderer",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/src/block-render-maps/article-content.tsx
+++ b/packages/draft-renderer/src/block-render-maps/article-content.tsx
@@ -22,6 +22,13 @@ export const Paragraph = styled.div`
   > div[data-block='true'] {
     margin-bottom: 38px;
   }
+
+  &:has(+ div:not([data-paragraph-block='true'])) {
+    margin-bottom: 40px;
+    ${mediaQuery.desktopAbove} {
+      margin-bottom: 60px;
+    }
+  }
 `
 
 export const Heading = styled.div`
@@ -48,6 +55,14 @@ export const Heading = styled.div`
     padding-left: 24px;
     padding-right: 24px;
   }
+
+  /* when the next sibling div contains a blockquote */
+  & + div:has(blockquote) {
+    margin-top: 0px;
+    ${mediaQuery.desktopAbove} {
+      margin-top: 0px;
+    }
+  }
 `
 
 export const List = styled.ol`
@@ -73,12 +88,26 @@ export const List = styled.ol`
   > li {
     margin-bottom: 6px;
   }
+
+  &:has(+ div:not([data-paragraph-block='true'])) {
+    margin-bottom: 40px;
+    ${mediaQuery.desktopAbove} {
+      margin-bottom: 60px;
+    }
+  }
 `
 
 export const Atomic = styled.div`
   /* reset browser default styles */
   > figure {
     margin: 0;
+  }
+
+  &:has(blockquote) {
+    margin-top: -2px;
+    ${mediaQuery.desktopAbove} {
+      margin-top: -22px;
+    }
   }
 
   ${mediaQuery.desktopAbove} {
@@ -120,15 +149,15 @@ const _blockRenderMap = Immutable.Map({
   },
   'ordered-list-item': {
     element: 'li',
-    wrapper: <List />,
+    wrapper: <List data-paragraph-block="true" />,
   },
   'unordered-list-item': {
     element: 'li',
-    wrapper: <List as="ul" />,
+    wrapper: <List as="ul" data-paragraph-block="true" />,
   },
   unstyled: {
     element: 'div',
-    wrapper: <Paragraph />,
+    wrapper: <Paragraph data-paragraph-block="true" />,
   },
 })
 

--- a/packages/draft-renderer/src/block-render-maps/image-link.tsx
+++ b/packages/draft-renderer/src/block-render-maps/image-link.tsx
@@ -3,6 +3,7 @@ import Immutable from 'immutable'
 import React from 'react'
 import styled from 'styled-components'
 
+import { mediaQuery } from '../utils/media-query'
 import { Atomic, Paragraph } from './article-content'
 
 const ParagraphForImageLink = styled(Paragraph)`
@@ -15,7 +16,16 @@ const ParagraphForImageLink = styled(Paragraph)`
   color: rgb(58, 79, 102);
   letter-spacing: 0.7px;
   line-height: 28px;
-  text-align: center;
+  text-align: left;
+
+  ${mediaQuery.smallOnly} {
+    padding-left: 0px;
+    padding-right: 0px;
+  }
+
+  > div[data-block='true'] {
+    margin-bottom: 0px;
+  }
 `
 
 const _blockRenderMapForAnnotation = Immutable.Map({

--- a/packages/draft-renderer/src/block-render-maps/index.tsx
+++ b/packages/draft-renderer/src/block-render-maps/index.tsx
@@ -7,7 +7,6 @@ import {
   blockRenderMapForInfoBoxWithHeaderBorder,
 } from './info-box'
 import { blockRenderMap as blockRenderMapForProjectContent } from './project-content'
-
 export default {
   annotation: blockRenderMapForAnnotation,
   // article page brief

--- a/packages/draft-renderer/src/block-renderers/blockquote.tsx
+++ b/packages/draft-renderer/src/block-renderers/blockquote.tsx
@@ -12,6 +12,7 @@ const BorderLeftLine = styled.div`
   border-radius: 10px;
   background-color: #c6c6c6;
   align-self: stretch;
+  flex-shrink: 0;
 `
 
 export function BorderLeftBlockquote({ text }: { text: string }) {

--- a/packages/draft-renderer/src/block-renderers/image-block.tsx
+++ b/packages/draft-renderer/src/block-renderers/image-block.tsx
@@ -245,10 +245,10 @@ const ArticleBodyContainer = styled.div<{ $alignment?: string }>`
     margin: 0;
   }
 
-  margin: 40px auto;
+  margin: 0 auto 40px auto;
 
   ${mediaQuery.mediumAbove} {
-    margin: 60px auto;
+    margin: 0 auto 60px auto;
   }
 
   ${mediaQuery.smallOnly} {
@@ -275,8 +275,6 @@ const ArticleBodyContainer = styled.div<{ $alignment?: string }>`
         return `
           ${mediaQuery.smallOnly} {
             max-width: 512px;
-            padding-left: 24px;
-            padding-right: 24px;
           }
 
           ${mediaQuery.mediumAbove} {

--- a/packages/draft-renderer/src/block-renderers/image-link.tsx
+++ b/packages/draft-renderer/src/block-renderers/image-link.tsx
@@ -39,7 +39,7 @@ const Figure = styled.figure<{ $alignment?: string }>`
 `
 
 const FigureCaption = styled.figcaption<{ $alignment?: string }>`
-  width: fit-content;
+  width: 100%;
   max-width: 100%;
   font-size: ${({ theme }) =>
     theme?.fontSizeLevel === 'large' ? '18px' : '14px'};
@@ -48,7 +48,7 @@ const FigureCaption = styled.figcaption<{ $alignment?: string }>`
   color: #575757;
   letter-spacing: 0.7px;
   line-height: 28px;
-  text-align: center;
+  text-align: left;
   padding: 16px 0 20px 0;
   border-bottom: 2px solid #c6c6c6;
 
@@ -69,7 +69,7 @@ const FigureCaption = styled.figcaption<{ $alignment?: string }>`
           ${mediaQuery.mediumAbove} {
             max-width: 340px;
             margin-left: auto;
-            margin-right: 0px;
+            margin-right: 32px;
           }
 
           ${mediaQuery.desktopAbove} {
@@ -230,10 +230,10 @@ const ArticleBodyContainer = styled.div<{ $alignment?: string }>`
     margin: 0;
   }
 
-  margin: 40px auto;
+  margin: 0 auto 40px auto;
 
   ${mediaQuery.mediumAbove} {
-    margin: 60px auto;
+    margin: 0 auto 60px auto;
   }
 
   ${mediaQuery.smallOnly} {
@@ -259,8 +259,6 @@ const ArticleBodyContainer = styled.div<{ $alignment?: string }>`
         return `
           ${mediaQuery.smallOnly} {
             max-width: 512px;
-            padding-left: 24px;
-            padding-right: 24px;
           }
 
           ${mediaQuery.mediumAbove} {
@@ -306,7 +304,11 @@ export const ImageLinkInArticleBody = ({
   data,
 }: ImageBlockInArticleBodyProps) => {
   return (
-    <ArticleBodyContainer $alignment={data.alignment} className={className}>
+    <ArticleBodyContainer
+      $alignment={data.alignment}
+      className={className}
+      data-image-link-block="true"
+    >
       <ImageLinkBlock data={data} />
     </ArticleBodyContainer>
   )

--- a/packages/draft-renderer/src/block-renderers/slideshow-block.tsx
+++ b/packages/draft-renderer/src/block-renderers/slideshow-block.tsx
@@ -616,11 +616,11 @@ export function SlideshowBlock({ className = '', data }: SlideshowBlockProps) {
 
 const ArticleBodyContainer = styled.div`
   ${mediaQuery.smallOnly} {
-    margin: 40px auto;
+    margin: 0 auto 40px auto;
   }
 
   ${mediaQuery.mediumAbove} {
-    margin: 60px auto;
+    margin: 0 auto 60px auto;
   }
 `
 

--- a/packages/draft-renderer/src/entity-decorators/link-decorator.tsx
+++ b/packages/draft-renderer/src/entity-decorators/link-decorator.tsx
@@ -11,9 +11,23 @@ const LinkWrapper = styled.a`
   cursor: pointer;
   text-decoration-color: #c6c6c6;
   text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
 
   &:hover {
     text-decoration-color: #27b3f5;
+  }
+
+  & > span {
+    color: #27b3f5 !important;
+    text-decoration: underline !important;
+    text-decoration-color: #c6c6c6 !important;
+    text-underline-offset: 3px !important;
+    text-decoration-thickness: 1px !important;
+    transition: text-decoration-color 0.1s ease-in !important;
+
+    &:hover {
+      text-decoration-color: #27b3f5 !important;
+    }
   }
 `
 

--- a/packages/frontend/src/globals.css
+++ b/packages/frontend/src/globals.css
@@ -243,6 +243,27 @@
   body {
     max-width: 100vw;
     font-family: var(--fontFamily);
+    overflow-x: hidden;
+
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-neutral-500) var(--color-neutral-200);
+
+    &::-webkit-scrollbar {
+      width: 0px;
+    }
+
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: transparent;
+      border-radius: 3px;
+    }
+
+    &::-webkit-scrollbar-thumb:hover {
+      background: transparent;
+    }
   }
 
   body {

--- a/packages/frontend/src/modules/article/components/news-reading.tsx
+++ b/packages/frontend/src/modules/article/components/news-reading.tsx
@@ -57,7 +57,7 @@ function NewsReading({ className, items }: NewsReadingProps) {
     <div className="w-full px-4">
       <div
         className={cn(
-          'mx-auto mt-10 flex max-w-[584px] flex-col rounded-[20px] border border-neutral-200 p-6 tablet:mt-20 tablet:p-9 hd:max-w-[656px]',
+          'mx-auto mt-10 flex max-w-[512px] flex-col rounded-[20px] border border-neutral-200 p-6 tablet:mt-20 tablet:max-w-[584px] tablet:p-9 hd:max-w-[656px]',
           className
         )}
       >

--- a/packages/frontend/src/modules/article/components/popular-keywords.tsx
+++ b/packages/frontend/src/modules/article/components/popular-keywords.tsx
@@ -10,7 +10,7 @@ type PopularKeywordsProp = {
 
 function PopularKeywords({ keywords }: PopularKeywordsProp) {
   return (
-    <div className="-mt-1 flex w-[min(100vw,512px)] flex-col items-start gap-5 px-6 tablet:mt-4 tablet:px-0 hd:w-[584px]">
+    <div className="mt-4 flex w-[min(100vw,512px)] flex-col items-start gap-5 px-6 tablet:px-0 desktop:mt-5 hd:w-[584px]">
       <div className="flex flex-row items-center gap-2">
         <PopularKeywordsIcon />
         <h5 className="prose-h5-small desktop:prose-h5-large">常用關鍵字</h5>

--- a/packages/frontend/src/modules/article/components/post-renderer.tsx
+++ b/packages/frontend/src/modules/article/components/post-renderer.tsx
@@ -39,7 +39,7 @@ function PostRenderer({ content }: PostProp) {
   return (
     <div
       className={cn(
-        'prose-article text-neutral-900',
+        'mb-10 prose-article text-neutral-900 tablet:mb-15',
         ...ARTICLE_FONT_SIZE_CLASSNAMES,
         fontSize === FontSizeLevel.LARGE && [
           ...ARTICLE_FONT_SIZE_CLASSNAMES_LARGE,

--- a/packages/frontend/src/modules/article/components/title-hero/index.tsx
+++ b/packages/frontend/src/modules/article/components/title-hero/index.tsx
@@ -61,7 +61,7 @@ function TitleHero({
             </svg>
           </Link>
         )}
-        <header className="ml-6 flex flex-col gap-1 tablet:ml-0 tablet:gap-2">
+        <header className="mx-6 flex flex-col gap-1 tablet:mx-0 tablet:gap-2">
           {subtitle && (
             <h4
               className={cn(

--- a/packages/frontend/src/modules/article/index.tsx
+++ b/packages/frontend/src/modules/article/index.tsx
@@ -332,7 +332,7 @@ const ArticleModule = ({
         />
       </div>
       <SupportAction
-        title="每一篇好報導，都需要有心人支持"
+        title="兒少好新聞，需要您的行動支持"
         content={<SupportActionContent />}
       />
       {postQuestions && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -5030,7 +5030,7 @@ __metadata:
     "@keystone-ui/button": "npm:^7.0.2"
     "@keystone-ui/fields": "npm:^7.2.0"
     "@keystone-ui/modals": "npm:^6.0.3"
-    "@kids-reporter/draft-editor": "npm:^1.0.25"
+    "@kids-reporter/draft-editor": "npm:^1.0.26"
     "@twreporter/errors": "npm:^1.1.1"
     axios: "npm:^0.26.0"
     draft-convert: "npm:^2.1.12"
@@ -5094,7 +5094,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/draft-editor@npm:^1.0.25, @kids-reporter/draft-editor@workspace:packages/draft-editor":
+"@kids-reporter/draft-editor@npm:^1.0.26, @kids-reporter/draft-editor@workspace:packages/draft-editor":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/draft-editor@workspace:packages/draft-editor"
   dependencies:
@@ -5107,7 +5107,7 @@ __metadata:
     "@keystone-ui/button": "npm:^7.0.2"
     "@keystone-ui/fields": "npm:^7.2.0"
     "@keystone-ui/modals": "npm:^6.0.3"
-    "@kids-reporter/draft-renderer": "npm:^1.0.21"
+    "@kids-reporter/draft-renderer": "npm:^1.0.22"
     "@twreporter/errors": "npm:^1.1.2"
     axios: "npm:^1.12.2"
     babel-loader: "npm:^8.3.0"
@@ -5126,7 +5126,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/draft-renderer@npm:^1.0.13, @kids-reporter/draft-renderer@npm:^1.0.21, @kids-reporter/draft-renderer@workspace:packages/draft-renderer":
+"@kids-reporter/draft-renderer@npm:^1.0.13, @kids-reporter/draft-renderer@npm:^1.0.22, @kids-reporter/draft-renderer@workspace:packages/draft-renderer":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/draft-renderer@workspace:packages/draft-renderer"
   dependencies:


### PR DESCRIPTION
## Summary

Fixes article page UI defects: spacing between content blocks (paragraphs, lists, headings, blockquotes), image/image-link/slideshow block margins and caption styling, link underline appearance, popular keywords and article body spacing, and support action copy. Bumps `@kids-reporter/draft-renderer`, `@kids-reporter/draft-editor`, and `@kids-reporter/cms-core` versions.

## Changes

- **draft-renderer – article content**
  - Paragraph/List: increased bottom margin (40px / 60px desktop) when followed by a non-paragraph block via `:has(+ div:not([data-paragraph-block='true']))`.
  - Heading: zero top margin when next sibling is a blockquote.
  - Atomic: negative top margin when it contains a blockquote.
  - Added `data-paragraph-block="true"` to Paragraph and List wrappers (unstyled, ordered-list-item, unordered-list-item) for the above selectors.

- **draft-renderer – blockquote**
  - `BorderLeftLine`: added `flex-shrink: 0` to prevent border from shrinking.

- **draft-renderer – image / image-link / slideshow**
  - ArticleBodyContainer: `margin: 40px auto` → `margin: 0 auto 40px auto` (and 60px on larger breakpoints) so blocks have no top margin.
  - Image and image-link blocks: removed `padding-left`/`padding-right: 24px` on small screens.
  - Image-link: FigureCaption `width: fit-content` → `100%`, `text-align: center` → `left`; added `margin-right: 32px` for caption at mediumAbove; added `data-image-link-block="true"` on container.

- **draft-renderer – image-link block-render-map**
  - ParagraphForImageLink: `text-align: center` → `left`, small-only padding 0, inner blocks `margin-bottom: 0`.

- **draft-renderer – link decorator**
  - Set `text-decoration-thickness: 1px` and inner `span` styles (color, underline, hover) for consistent link appearance.

- **frontend – article**
  - Popular keywords: margin tweaks (`-mt-1` → `mt-4`, `desktop:mt-5`).
  - Post renderer: added `mb-10 tablet:mb-15` to article content wrapper.
  - SupportAction title: "每一篇好報導，都需要有心人支持" → "兒少好新聞，需要您的行動支持".

- **Versions**
  - `@kids-reporter/draft-renderer`: 1.0.21 → 1.0.22
  - `@kids-reporter/draft-editor`: 1.0.25 → 1.0.26 (depends on draft-renderer ^1.0.22)
  - `@kids-reporter/cms-core`: 1.0.25 → 1.0.26 (depends on draft-editor ^1.0.26)
  - `yarn.lock` updated.

## Additional Notes

- Spacing logic uses `:has()` and `data-paragraph-block` so only paragraph-like blocks (unstyled, list items) get the extra bottom margin when followed by headings, blockquotes, or media.
- Image-related containers no longer add horizontal padding on small screens; alignment is handled by existing layout.

## Screenshot(s)

## Reference(s)

- [Notion Page (defect UI)](https://www.notion.so/twreporter/defect-UI-2f68dbdca932807ba99ccbbcddc48061?source=copy_link)