### PR TITLE
feat(frontend): hide brief when empty

### DIFF
--- a/packages/frontend/src/modules/article/components/post-renderer.tsx
+++ b/packages/frontend/src/modules/article/components/post-renderer.tsx
@@ -12,18 +12,7 @@ import {
   ARTICLE_FONT_SIZE_CLASSNAMES_LARGE,
 } from '../constants'
 import { useArticleContext } from '../context'
-
-function trimEmptyBlocks(raw: RawDraftContentState): RawDraftContentState {
-  const { blocks, entityMap } = raw
-  if (blocks.length === 0) return raw
-
-  const filtered = blocks.filter(
-    (block) => !(block.type === 'unstyled' && block.text.trim() === '')
-  )
-  if (filtered.length === blocks.length) return raw
-
-  return { blocks: filtered, entityMap }
-}
+import trimEmptyBlocks from '../utils/trim-empty-blocks'
 
 type PostProp = {
   content: RawDraftContentState

--- a/packages/frontend/src/modules/article/index.tsx
+++ b/packages/frontend/src/modules/article/index.tsx
@@ -44,6 +44,7 @@ import useBatchSubmitAnswers from './hooks/use-batch-submit-answers'
 import { Keyword } from './types'
 import parsePostToContent from './utils/parse-post-to-content'
 import parseTocIndexesFromEntityMap from './utils/parse-toc-indexes-from-entity-map'
+import trimEmptyBlocks from './utils/trim-empty-blocks'
 
 const ArticleModule = ({
   post,
@@ -223,6 +224,11 @@ const ArticleModule = ({
   useEffect(() => {
     setIsMounted(true)
   }, [])
+
+  const trimmedBrief = useMemo(() => {
+    return trimEmptyBlocks(post?.brief ?? { blocks: [], entityMap: {} })
+  }, [post?.brief])
+
   return (
     <>
       <BaodaozaiVisibilitySetter show={showBaodaozai} />
@@ -282,17 +288,24 @@ const ArticleModule = ({
               disabled={!isScrollingDown}
               startReadingContent={post?.opening ?? ''}
             />
-            <ArticleSummary
-              subSubcategoryName={subSubcategory?.name ?? ''}
-              subSubcategoryURL={subSubcategoryURL ?? ''}
-              publishedDate={post?.publishedDate ?? ''}
-              content={post?.brief}
-              authors={authorsInBrief}
-              fontSizeLevel={fontSize}
-            />
-            <div className="mb-10">
-              <SeparateIcon />
-            </div>
+            {trimmedBrief.blocks.length > 0 ? (
+              <>
+                <ArticleSummary
+                  subSubcategoryName={subSubcategory?.name ?? ''}
+                  subSubcategoryURL={subSubcategoryURL ?? ''}
+                  publishedDate={post?.publishedDate ?? ''}
+                  content={trimmedBrief}
+                  authors={authorsInBrief}
+                  fontSizeLevel={fontSize}
+                />
+                <div className="mb-10">
+                  <SeparateIcon />
+                </div>
+              </>
+            ) : (
+              <div className="mb-10 tablet:mb-15"></div>
+            )}
+
             <div className="relative w-full">
               <PostRenderer
                 content={post?.content ?? { blocks: [], entityMap: {} }}

--- a/packages/frontend/src/modules/article/utils/trim-empty-blocks.ts
+++ b/packages/frontend/src/modules/article/utils/trim-empty-blocks.ts
@@ -1,0 +1,15 @@
+import { RawDraftContentState } from 'draft-js'
+
+function trimEmptyBlocks(raw: RawDraftContentState): RawDraftContentState {
+  const { blocks, entityMap } = raw
+  if (blocks.length === 0) return raw
+
+  const filtered = blocks.filter(
+    (block) => !(block.type === 'unstyled' && block.text.trim() === '')
+  )
+  if (filtered.length === blocks.length) return raw
+
+  return { blocks: filtered, entityMap }
+}
+
+export default trimEmptyBlocks


### PR DESCRIPTION
## Summary

Hide the article brief/summary section when it is empty (or contains only empty blocks). `trimEmptyBlocks` is extracted to a shared util and used for both brief and post content; layout spacing is preserved when the brief is hidden.

## Changes

- **New util** `trim-empty-blocks.ts`: `trimEmptyBlocks(raw)` filters out unstyled blocks with no text from Draft.js raw content state.
- **`post-renderer.tsx`**: Remove inline `trimEmptyBlocks` and import from `../utils/trim-empty-blocks`.
- **`article/index.tsx`**: Compute `trimmedBrief` with `useMemo` from `post?.brief`; render `ArticleSummary` and separator only when `trimmedBrief.blocks.length > 0`, otherwise render a spacer div to keep layout.

## Additional Notes

- Empty brief = no blocks or only unstyled blocks with blank/whitespace-only text.
- When brief is hidden, a spacer preserves vertical rhythm before main content.

## Screenshot(s)

<img width="844" height="606" alt="image" src="https://github.com/user-attachments/assets/d1517749-14ba-49c6-a484-7a73bbedd270" />

<img width="1092" height="859" alt="image" src="https://github.com/user-attachments/assets/a083a390-0177-41be-8036-67bab8963aed" />

## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/3118dbdca9328039929eec6d6af0dc95?source=copy_link)