### PR TITLE
fix(frontend): article nav, TOC anchors, and content fixes

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/cms-core",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "",
   "main": "lib/index.js",
   "types": "src/index.ts",
@@ -36,7 +36,7 @@
     "@keystone-ui/button": "^7.0.2",
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",
-    "@kids-reporter/draft-editor": "^1.0.28",
+    "@kids-reporter/draft-editor": "^1.0.29",
     "@twreporter/errors": "^1.1.1",
     "axios": "^0.26.0",
     "draft-convert": "^2.1.12",

--- a/packages/draft-editor/package.json
+++ b/packages/draft-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/draft-editor",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -29,7 +29,7 @@
     "@keystone-ui/button": "^7.0.2",
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",
-    "@kids-reporter/draft-renderer": "^1.0.24",
+    "@kids-reporter/draft-renderer": "^1.0.25",
     "@twreporter/errors": "^1.1.2",
     "axios": "^1.12.2",
     "draft-js": "^0.11.7"

--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/draft-renderer",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/src/block-render-maps/article-content.tsx
+++ b/packages/draft-renderer/src/block-render-maps/article-content.tsx
@@ -111,22 +111,11 @@ export const Atomic = styled.div`
   }
 
   ${mediaQuery.desktopAbove} {
-    div:has(+ div [data-image-block-caption-alignment='default'])
-      [data-image-block-caption-alignment='default'] {
-      position: relative !important;
-    }
-    div:has(+ div [data-image-block-caption-alignment='default'])
-      [data-image-slideshow-caption-alignment='default'] {
-      position: relative !important;
-    }
-
-    div:has(+ div [data-image-slideshow-caption-alignment='default'])
-      [data-image-block-caption-alignment='default'] {
-      position: relative !important;
-    }
-    div:has(+ div [data-image-slideshow-caption-alignment='default'])
-      [data-image-slideshow-caption-alignment='default'] {
-      position: relative !important;
+    > div:last-child figcaption[data-image-block-caption-alignment='default'] {
+      position: absolute;
+      right: 0;
+      top: 100%;
+      margin-right: 0px;
     }
   }
 `

--- a/packages/draft-renderer/src/block-renderers/image-block.tsx
+++ b/packages/draft-renderer/src/block-renderers/image-block.tsx
@@ -63,18 +63,10 @@ const FigureCaption = styled.figcaption<{ $alignment?: string }>`
 
           ${mediaQuery.desktopAbove} {
             max-width: calc(100% - 640px);
-            position: absolute;
-            right: 0;
-            top: 100%;
-            margin-right: 0px;
           }
 
           ${mediaQuery.largeOnly} {
             max-width: 240px;
-            position: absolute;
-            right: 0;
-            top: 100%;
-            margin-right: 0px;
           }
         `
       case 'paragraph-width':

--- a/packages/draft-renderer/src/block-renderers/slideshow-block.tsx
+++ b/packages/draft-renderer/src/block-renderers/slideshow-block.tsx
@@ -159,7 +159,6 @@ const CaptionContainer = styled.div`
   ${mediaQuery.desktopAbove} {
     position: absolute;
     right: 0;
-    top: calc(100% - 76px);
   }
 `
 

--- a/packages/draft-renderer/src/entity-decorators/link-decorator.tsx
+++ b/packages/draft-renderer/src/entity-decorators/link-decorator.tsx
@@ -1,6 +1,6 @@
 import { ContentState } from 'draft-js'
 import React from 'react'
-import styled, { ThemeProvider, useTheme } from 'styled-components'
+import styled, { ThemeProvider } from 'styled-components'
 
 import { ENTITY, findEntitiesByType } from '../utils/entity'
 
