### PR TITLE
fix(frontend): topic about content styling and award card team label

### DIFF
--- a/packages/frontend/src/app/(general)/_components/topic/draft-renderer.tsx
+++ b/packages/frontend/src/app/(general)/_components/topic/draft-renderer.tsx
@@ -2,12 +2,14 @@
 import 'react-loading-skeleton/dist/skeleton.css'
 
 import { ProjectContentDraftRenderer } from '@kids-reporter/draft-renderer'
+import { cn } from '@kids-reporter/routing-ui'
 import { RawDraftContentState } from 'draft-js'
 import { useEffect, useState } from 'react'
 import Skeleton from 'react-loading-skeleton'
 import styled from 'styled-components'
 
 import { Theme } from '@/constants'
+import { ARTICLE_FONT_SIZE_CLASSNAMES } from '@/modules/article/constants'
 
 const SkeletonContainer = styled.div`
   width: 100%;
@@ -30,10 +32,17 @@ export const DraftRenderer = ({
   }, [])
 
   return isMounted && rawContentState && theme ? (
-    <ProjectContentDraftRenderer
-      rawContentState={rawContentState}
-      themeColor={theme}
-    />
+    <div
+      className={cn(
+        'mb-10 prose-article text-neutral-900 tablet:mb-15',
+        ...ARTICLE_FONT_SIZE_CLASSNAMES
+      )}
+    >
+      <ProjectContentDraftRenderer
+        rawContentState={rawContentState}
+        themeColor={theme}
+      />
+    </div>
   ) : (
     <SkeletonContainer>
       <Skeleton width={'80%'} count={5} />

--- a/packages/frontend/src/modules/about/components/awards/award-card.tsx
+++ b/packages/frontend/src/modules/about/components/awards/award-card.tsx
@@ -58,7 +58,7 @@ function AwardCard({ card }: AwardCardProps) {
             )
           })}
         </p>
-        <p className="prose-p2 text-neutral-700">團隊：{card.team}</p>
+        <p className="prose-p2 text-neutral-700">{card.team}</p>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Fixes two defects: (1) topic \"about\" content now uses the same article typography and layout as article body content for consistency; (2) the about page award card no longer shows a redundant \"團隊：\" label before the team name.

## Changes

- **Topic draft renderer** (\`app/(general)/_components/topic/draft-renderer.tsx\`): Wrapped \`ProjectContentDraftRenderer\` in a container with \`prose-article\`, \`text-neutral-900\`, responsive margins (\`mb-10\`, \`tablet:mb-15\`), and \`ARTICLE_FONT_SIZE_CLASSNAMES\` from the article module so topic about content matches article body typography (heading sizes, etc.).
- **Award card** (\`modules/about/components/awards/award-card.tsx\`): Removed the \"團隊：\" prefix; the team line now displays only the team value.

## Additional Notes

- Tontent and article body now share the same design tokens for headings and spacing, reducing inconsistency between topic and article pages.
- No reviewer specified; add \`--reviewer <github-username>\` if needed.

## Screenshot(s)

## Reference(s)