### PR TITLE
fix(frontend): resolve article page layout and interaction defects

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/cms-core",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "",
   "main": "lib/index.js",
   "types": "src/index.ts",
@@ -36,7 +36,7 @@
     "@keystone-ui/button": "^7.0.2",
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",
-    "@kids-reporter/draft-editor": "^1.0.26",
+    "@kids-reporter/draft-editor": "^1.0.27",
     "@twreporter/errors": "^1.1.1",
     "axios": "^0.26.0",
     "draft-convert": "^2.1.12",

--- a/packages/draft-editor/package.json
+++ b/packages/draft-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/draft-editor",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -29,7 +29,7 @@
     "@keystone-ui/button": "^7.0.2",
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",
-    "@kids-reporter/draft-renderer": "^1.0.22",
+    "@kids-reporter/draft-renderer": "^1.0.23",
     "@twreporter/errors": "^1.1.2",
     "axios": "^1.12.2",
     "draft-js": "^0.11.7"

--- a/packages/draft-editor/src/block-renderers/styled.tsx
+++ b/packages/draft-editor/src/block-renderers/styled.tsx
@@ -96,7 +96,7 @@ export const EditableBlock = (props: {
   onClick: () => void
 }) => {
   return (
-    <_EditableBlock className={props.className}>
+    <_EditableBlock className={props.className} onClick={props.onClick}>
       {props.component}
       <EditButton onClick={props.onClick}>
         <i className="fa-solid fa-pen"></i>

--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/draft-renderer",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/src/block-render-maps/article-content.tsx
+++ b/packages/draft-renderer/src/block-render-maps/article-content.tsx
@@ -25,7 +25,7 @@ export const Paragraph = styled.div`
 
   &:has(+ div:not([data-paragraph-block='true'])) {
     margin-bottom: 40px;
-    ${mediaQuery.desktopAbove} {
+    ${mediaQuery.mediumAbove} {
       margin-bottom: 60px;
     }
   }
@@ -91,7 +91,7 @@ export const List = styled.ol`
 
   &:has(+ div:not([data-paragraph-block='true'])) {
     margin-bottom: 40px;
-    ${mediaQuery.desktopAbove} {
+    ${mediaQuery.mediumAbove} {
       margin-bottom: 60px;
     }
   }
@@ -105,22 +105,27 @@ export const Atomic = styled.div`
 
   &:has(blockquote) {
     margin-top: -2px;
-    ${mediaQuery.desktopAbove} {
+    ${mediaQuery.mediumAbove} {
       margin-top: -22px;
     }
   }
 
   ${mediaQuery.desktopAbove} {
     div:has(+ div [data-image-block-caption-alignment='default'])
-      [data-image-block-caption-alignment='default'],
-    [data-image-slideshow-caption-alignment='default'] {
+      [data-image-block-caption-alignment='default'] {
       position: relative !important;
     }
-  }
-  ${mediaQuery.largeOnly} {
     div:has(+ div [data-image-block-caption-alignment='default'])
-      [data-image-block-caption-alignment='default'],
-    [data-image-slideshow-caption-alignment='default'] {
+      [data-image-slideshow-caption-alignment='default'] {
+      position: relative !important;
+    }
+
+    div:has(+ div [data-image-slideshow-caption-alignment='default'])
+      [data-image-block-caption-alignment='default'] {
+      position: relative !important;
+    }
+    div:has(+ div [data-image-slideshow-caption-alignment='default'])
+      [data-image-slideshow-caption-alignment='default'] {
       position: relative !important;
     }
   }

--- a/packages/draft-renderer/src/block-render-maps/image-link.tsx
+++ b/packages/draft-renderer/src/block-render-maps/image-link.tsx
@@ -10,13 +10,9 @@ const ParagraphForImageLink = styled(Paragraph)`
   /* overwrite css */
   font-size: ${({ theme }) =>
     theme?.fontSizeLevel === 'large' ? '18px' : '14px'};
-  margin-left: auto;
-  margin-right: auto;
-  margin-top: 0.5em;
-  color: rgb(58, 79, 102);
-  letter-spacing: 0.7px;
-  line-height: 28px;
+  margin: 0;
   text-align: left;
+  max-width: 100%;
 
   ${mediaQuery.smallOnly} {
     padding-left: 0px;

--- a/packages/draft-renderer/src/block-renderers/image-block.tsx
+++ b/packages/draft-renderer/src/block-renderers/image-block.tsx
@@ -112,7 +112,6 @@ const FigureCaption = styled.figcaption<{ $alignment?: string }>`
           }
 
           ${mediaQuery.mediumAbove} {
-            max-width: 340px;
             margin-left: 0px;
             margin-right: 0px;
           }
@@ -275,6 +274,7 @@ const ArticleBodyContainer = styled.div<{ $alignment?: string }>`
         return `
           ${mediaQuery.smallOnly} {
             max-width: 512px;
+            padding: 0 24px;
           }
 
           ${mediaQuery.mediumAbove} {

--- a/packages/draft-renderer/src/block-renderers/image-link.tsx
+++ b/packages/draft-renderer/src/block-renderers/image-link.tsx
@@ -115,7 +115,6 @@ const FigureCaption = styled.figcaption<{ $alignment?: string }>`
           }
 
           ${mediaQuery.mediumAbove} {
-            max-width: 340px;
             margin-left: 0px;
             margin-right: 0px;
           }
@@ -259,6 +258,7 @@ const ArticleBodyContainer = styled.div<{ $alignment?: string }>`
         return `
           ${mediaQuery.smallOnly} {
             max-width: 512px;
+            padding: 0 24px;
           }
 
           ${mediaQuery.mediumAbove} {

--- a/packages/frontend/src/components/support-action/index.tsx
+++ b/packages/frontend/src/components/support-action/index.tsx
@@ -11,17 +11,10 @@ type SupportActionProps = {
   title: React.ReactNode
   content: React.ReactNode
   className?: string
-  contentClassName?: string
   id?: string
 }
 
-function SupportAction({
-  title,
-  content,
-  className,
-  contentClassName,
-  id,
-}: SupportActionProps) {
+function SupportAction({ title, content, className, id }: SupportActionProps) {
   return (
     <div
       className={cn(
@@ -33,12 +26,7 @@ function SupportAction({
       <div className="relative w-full">
         <TriangleIllustrations />
 
-        <div
-          className={cn(
-            'relative z-10 flex flex-col items-center justify-center px-14 py-12 tablet:px-12 desktop:px-16 desktop:py-16',
-            contentClassName
-          )}
-        >
+        <div className="relative z-10 flex flex-col items-center justify-center px-14 py-14 tablet:px-12 desktop:px-16 desktop:py-16">
           <div className="flex w-full max-w-[510px] flex-col hd:max-w-[584px]">
             <div className="flex flex-col gap-4">
               <h3 className="text-center prose-h3-small !font-swei text-neutral-900 desktop:prose-h3-large">

--- a/packages/frontend/src/modules/about/index.tsx
+++ b/packages/frontend/src/modules/about/index.tsx
@@ -53,7 +53,6 @@ function AboutModule({ teamMembers, consultants }: AboutModuleProps) {
         }
         content={<SupportActionContent />}
         className="bg-yellow-200"
-        contentClassName="py-14 desktop:py-16"
         id="support"
       />
     </main>

--- a/packages/frontend/src/modules/article/components/authors.tsx
+++ b/packages/frontend/src/modules/article/components/authors.tsx
@@ -3,7 +3,7 @@
 import { Button, cn } from '@kids-reporter/routing-ui'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { DEFAULT_AVATAR } from '@/constants'
 import useClickOutside from '@/hooks/use-click-outside'
@@ -142,6 +142,31 @@ function AuthorCard({ author }: { author: Author }) {
 
 function Authors({ authors }: AuthorsProp) {
   const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const [isAtStart, setIsAtStart] = useState(true)
+  const [isAtEnd, setIsAtEnd] = useState(false)
+
+  const updateScrollState = useCallback(() => {
+    const el = scrollContainerRef.current
+    if (!el) return
+    const atStart = el.scrollLeft <= 0
+    const atEnd = el.scrollLeft >= el.scrollWidth - el.clientWidth - 1
+    setIsAtStart(atStart)
+    setIsAtEnd(atEnd)
+  }, [])
+
+  useEffect(() => {
+    const el = scrollContainerRef.current
+    if (!el) return
+    updateScrollState()
+    el.addEventListener('scroll', updateScrollState)
+    const resizeObserver = new ResizeObserver(updateScrollState)
+    resizeObserver.observe(el)
+    return () => {
+      el.removeEventListener('scroll', updateScrollState)
+      resizeObserver.disconnect()
+    }
+  }, [updateScrollState])
+
   const scrollLeft = useCallback(() => {
     if (scrollContainerRef.current) {
       const scrollAmount = CARD_WIDTH + GAP
@@ -174,6 +199,7 @@ function Authors({ authors }: AuthorsProp) {
           variant="secondary"
           className="mr-2 hidden size-11 p-0 tablet:flex"
           onClick={scrollLeft}
+          disabled={isAtStart}
         >
           <ArrowLeft />
         </Button>
@@ -181,6 +207,7 @@ function Authors({ authors }: AuthorsProp) {
           variant="secondary"
           className="hidden size-11 p-0 tablet:flex"
           onClick={scrollRight}
+          disabled={isAtEnd}
         >
           <ArrowRight />
         </Button>

--- a/packages/frontend/src/modules/article/components/related-articles.tsx
+++ b/packages/frontend/src/modules/article/components/related-articles.tsx
@@ -53,7 +53,7 @@ function RelatedArticles({
   }, [visibleArticles, selectedSegment])
 
   return (
-    <div className="mx-auto flex w-full max-w-300 flex-col items-center justify-center px-6 py-10 tablet:px-8 tablet:py-12 desktop:px-12 desktop:py-18 hd:px-14 hd:py-24">
+    <div className="mx-auto flex w-full max-w-300 flex-col items-center justify-center px-6 pt-8 pb-14 tablet:px-8 tablet:pt-14 tablet:pb-16 desktop:px-12 desktop:pt-14 desktop:pb-24 hd:px-14 hd:pt-18 hd:pb-30">
       <div className="mb-6 flex w-full flex-col items-start justify-between gap-6 tablet:mb-8 tablet:flex-row tablet:items-center desktop:mb-10">
         <div className="flex items-center gap-2">
           <div className="flex size-11 items-center justify-center desktop:size-16">

--- a/packages/frontend/src/modules/home/components/topic-slider/index.tsx
+++ b/packages/frontend/src/modules/home/components/topic-slider/index.tsx
@@ -76,12 +76,12 @@ function TopicSlider({ topics }: TopicSliderProp) {
           <SwiperButton
             variant="prev"
             onClick={() => swiperRef.current?.slidePrev()}
-            className="absolute top-26 left-0 z-[900] -translate-y-1/2 scale-[0.625] tablet:top-42 tablet:left-[calc(50%-320px)] tablet:-translate-x-1/2 desktop:top-52 desktop:left-[calc(50%-416px)] desktop:scale-100 hd:top-62 hd:left-[calc(50%-544px)] hd:scale-100"
+            className="absolute top-[calc(30vw-20px)] left-0 z-[900] -translate-y-1/2 scale-[0.625] tablet:top-42 tablet:left-[calc(50%-320px)] tablet:-translate-x-1/2 desktop:top-52 desktop:left-[calc(50%-416px)] desktop:scale-100 hd:top-62 hd:left-[calc(50%-544px)] hd:scale-100"
           />
           <SwiperButton
             variant="next"
             onClick={() => swiperRef.current?.slideNext()}
-            className="absolute top-26 right-0 z-[900] -translate-y-1/2 scale-[0.625] tablet:top-42 tablet:right-[calc(50%-320px)] tablet:translate-x-1/2 desktop:top-52 desktop:right-[calc(50%-416px)] desktop:scale-100 hd:top-62 hd:right-[calc(50%-544px)] hd:scale-100"
+            className="absolute top-[calc(30vw-20px)] right-0 z-[900] -translate-y-1/2 scale-[0.625] tablet:top-42 tablet:right-[calc(50%-320px)] tablet:translate-x-1/2 desktop:top-52 desktop:right-[calc(50%-416px)] desktop:scale-100 hd:top-62 hd:right-[calc(50%-544px)] hd:scale-100"
           />
         </div>
         <WaveIllustrations />

--- a/packages/frontend/src/modules/idea-hub/all-answers/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/all-answers/index.tsx
@@ -150,7 +150,7 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
     <div className="relative flex w-[calc(100%+48px)] flex-col bg-neutral-100 pt-10 tablet:w-[calc(100%+64px)] tablet:pt-12 desktop:w-screen desktop:pt-18 hd:w-screen hd:pt-24">
       <div
         ref={titleRef}
-        className="mb-6 flex scroll-mt-[104px] items-center gap-3 pl-6 tablet:mb-8 tablet:scroll-mt-[112px] tablet:pl-8 desktop:mb-10 desktop:scroll-mt-[136px] desktop:pl-[max(calc(50vw+56px-600px),48px)] hd:scroll-mt-[160px] hd:pl-[calc(50vw-600px+64px)]"
+        className="mb-6 flex scroll-mt-[40px] items-center gap-3 pl-6 tablet:mb-8 tablet:scroll-mt-[48px] tablet:pl-8 desktop:mb-10 desktop:scroll-mt-[136px] desktop:pl-[max(calc(50vw+56px-600px),48px)] hd:scroll-mt-[160px] hd:pl-[calc(50vw-600px+56px)]"
       >
         <div className="h-8 w-1.5 rounded-md bg-blue-400" />
         <h3 className="prose-h3-small font-swei text-neutral-900 desktop:prose-h3-large">
@@ -159,7 +159,7 @@ function AllAnswers({ onOpenModal }: AllAnswersProps) {
       </div>
       <div
         ref={scrollContainerRef}
-        className="flex snap-x snap-mandatory scroll-px-6 gap-6 overflow-x-auto px-6 pb-14 scrollbar-none tablet:scroll-px-8 tablet:px-8 tablet:pb-16 desktop:scroll-px-[max(calc(50vw+56px-600px),48px)] desktop:gap-8 desktop:px-[max(calc(50vw+56px-600px),48px)] desktop:pb-24 hd:scroll-pr-14 hd:scroll-pl-[calc(50vw-600px+64px)] hd:pr-14 hd:pb-30 hd:pl-[calc(50vw-600px+64px)]"
+        className="flex snap-x snap-mandatory scroll-px-6 gap-6 overflow-x-auto px-6 pb-14 scrollbar-none tablet:scroll-px-8 tablet:px-8 tablet:pb-16 desktop:scroll-px-[max(calc(50vw+56px-600px),48px)] desktop:gap-8 desktop:px-[max(calc(50vw+56px-600px),48px)] desktop:pb-24 hd:scroll-pr-14 hd:scroll-pl-[calc(50vw-600px+56px)] hd:pr-14 hd:pb-30 hd:pl-[calc(50vw-600px+56px)]"
       >
         {posts?.map((post, index) => (
           <div

--- a/packages/frontend/src/modules/idea-hub/latest-answers/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/latest-answers/index.tsx
@@ -37,7 +37,7 @@ function LatestAnswers({ onOpenModal }: LatestAnswersProps) {
   }
 
   return (
-    <div className="mt-10 mb-14 flex w-[calc(100%+48px)] flex-col gap-6 tablet:mt-12 tablet:mb-16 tablet:w-full tablet:gap-8 desktop:mt-18 desktop:mb-24 desktop:w-screen desktop:max-w-300 desktop:gap-10 desktop:px-12 hd:mt-24 hd:mb-30 hd:max-w-none hd:px-[calc(50vw-600px+64px)]">
+    <div className="mt-10 mb-14 flex w-[calc(100%+48px)] flex-col gap-6 tablet:mt-12 tablet:mb-16 tablet:w-full tablet:gap-8 desktop:mt-18 desktop:mb-24 desktop:w-screen desktop:max-w-300 desktop:gap-10 desktop:px-14 hd:mt-24 hd:mb-30 hd:max-w-none hd:px-[calc(50vw-600px+56px)]">
       <div className="flex items-center gap-3 pl-6 tablet:pl-0">
         <div className="h-8 w-1.5 rounded-md bg-yellow-400" />
         <h3 className="prose-h3-small font-swei text-neutral-900 desktop:prose-h3-large">
@@ -46,7 +46,7 @@ function LatestAnswers({ onOpenModal }: LatestAnswersProps) {
       </div>
       <div
         className={cn(
-          'flex scrollbar-thin snap-x snap-mandatory scroll-px-6 gap-6 overflow-x-auto px-6 tablet:grid tablet:snap-none tablet:grid-cols-3 tablet:overflow-x-hidden tablet:px-0 desktop:gap-8',
+          'flex snap-x snap-mandatory scroll-px-6 gap-6 overflow-x-auto px-6 scrollbar-none tablet:grid tablet:snap-none tablet:grid-cols-3 tablet:overflow-x-hidden tablet:px-0 desktop:gap-8',
           !isLoading && answers.length === 0 && 'tablet:grid-cols-1'
         )}
       >

--- a/yarn.lock
+++ b/yarn.lock
@@ -5030,7 +5030,7 @@ __metadata:
     "@keystone-ui/button": "npm:^7.0.2"
     "@keystone-ui/fields": "npm:^7.2.0"
     "@keystone-ui/modals": "npm:^6.0.3"
-    "@kids-reporter/draft-editor": "npm:^1.0.26"
+    "@kids-reporter/draft-editor": "npm:^1.0.27"
     "@twreporter/errors": "npm:^1.1.1"
     axios: "npm:^0.26.0"
     draft-convert: "npm:^2.1.12"
@@ -5094,7 +5094,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/draft-editor@npm:^1.0.26, @kids-reporter/draft-editor@workspace:packages/draft-editor":
+"@kids-reporter/draft-editor@npm:^1.0.27, @kids-reporter/draft-editor@workspace:packages/draft-editor":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/draft-editor@workspace:packages/draft-editor"
   dependencies:
@@ -5107,7 +5107,7 @@ __metadata:
     "@keystone-ui/button": "npm:^7.0.2"
     "@keystone-ui/fields": "npm:^7.2.0"
     "@keystone-ui/modals": "npm:^6.0.3"
-    "@kids-reporter/draft-renderer": "npm:^1.0.22"
+    "@kids-reporter/draft-renderer": "npm:^1.0.23"
     "@twreporter/errors": "npm:^1.1.2"
     axios: "npm:^1.12.2"
     babel-loader: "npm:^8.3.0"
@@ -5126,7 +5126,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/draft-renderer@npm:^1.0.13, @kids-reporter/draft-renderer@npm:^1.0.22, @kids-reporter/draft-renderer@workspace:packages/draft-renderer":
+"@kids-reporter/draft-renderer@npm:^1.0.13, @kids-reporter/draft-renderer@npm:^1.0.23, @kids-reporter/draft-renderer@workspace:packages/draft-renderer":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/draft-renderer@workspace:packages/draft-renderer"
   dependencies:


### PR DESCRIPTION
## Summary

This PR fixes several article-page and related UI defects: draft-editor block clickability, draft-renderer article content and image layout/breakpoints, support-action API simplification, article authors carousel behavior, and spacing/scroll adjustments across related-articles, idea-hub, and topic slider.

## Changes

- **draft-editor**: Forward `onClick` on `EditableBlock` so the entire block is clickable (not only the edit button). Bump package to 1.0.27 and core dependency to ^1.0.27.
- **draft-renderer**: Use `mediumAbove` instead of `desktopAbove` for paragraph/list/atomic margin and caption rules; fix Atomic caption alignment by separating image-block and image-slideshow selectors; simplify image-link paragraph styles (margin, alignment, max-width); remove fixed caption max-width and add small-screen padding on article body containers. Bump package to 1.0.23; draft-editor depends on ^1.0.23.
- **frontend – SupportAction**: Remove `contentClassName` prop and use fixed content padding (`py-14 desktop:py-16`). Update about module to stop passing `contentClassName`.
- **frontend – article authors**: Add scroll state (`isAtStart` / `isAtEnd`) with scroll listener and ResizeObserver; disable prev/next buttons at start/end.
- **frontend – related-articles**: Adjust vertical padding to asymmetric values (e.g. pt-8 pb-14, tablet/desktop/hd variants).
- **frontend – topic slider**: Make Swiper prev/next button vertical position responsive via `top-[calc(30vw-20px)]` on small screens instead of fixed `top-26`.
- **frontend – idea-hub**: Tweak scroll-margin and horizontal padding (all-answers, latest-answers); latest-answers use `scrollbar-none` and updated desktop/hd padding.
- **core & lockfile**: Bump core to 1.0.27 and refresh `yarn.lock` for updated workspace deps.

## Adotes

- Styling and breakpoint changes in draft-renderer may affect article layout on various viewports; worth checking article, idea-hub, and topic slider on mobile/tablet/desktop.
- Authors carousel edge state (empty or single item) is handled by disabling buttons when at start/end.

## Screenshot(s)


## Reference(s)