### PR TITLE
fix(frontend): scale font size correctly for article large font mode

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -19,7 +19,7 @@
     "@googleapis/customsearch": "^1.0.4",
     "@hookform/resolvers": "^5.2.2",
     "@kids-reporter/draft-renderer": "^1.0.13",
-    "@kids-reporter/routing-ui": "0.1.16",
+    "@kids-reporter/routing-ui": "0.1.17",
     "@next/third-parties": "^14.1.1",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/packages/frontend/src/modules/article/components/article-summary.tsx
+++ b/packages/frontend/src/modules/article/components/article-summary.tsx
@@ -61,6 +61,7 @@ function ArticleSummary({
         className={cn(
           'mx-[-24px] prose-article-bold text-neutral-700 tablet:mx-0',
           ...ARTICLE_FONT_SIZE_CLASSNAMES,
+          fontSizeLevel === FontSizeLevel.LARGE && 'text-[22.5px]',
           fontSizeLevel === FontSizeLevel.LARGE && [
             ...ARTICLE_FONT_SIZE_CLASSNAMES_LARGE,
           ]

--- a/packages/frontend/src/modules/article/components/article-summary.tsx
+++ b/packages/frontend/src/modules/article/components/article-summary.tsx
@@ -12,6 +12,7 @@ import { getFormattedDate } from '@/utils'
 import {
   ARTICLE_FONT_SIZE_CLASSNAMES,
   ARTICLE_FONT_SIZE_CLASSNAMES_LARGE,
+  ARTICLE_LARGE_FONT_BASE_CLASSNAME,
 } from '../constants'
 
 type AuthorGroup = {
@@ -61,8 +62,8 @@ function ArticleSummary({
         className={cn(
           'mx-[-24px] prose-article-bold text-neutral-700 tablet:mx-0',
           ...ARTICLE_FONT_SIZE_CLASSNAMES,
-          fontSizeLevel === FontSizeLevel.LARGE && 'text-[22.5px]',
           fontSizeLevel === FontSizeLevel.LARGE && [
+            ARTICLE_LARGE_FONT_BASE_CLASSNAME,
             ...ARTICLE_FONT_SIZE_CLASSNAMES_LARGE,
           ]
         )}

--- a/packages/frontend/src/modules/article/components/post-renderer.tsx
+++ b/packages/frontend/src/modules/article/components/post-renderer.tsx
@@ -10,6 +10,7 @@ import { FontSizeLevel, STICKY_HEADER_HEIGHT } from '@/constants'
 import {
   ARTICLE_FONT_SIZE_CLASSNAMES,
   ARTICLE_FONT_SIZE_CLASSNAMES_LARGE,
+  ARTICLE_LARGE_FONT_BASE_CLASSNAME,
 } from '../constants'
 import { useArticleContext } from '../context'
 import trimEmptyBlocks from '../utils/trim-empty-blocks'
@@ -27,8 +28,8 @@ function PostRenderer({ content, shouldMount }: PostProp) {
       className={cn(
         'mb-10 prose-article text-neutral-900 tablet:mb-15',
         ...ARTICLE_FONT_SIZE_CLASSNAMES,
-        fontSize === FontSizeLevel.LARGE && 'text-[22.5px]',
         fontSize === FontSizeLevel.LARGE && [
+          ARTICLE_LARGE_FONT_BASE_CLASSNAME,
           ...ARTICLE_FONT_SIZE_CLASSNAMES_LARGE,
         ]
       )}

--- a/packages/frontend/src/modules/article/components/post-renderer.tsx
+++ b/packages/frontend/src/modules/article/components/post-renderer.tsx
@@ -27,6 +27,7 @@ function PostRenderer({ content, shouldMount }: PostProp) {
       className={cn(
         'mb-10 prose-article text-neutral-900 tablet:mb-15',
         ...ARTICLE_FONT_SIZE_CLASSNAMES,
+        fontSize === FontSizeLevel.LARGE && 'text-[22.5px]',
         fontSize === FontSizeLevel.LARGE && [
           ...ARTICLE_FONT_SIZE_CLASSNAMES_LARGE,
         ]

--- a/packages/frontend/src/modules/article/constants.tsx
+++ b/packages/frontend/src/modules/article/constants.tsx
@@ -56,6 +56,8 @@ export const SHARE_ICONS = [
   },
 ]
 
+export const ARTICLE_LARGE_FONT_BASE_CLASSNAME = 'text-[22.5px]'
+
 export const ARTICLE_FONT_SIZE_CLASSNAMES = [
   '[&_h2]:prose-h2-small desktop:[&_h2]:prose-h2-large',
   '[&_h3]:prose-h3-small desktop:[&_h3]:prose-h3-large',

--- a/packages/routing-ui/package.json
+++ b/packages/routing-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kids-reporter/routing-ui",
   "license": "MIT",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Routing UI for Kids Reporter",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/routing-ui/src/utils/cn.ts
+++ b/packages/routing-ui/src/utils/cn.ts
@@ -1,11 +1,11 @@
 import { ClassValue, clsx } from 'clsx'
 import { extendTailwindMerge } from 'tailwind-merge'
 
-const twMerge = extendTailwindMerge({
+const twMerge = extendTailwindMerge<'prose-typography'>({
   extend: {
     classGroups: {
-      // Add custom prose classes in font-size group since we follow the design system
-      'font-size': [
+      // Custom group so prose typography only conflicts with itself, not with font-size (text-*)
+      'prose-typography': [
         'prose-p1',
         'prose-p1-bold',
         'prose-p2',

--- a/packages/routing-ui/src/utils/cn.ts
+++ b/packages/routing-ui/src/utils/cn.ts
@@ -4,7 +4,6 @@ import { extendTailwindMerge } from 'tailwind-merge'
 const twMerge = extendTailwindMerge<'prose-typography'>({
   extend: {
     classGroups: {
-      // Custom group so prose typography only conflicts with itself, not with font-size (text-*)
       'prose-typography': [
         'prose-p1',
         'prose-p1-bold',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5166,7 +5166,7 @@ __metadata:
     "@graphql-codegen/typescript-operations": "npm:^5.0.2"
     "@hookform/resolvers": "npm:^5.2.2"
     "@kids-reporter/draft-renderer": "npm:^1.0.13"
-    "@kids-reporter/routing-ui": "npm:0.1.16"
+    "@kids-reporter/routing-ui": "npm:0.1.17"
     "@next/bundle-analyzer": "npm:^14.2.33"
     "@next/eslint-plugin-next": "npm:^14.2.33"
     "@next/third-parties": "npm:^14.1.1"
@@ -5233,7 +5233,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/routing-ui@npm:0.1.16, @kids-reporter/routing-ui@workspace:packages/routing-ui":
+"@kids-reporter/routing-ui@npm:0.1.17, @kids-reporter/routing-ui@workspace:packages/routing-ui":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/routing-ui@workspace:packages/routing-ui"
   dependencies:


### PR DESCRIPTION
## Summary

Fixes article large font size scaling by aligning tailwind-merge behavior with the design system and explicitly applying the large base font size in the frontend. Previously, prose typography classes were in the same merge group as `text-*` font-size classes, so merging could drop the intended base size. This PR introduces a dedicated prose-typography merge group and applies the large base size where needed.

## Changes

- **routing-ui (v0.1.16 → 0.1.17):** In `cn.ts`, moved prose typography classes from the built-in `font-size` class group into a custom `prose-typography` group so they only conflict with each other, not with `text-*` (e.g. `text-[22.5px]`). Added type parameter to `extendTailwindMerge`.
- **frontend:** In article summary and post renderer, added `text-[22.5px]` when `FontzeLevel.LARGE` is selected so the large base body size is applied alongside existing large heading styles.
- **frontend:** Bumped `@kids-reporter/routing-ui` dependency to 0.1.17 and updated lockfile.

## Additional Notes

- Large mode still uses `ARTICLE_FONT_SIZE_CLASSNAMES_LARGE` for heading sizes; the new base `text-[22.5px]` ensures body text scales correctly and is no longer overridden by merge behavior.

## Screenshot(s)


## Reference(s)