### PR TITLE
feat(frontend): adjust article font weight and awards wording

### DIFF
--- a/packages/frontend/src/app/layout.tsx
+++ b/packages/frontend/src/app/layout.tsx
@@ -14,7 +14,7 @@ const GTM_ID = 'GTM-T37WZJ44'
 
 const notoSansTC = Noto_Sans_TC({
   subsets: ['latin'],
-  weight: ['500', '700'],
+  weight: ['400', '500', '700'],
   variable: '--font-noto-sans-tc',
 })
 

--- a/packages/frontend/src/globals.css
+++ b/packages/frontend/src/globals.css
@@ -507,7 +507,7 @@
 @utility prose-article {
   font-family: var(--font-family-noto);
   font-size: var(--font-size-article);
-  font-weight: 500;
+  font-weight: 400;
   line-height: var(--line-height-article);
   letter-spacing: 1.08px;
 }

--- a/packages/frontend/src/modules/about/components/awards/constants.ts
+++ b/packages/frontend/src/modules/about/components/awards/constants.ts
@@ -26,7 +26,7 @@ export const AWARDS_BY_YEAR: AwardsByYear[] = [
     cards: [
       {
         id: '2025-card1',
-        title: '第24屆卓越新聞獎【不分媒體類—藝術與文化新聞獎】',
+        title: '第24屆卓越新聞獎【不分媒體類—藝術與文化新聞獎】入圍',
         workParts: [
           {
             type: 'link',


### PR DESCRIPTION
## Summary

Adjust article typography to use regular (400) font weight instead of medium (500), and clarify one award title in the About awards section.

## Changes

- **Font loading** (`packages/frontend/src/app/layout.tsx`): Add weight `400` to Noto Sans TC so the regular weight is available.
- **Article prose** (`packages/frontend/src/globals.css`): Change `prose-article` font-weight from `500` to `400`.
- **Awards copy** (`packages/frontend/src/modules/about/components/awards/constants.ts`): Update 第24屆卓越新聞獎 card title to include 「入圍」 for accuracy.

## Additional Notes

Two commits on this branch: one for font weight changes, one for the wording update.

## Screenshot(s)

## Reference(s)

