### PR TITLE
feat(frontend): add encourage-reading baodaozai event and adjust scroll triggers

### DIFF
--- a/packages/frontend/src/modules/article/components/article-baodaozai-event-trigger.tsx
+++ b/packages/frontend/src/modules/article/components/article-baodaozai-event-trigger.tsx
@@ -12,6 +12,7 @@ type EventId =
   | 'show-start-reading'
   | 'hide-start-reading'
   | 'change-start-reading'
+  | 'change-encourage-reading'
   | 'change-ask-questions'
   | 'show-ask-questions'
   | 'show-related-articles'
@@ -29,6 +30,9 @@ type ArticleBaodaozaiEventTriggerProps = {
   onAskQuestionsConfirm?: BaodaozaiActionSetter
   startReadingContent?: string
 }
+
+const ENCOURAGE_READING_CONTENT =
+  '進度很棒！再看一下下，最後會有小挑戰等你破解！'
 
 function createBaodaozaiEventConfig({
   onAskQuestionsConfirm,
@@ -70,6 +74,19 @@ function createBaodaozaiEventConfig({
         hideCancelButton: true,
         confirmText: '開始閱讀',
         content: startReadingContent || '',
+        confirmAction: () => {},
+      },
+      baodaozaiState: {
+        isActive: false,
+        action: 'none',
+      },
+    },
+    'change-encourage-reading': {
+      dialogState: {
+        isOpen: false,
+        hideCancelButton: true,
+        confirmText: '繼續閱讀',
+        content: ENCOURAGE_READING_CONTENT,
         confirmAction: () => {},
       },
       baodaozaiState: {

--- a/packages/frontend/src/modules/article/index.tsx
+++ b/packages/frontend/src/modules/article/index.tsx
@@ -286,17 +286,26 @@ const ArticleModule = ({
             </div>
             <div className="relative w-full">
               <PostRenderer content={post?.content ?? {}} />
-              {/* middle of the article content enters 50% of the viewport*/}
               <div className="absolute top-[calc(50%+50vh)]">
+                <ArticleBaodaozaiEventTrigger
+                  id="change-encourage-reading"
+                  disabled={!isScrollingDown}
+                />
+                <ArticleBaodaozaiEventTrigger
+                  id="change-start-reading"
+                  disabled={isScrollingDown}
+                  startReadingContent={post?.opening ?? ''}
+                />
+              </div>
+              <div className="absolute top-[calc(75%+50vh)]">
                 <ArticleBaodaozaiEventTrigger
                   id="change-ask-questions"
                   disabled={!isScrollingDown}
                   onAskQuestionsConfirm={handleBaodaozaiConfirm}
                 />
                 <ArticleBaodaozaiEventTrigger
-                  id="change-start-reading"
+                  id="change-encourage-reading"
                   disabled={isScrollingDown}
-                  startReadingContent={post?.opening ?? ''}
                 />
               </div>
             </div>
@@ -319,13 +328,6 @@ const ArticleModule = ({
       <Authors authors={orderedAuthors} />
 
       <div className="relative w-full">
-        {/* related posts enters 50% of the viewport*/}
-        <div className="absolute top-[calc(50%+50vh)]">
-          <ArticleBaodaozaiEventTrigger
-            id="show-related-articles"
-            disabled={!isScrollingDown}
-          />
-        </div>
         <RelatedArticles
           articles={relatedPosts ?? []}
           twReporterArticles={twReporterRelatedPosts ?? []}


### PR DESCRIPTION
## Summary

Updates the 報到仔 (Baodaozai) flow in the article module by adding an "encourage reading" event and changing when triggers fire. Encourage-reading is shown at 50% scroll; ask-questions is moved to 75% scroll; the viewport-based show-related-articles trigger is removed.

## Changes

- **article-baodaozai-event-trigger.tsx**: Add `change-encourage-reading` event type and config with fixed copy and dialog (confirm "繼續閱讀").
- **article/index.tsx**: Fire encourage-reading at 50% viewport (replacing ask-questions at that position).
- **article/index.tsx**: Add a second trigger block at 75% viewport: ask-questions when scrolling down, encourage-reading when scrolling up (with `startReadingContent`).
- **article/index.tsx**: Remove the viewport-based `show-rs` trigger before RelatedArticles.

## Additional Notes

- Encourage-reading copy: 「進度很棒！再看一下下，最後會有小挑戰等你破解！」
- Potential edge case: Two `ArticleBaodaozaiEventTrigger` instances use `change-encourage-reading` (50% scroll-down vs 75% scroll-up); confirm intended behavior when crossing 50% / 75% in both directions.

## Screenshot(s)

## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/3038dbdca932806798ecfa7e07714378?source=copy_link)