@@ -37,16 +37,17 @@ const LinkInner = (props: {
   children: React.ReactNode
 }) => {
   const { url } = props.contentState.getEntity(props.entityKey).getData()
-  const theme = useTheme()
 
   // Handling for internal/external links, internal links start with '#'
   const linkProps = url.match(/^#/)
     ? {
         onClick: () => {
           const anchor = document.querySelector(url) as HTMLElement
+          const elementPosition = anchor.getBoundingClientRect().top
+          const offsetPosition = elementPosition + window.scrollY - 64
           if (anchor) {
             window.scrollTo({
-              top: anchor.offsetTop - (theme as any)?.offsetTop,
+              top: offsetPosition,
               behavior: 'smooth',
             })
           }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -19,7 +19,7 @@
     "@googleapis/customsearch": "^1.0.4",
     "@hookform/resolvers": "^5.2.2",
     "@kids-reporter/draft-renderer": "^1.0.13",
-    "@kids-reporter/routing-ui": "0.1.13",
+    "@kids-reporter/routing-ui": "0.1.14",
     "@next/third-parties": "^14.1.1",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/packages/frontend/src/components/table-of-content/table-of-content-side-menu.tsx
+++ b/packages/frontend/src/components/table-of-content/table-of-content-side-menu.tsx
@@ -25,6 +25,8 @@ type TableOfContentSideMenuProps = {
   scrollDownDistance?: number
   /** Aria-label for the nav element. */
   ariaLabel?: string
+  /** Manually trigger assign anchors. */
+  manuallyAssignAnchors?: boolean
 }
 
 function makeAnchorIndexKey(key: string) {
@@ -43,6 +45,7 @@ function TableOfContentSideMenu({
   anchorIdPrefix = DEFAULT_ANCHOR_ID_PREFIX,
   scrollDownDistance = DEFAULT_SCROLL_DOWN_DISTANCE,
   ariaLabel = '文章目錄',
+  manuallyAssignAnchors: triggerAssignAnchors = true,
 }: TableOfContentSideMenuProps) {
   const [currentActiveIndex, setCurrentActiveIndex] = useState<string | null>(
     makeAnchorKey(TABLE_OF_CONTENT_BACK_TO_TOP_KEY, anchorIdPrefix)
@@ -52,16 +55,18 @@ function TableOfContentSideMenu({
   const menuContainerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    anchorRefs.current = indexes
-      .map(({ key }) => {
-        const id = makeAnchorKey(key, anchorIdPrefix)
-        const element = document.querySelector(
-          `#${CSS.escape(id)}`
-        ) as HTMLElement | null
-        return element
-      })
-      .filter((anchor): anchor is HTMLElement => anchor !== null)
-  }, [indexes, anchorIdPrefix])
+    if (triggerAssignAnchors) {
+      anchorRefs.current = indexes
+        .map(({ key }) => {
+          const id = makeAnchorKey(key, anchorIdPrefix)
+          const element = document.querySelector(
+            `#${CSS.escape(id)}`
+          ) as HTMLElement | null
+          return element
+        })
+        .filter((anchor): anchor is HTMLElement => anchor !== null)
+    }
+  }, [indexes, anchorIdPrefix, triggerAssignAnchors])
 
   const handleClickAnchorIndex = useCallback(
     (key: string) => {
@@ -80,6 +85,7 @@ function TableOfContentSideMenu({
   )
 
   useEffect(() => {
+    if (!triggerAssignAnchors) return
     const anchors = anchorRefs.current
 
     if (anchors.length === 0) return
@@ -149,7 +155,7 @@ function TableOfContentSideMenu({
       observer.disconnect()
       window.removeEventListener('scroll', handleScroll)
     }
-  }, [indexes, anchorIdPrefix])
+  }, [indexes, anchorIdPrefix, triggerAssignAnchors])
 
   const handleClickOutside = useCallback(() => {
     if (isExpanded) {

--- a/packages/frontend/src/modules/about/components/join-us/constants.ts
+++ b/packages/frontend/src/modules/about/components/join-us/constants.ts
@@ -15,7 +15,7 @@ export const JOIN_US_CARDS: Card[] = [
     anchorId: 'call',
     title: '呼叫報導仔',
     description:
-      '2025年全新開發的閱讀探索新功能，有測驗、有互動、可留言，由小幫手「報導仔」協助下，閱讀文章效率加倍、趣味無限。',
+      '2026年全新開發的閱讀探索新功能，有測驗、有互動、可留言，由小幫手「報導仔」協助下，閱讀文章效率加倍、趣味無限。',
     buttonText: '了解更多',
     actionType: 'dialog',
     actionValue: '',

--- a/packages/frontend/src/modules/about/components/reader-recommendations/constants.tsx
+++ b/packages/frontend/src/modules/about/components/reader-recommendations/constants.tsx
@@ -21,7 +21,7 @@ export const TESTIMONIALS: Testimonial[] = [
   {
     id: 'ding-zhen-huan',
     text: '從小六開始發現《少年報導者》，每一篇報導都具有意義，也讓我了解這個社會發生什麼事，充實了我小學的最後一年，如今我升上國中，要繼續把好看的內容分享給同學看。',
-    name: '丁馥孋',
+    name: '小讀者Tiffany',
     title: '國中生',
   },
   {

--- a/packages/frontend/src/modules/article/components/post-renderer.tsx
+++ b/packages/frontend/src/modules/article/components/post-renderer.tsx
@@ -4,7 +4,6 @@ import 'react-loading-skeleton/dist/skeleton.css'
 import { ArticleBodyDraftRenderer } from '@kids-reporter/draft-renderer'
 import { cn } from '@kids-reporter/routing-ui'
 import { RawDraftContentState } from 'draft-js'
-import { useEffect, useState } from 'react'
 
 import { FontSizeLevel, STICKY_HEADER_HEIGHT } from '@/constants'
 

--- a/packages/frontend/src/modules/article/components/post-renderer.tsx
+++ b/packages/frontend/src/modules/article/components/post-renderer.tsx
@@ -28,14 +28,12 @@ function trimEmptyBlocks(raw: RawDraftContentState): RawDraftContentState {
 
 type PostProp = {
   content: RawDraftContentState
+  shouldMount?: boolean
 }
 
-function PostRenderer({ content }: PostProp) {
+function PostRenderer({ content, shouldMount }: PostProp) {
   const { onImageModalOpen, fontSize } = useArticleContext()
-  const [isMounted, setIsMounted] = useState(false)
-  useEffect(() => {
-    setIsMounted(true)
-  }, [])
+
   return (
     <div
       className={cn(
@@ -46,7 +44,7 @@ function PostRenderer({ content }: PostProp) {
         ]
       )}
     >
-      {isMounted && (
+      {shouldMount && (
         <ArticleBodyDraftRenderer
           rawContentState={trimEmptyBlocks(content)}
           onImageModalOpen={onImageModalOpen}

--- a/packages/frontend/src/modules/article/components/title-hero/hero-image.tsx
+++ b/packages/frontend/src/modules/article/components/title-hero/hero-image.tsx
@@ -41,7 +41,7 @@ function HeroImage({
   return (
     <figure className="mx-auto pt-10 hd:w-[1058px]">
       <div
-        className="relative inline-flex w-full overflow-hidden hd:!aspect-video"
+        className="relative inline-flex w-full overflow-hidden"
         style={{
           aspectRatio: aspectRatio,
         }}

--- a/packages/frontend/src/modules/article/index.tsx
+++ b/packages/frontend/src/modules/article/index.tsx
@@ -8,7 +8,7 @@ import {
   useScrollLevel,
 } from '@kids-reporter/routing-ui'
 import { useRouter } from 'next/navigation'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { TableOfContentSideMenu } from '@/components/table-of-content'
 import { FontSizeLevel } from '@/constants'
@@ -219,11 +219,20 @@ const ArticleModule = ({
 
   const isDesktop = useMediaQuery('(min-width: 1024px)')
 
+  const [isMounted, setIsMounted] = useState(false)
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
   return (
     <>
       <BaodaozaiVisibilitySetter show={showBaodaozai} />
       <HeaderPostTitleSetter postTitle={post?.title} />
-      {tocIndexes.length > 0 && <TableOfContentSideMenu indexes={tocIndexes} />}
+      {tocIndexes.length > 0 && (
+        <TableOfContentSideMenu
+          indexes={tocIndexes}
+          manuallyAssignAnchors={isMounted}
+        />
+      )}
       <div className="relative w-screen">
         <ArticleContext.Provider
           value={{
@@ -285,7 +294,10 @@ const ArticleModule = ({
               <SeparateIcon />
             </div>
             <div className="relative w-full">
-              <PostRenderer content={post?.content ?? {}} />
+              <PostRenderer
+                content={post?.content ?? {}}
+                shouldMount={isMounted}
+              />
               <div className="absolute top-[calc(25%+50vh)]">
                 <ArticleBaodaozaiEventTrigger
                   id="change-encourage-reading"

--- a/packages/frontend/src/modules/article/index.tsx
+++ b/packages/frontend/src/modules/article/index.tsx
@@ -295,7 +295,7 @@ const ArticleModule = ({
             </div>
             <div className="relative w-full">
               <PostRenderer
-                content={post?.content ?? {}}
+                content={post?.content ?? { blocks: [], entityMap: {} }}
                 shouldMount={isMounted}
               />
               <div className="absolute top-[calc(25%+50vh)]">

--- a/packages/routing-ui/package.json
+++ b/packages/routing-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kids-reporter/routing-ui",
   "license": "MIT",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Routing UI for Kids Reporter",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/routing-ui/src/constants/default-values.tsx
+++ b/packages/routing-ui/src/constants/default-values.tsx
@@ -141,7 +141,7 @@ export const ADDITIONAL_MENU_ITEMS: MenuItem[] = [
   },
   {
     label: '聯絡我們',
-    href: '/about#mail',
+    href: '/about#contact',
     subItems: [],
   },
   {

--- a/packages/routing-ui/src/header/menu/index.tsx
+++ b/packages/routing-ui/src/header/menu/index.tsx
@@ -122,10 +122,6 @@ function Menu({
           </div>
 
           <div className="py-4 flex-1">
-            <HeaderMenuItem {...menuItems?.[0]} />
-
-            <Divider />
-
             {/* Categories */}
             <div className="py-2">
               <HeaderMenuItemGroup isMenuOpen={isOpen} menuItems={menuItems} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -5030,7 +5030,7 @@ __metadata:
     "@keystone-ui/button": "npm:^7.0.2"
     "@keystone-ui/fields": "npm:^7.2.0"
     "@keystone-ui/modals": "npm:^6.0.3"
-    "@kids-reporter/draft-editor": "npm:^1.0.28"
+    "@kids-reporter/draft-editor": "npm:^1.0.29"
     "@twreporter/errors": "npm:^1.1.1"
     axios: "npm:^0.26.0"
     draft-convert: "npm:^2.1.12"
@@ -5094,7 +5094,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/draft-editor@npm:^1.0.28, @kids-reporter/draft-editor@workspace:packages/draft-editor":
+"@kids-reporter/draft-editor@npm:^1.0.29, @kids-reporter/draft-editor@workspace:packages/draft-editor":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/draft-editor@workspace:packages/draft-editor"
   dependencies:
@@ -5107,7 +5107,7 @@ __metadata:
     "@keystone-ui/button": "npm:^7.0.2"
     "@keystone-ui/fields": "npm:^7.2.0"
     "@keystone-ui/modals": "npm:^6.0.3"
-    "@kids-reporter/draft-renderer": "npm:^1.0.24"
+    "@kids-reporter/draft-renderer": "npm:^1.0.25"
     "@twreporter/errors": "npm:^1.1.2"
     axios: "npm:^1.12.2"
     babel-loader: "npm:^8.3.0"
@@ -5126,7 +5126,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/draft-renderer@npm:^1.0.13, @kids-reporter/draft-renderer@npm:^1.0.24, @kids-reporter/draft-renderer@workspace:packages/draft-renderer":
+"@kids-reporter/draft-renderer@npm:^1.0.13, @kids-reporter/draft-renderer@npm:^1.0.25, @kids-reporter/draft-renderer@workspace:packages/draft-renderer":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/draft-renderer@workspace:packages/draft-renderer"
   dependencies:
@@ -5166,7 +5166,7 @@ __metadata:
     "@graphql-codegen/typescript-operations": "npm:^5.0.2"
     "@hookform/resolvers": "npm:^5.2.2"
     "@kids-reporter/draft-renderer": "npm:^1.0.13"
-    "@kids-reporter/routing-ui": "npm:0.1.13"
+    "@kids-reporter/routing-ui": "npm:0.1.14"
     "@next/bundle-analyzer": "npm:^14.2.33"
     "@next/eslint-plugin-next": "npm:^14.2.33"
     "@next/third-parties": "npm:^14.1.1"
@@ -5233,7 +5233,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/routing-ui@npm:0.1.13, @kids-reporter/routing-ui@workspace:packages/routing-ui":
+"@kids-reporter/routing-ui@npm:0.1.14, @kids-reporter/routing-ui@workspace:packages/routing-ui":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/routing-ui@workspace:packages/routing-ui"
   dependencies:


### PR DESCRIPTION
## Summary

Fix article in-page navigation (TOC and anchor links), image/slideshow caption styling, and minor content/navigation updates. TOC anchor assignment and article body now run after client mount to avoid hydration issues.

## Changes

- **draft-renderer**: Simplified article image/slideshow caption positioning CSS; internal anchor links scroll using `getBoundingClientRect()` + 64px offset instead of theme; removed `useTheme` from link decorator
- **frontend (article)**: Table of content side menu supports `manuallyAssignAnchors`; article module defers TOC anchor assignment and post render until after mount (`isMounted`)
- **frontend (post-renderer)**: Replaced internal mount state with `shouldMount` prop from parent
- **frontend (hero)**: Hero image container no longer forces `hd:!aspect-video`; keeps inline aspect ratio
- **frontend (about)**: Join us copy year 2025 → 2026; reader recommendation name 丁馥孋 → 小讀者Tiffany
- **routing-ui**: 「聯絡我們」 link `/about#mail` → `/about#contact`; removed first menu item and divider from mobile menu
- Package version bumps: core, draft-editor, draft-renderer, routing-ui; frontend dependency and yarn.lock updated

## Additional Notes

- Verify TOC and in-article anchor scroll on article pages with multiple headings
- Check image/slideshow caption layout on desktop
- When `manuallyAssignAnchors` is false, TOC will not assign anchors or track scroll position; article page relies on `isMounted` so this is intended

## Screenshot(s)

## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/20260223-defect-3108dbdca932808f8f41e09504ef849e?source=copy_link)