### PR TITLE
fix(frontend): fix slideshow and related articles spacing

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/cms-core",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "description": "",
   "main": "lib/index.js",
   "types": "src/index.ts",
@@ -36,7 +36,7 @@
     "@keystone-ui/button": "^7.0.2",
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",
-    "@kids-reporter/draft-editor": "^1.0.27",
+    "@kids-reporter/draft-editor": "^1.0.28",
     "@twreporter/errors": "^1.1.1",
     "axios": "^0.26.0",
     "draft-convert": "^2.1.12",

--- a/packages/draft-editor/package.json
+++ b/packages/draft-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/draft-editor",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -29,7 +29,7 @@
     "@keystone-ui/button": "^7.0.2",
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",
-    "@kids-reporter/draft-renderer": "^1.0.23",
+    "@kids-reporter/draft-renderer": "^1.0.24",
     "@twreporter/errors": "^1.1.2",
     "axios": "^1.12.2",
     "draft-js": "^0.11.7"

--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/draft-renderer",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/src/block-renderers/slideshow-block.tsx
+++ b/packages/draft-renderer/src/block-renderers/slideshow-block.tsx
@@ -323,7 +323,7 @@ const NavigationAndCaptionRow = styled.div`
   }
 
   ${mediaQuery.desktopAbove} {
-    padding: 16px 0;
+    padding: 16px 0 0 0;
   }
 `
 

--- a/packages/frontend/src/modules/article/components/related-articles.tsx
+++ b/packages/frontend/src/modules/article/components/related-articles.tsx
@@ -53,7 +53,7 @@ function RelatedArticles({
   }, [visibleArticles, selectedSegment])
 
   return (
-    <div className="mx-auto flex w-full max-w-300 flex-col items-center justify-center px-6 pt-8 pb-14 tablet:px-8 tablet:pt-14 tablet:pb-16 desktop:px-12 desktop:pt-14 desktop:pb-24 hd:px-14 hd:pt-18 hd:pb-30">
+    <div className="mx-auto flex w-full max-w-300 flex-col items-center justify-center px-6 pt-12 pb-14 tablet:px-8 tablet:pt-18 tablet:pb-16 desktop:px-12 desktop:pt-18 desktop:pb-24 hd:px-14 hd:pt-22 hd:pb-30">
       <div className="mb-6 flex w-full flex-col items-start justify-between gap-6 tablet:mb-8 tablet:flex-row tablet:items-center desktop:mb-10">
         <div className="flex items-center gap-2">
           <div className="flex size-11 items-center justify-center desktop:size-16">

--- a/yarn.lock
+++ b/yarn.lock
@@ -5030,7 +5030,7 @@ __metadata:
     "@keystone-ui/button": "npm:^7.0.2"
     "@keystone-ui/fields": "npm:^7.2.0"
     "@keystone-ui/modals": "npm:^6.0.3"
-    "@kids-reporter/draft-editor": "npm:^1.0.27"
+    "@kids-reporter/draft-editor": "npm:^1.0.28"
     "@twreporter/errors": "npm:^1.1.1"
     axios: "npm:^0.26.0"
     draft-convert: "npm:^2.1.12"
@@ -5094,7 +5094,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/draft-editor@npm:^1.0.27, @kids-reporter/draft-editor@workspace:packages/draft-editor":
+"@kids-reporter/draft-editor@npm:^1.0.28, @kids-reporter/draft-editor@workspace:packages/draft-editor":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/draft-editor@workspace:packages/draft-editor"
   dependencies:
@@ -5107,7 +5107,7 @@ __metadata:
     "@keystone-ui/button": "npm:^7.0.2"
     "@keystone-ui/fields": "npm:^7.2.0"
     "@keystone-ui/modals": "npm:^6.0.3"
-    "@kids-reporter/draft-renderer": "npm:^1.0.23"
+    "@kids-reporter/draft-renderer": "npm:^1.0.24"
     "@twreporter/errors": "npm:^1.1.2"
     axios: "npm:^1.12.2"
     babel-loader: "npm:^8.3.0"
@@ -5126,7 +5126,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/draft-renderer@npm:^1.0.13, @kids-reporter/draft-renderer@npm:^1.0.23, @kids-reporter/draft-renderer@workspace:packages/draft-renderer":
+"@kids-reporter/draft-renderer@npm:^1.0.13, @kids-reporter/draft-renderer@npm:^1.0.24, @kids-reporter/draft-renderer@workspace:packages/draft-renderer":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/draft-renderer@workspace:packages/draft-renderer"
   dependencies:


### PR DESCRIPTION
## Summary

Fixes article defect with two spacing adjustments: (1) slideshow block navigation/caption row no longer has bottom padding on desktop, and (2) the related articles section gets increased top padding across breakpoints for better visual balance. Package versions are bumped in core, draft-editor, and draft-renderer to keep the monorepo in sync.

## Changes

- **draft-renderer**: Bump version to 1.0.24. In `slideshow-block.tsx`, change `NavigationAndCaptionRow` desktop padding from `16px 0` to `16px 0 0 0` (removes bottom padding on desktop).
- **draft-editor**: Bump version to 1.0.28 and dependency `@kids-reporter/draft-renderer` to ^1.0.24.
- **core**: Bump version to 1.0.28 and dependency `@kids-reporter/draft-editor` to ^1.0.28.
- **frontend – related-articles**: Increase p padding at all breakpoints (e.g. `pt-8` → `pt-12`, tablet/desktop/hd increased) for the related articles container.
- **yarn.lock**: Updated for the above dependency version changes.

## Additional Notes

- Before opening the PR, commit and push the currently unstaged changes (core, draft-editor, related-articles, yarn.lock) so the PR reflects the full fix.
- If defect #5 is tracked elsewhere (e.g. Notion), consider adding the link under Reference(s) below.

## Screenshot(s)

## Reference(s)