### PR TITLE
fix(frontend): idea hub nav layout and overflow defect

### DIFF
--- a/packages/frontend/src/globals.css
+++ b/packages/frontend/src/globals.css
@@ -243,7 +243,7 @@
   body {
     max-width: 100vw;
     font-family: var(--fontFamily);
-    overflow-x: hidden;
+    overflow-x: clip;
 
     scrollbar-width: thin;
     scrollbar-color: var(--color-neutral-500) var(--color-neutral-200);

--- a/packages/frontend/src/modules/article/components/authors.tsx
+++ b/packages/frontend/src/modules/article/components/authors.tsx
@@ -188,7 +188,7 @@ function Authors({ authors }: AuthorsProp) {
 
       <div
         ref={scrollContainerRef}
-        className="flex max-w-screen snap-x snap-mandatory scroll-px-6 gap-6 overflow-x-auto px-6 pb-2 scrollbar-none tablet:scroll-px-8 tablet:px-8 desktop:w-screen desktop:scroll-px-[max(50vw+56px-600px,48px)] desktop:px-[max(50vw+56px-600px,48px)]"
+        className="flex max-w-screen snap-x snap-mandatory scroll-px-6 gap-6 overflow-x-auto px-6 pb-2 scrollbar-none tablet:scroll-px-8 tablet:px-8 desktop:w-screen desktop:scroll-px-[max(calc(50vw+56px-600px),48px)] desktop:px-[max(calc(50vw+56px-600px),48px)]"
       >
         {authors.map((author) => {
           return <AuthorCard key={author.id} author={author} />

--- a/packages/frontend/src/modules/home/components/subcategories-marquee/illustrations.tsx
+++ b/packages/frontend/src/modules/home/components/subcategories-marquee/illustrations.tsx
@@ -42,7 +42,7 @@ function Illustrations() {
         alt="subcategories marquee illustrations"
         width={272}
         height={200}
-        className="absolute right-30 bottom-8 z-1 hidden desktop:block hd:right-[calc(max(120px,50vw-600px))]"
+        className="absolute right-30 bottom-8 z-1 hidden desktop:block hd:right-[max(120px,calc(50vw-600px))]"
       />
     </div>
   )

--- a/packages/frontend/src/modules/idea-hub/all-answers/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/all-answers/index.tsx
@@ -150,7 +150,7 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
     <div className="relative flex w-[calc(100%+48px)] flex-col bg-neutral-100 pt-10 tablet:w-[calc(100%+64px)] tablet:pt-12 desktop:w-screen desktop:pt-18 hd:w-screen hd:pt-24">
       <div
         ref={titleRef}
-        className="mb-6 flex items-center gap-3 pl-6 tablet:mb-8 tablet:pl-8 desktop:mb-10 desktop:pl-12 hd:pl-[calc(50vw-600px+64px)]"
+        className="mb-6 flex scroll-mt-[104px] items-center gap-3 pl-6 tablet:mb-8 tablet:scroll-mt-[112px] tablet:pl-8 desktop:mb-10 desktop:scroll-mt-[136px] desktop:pl-[max(calc(50vw+56px-600px),48px)] hd:scroll-mt-[160px] hd:pl-[calc(50vw-600px+64px)]"
       >
         <div className="h-8 w-1.5 rounded-md bg-blue-400" />
         <h3 className="prose-h3-small font-swei text-neutral-900 desktop:prose-h3-large">
@@ -159,7 +159,7 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
       </div>
       <div
         ref={scrollContainerRef}
-        className="flex snap-x snap-mandatory scroll-px-6 gap-6 overflow-x-auto px-6 pb-10 scrollbar-none tablet:scroll-px-8 tablet:px-8 tablet:pb-12 desktop:scroll-px-12 desktop:gap-8 desktop:px-12 desktop:pb-20 hd:scroll-pr-14 hd:scroll-pl-[calc(50vw-600px+64px)] hd:pr-14 hd:pb-26 hd:pl-[calc(50vw-600px+64px)]"
+        className="flex snap-x snap-mandatory scroll-px-6 gap-6 overflow-x-auto px-6 pb-14 scrollbar-none tablet:scroll-px-8 tablet:px-8 tablet:pb-16 desktop:scroll-px-[max(calc(50vw+56px-600px),48px)] desktop:gap-8 desktop:px-[max(calc(50vw+56px-600px),48px)] desktop:pb-24 hd:scroll-pr-14 hd:scroll-pl-[calc(50vw-600px+64px)] hd:pr-14 hd:pb-30 hd:pl-[calc(50vw-600px+64px)]"
       >
         {posts?.map((post, index) => (
           <div

--- a/packages/frontend/src/modules/idea-hub/latest-answers/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/latest-answers/index.tsx
@@ -37,7 +37,7 @@ function LatestAnswers({ onOpenModal }: LatestAnswersProps) {
   }
 
   return (
-    <div className="mt-10 mb-14 flex w-[calc(100%+48px)] flex-col gap-6 tablet:mt-12 tablet:mb-16 tablet:w-full tablet:gap-8 desktop:mt-18 desktop:mb-24 desktop:w-screen desktop:gap-10 desktop:pl-12 hd:mt-24 hd:mb-30 hd:px-[calc(50vw-600px+64px)]">
+    <div className="mt-10 mb-14 flex w-[calc(100%+48px)] flex-col gap-6 tablet:mt-12 tablet:mb-16 tablet:w-full tablet:gap-8 desktop:mt-18 desktop:mb-24 desktop:w-screen desktop:max-w-300 desktop:gap-10 desktop:px-12 hd:mt-24 hd:mb-30 hd:max-w-none hd:px-[calc(50vw-600px+64px)]">
       <div className="flex items-center gap-3 pl-6 tablet:pl-0">
         <div className="h-8 w-1.5 rounded-md bg-yellow-400" />
         <h3 className="prose-h3-small font-swei text-neutral-900 desktop:prose-h3-large">


### PR DESCRIPTION
## Summary

Fixes Idea Hub navigation and layout defect: horizontal overflow, scroll-into-view alignment when using the nav, and responsive padding/width so the All Answers and Latest Answers sections align correctly across breakpoints and no unwanted horizontal scrollbar appears.

## Changes

- **globals.css**: Changed body `overflow-x: hidden` to `overflow-x: clip` to avoid the body acting as a scroll container and prevent horizontal scrollbar issues.
- **all-answers/index.tsx**: Added `scroll-mt-*` (scroll-margin-top) on the section title at each breakpoint so nav-driven scroll-into-view accounts for the sticky header; updated desktop left/scroll padding to `max(50vw+56px-600px,48px)` for edge alignment; increased bottom padding on the scroll container (e.g. pb-10 → pb-14, desktop/hd bumps) and alied desktop scroll/px with the same `max()` for consistent edge-to-edge layout.
- **latest-answers/index.tsx**: Added `desktop:max-w-300` and `hd:max-w-none` so the Latest Answers container has a constrained width on desktop and full width on hd.

## Additional Notes

- `overflow-x: clip` avoids creating a scroll container for overflow, which can remove horizontal scrollbar issues that `hidden` can still trigger in some browsers.
- `scroll-mt-*` ensures that when a user clicks a nav item to scroll to a section, the sticky header does not cover the section title.

## Screenshot(s)

## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/defect-btn-3038dbdca9328095a74fe9e703ae705c?source=copy_link)