### PR TITLE
fix(cronjob): make RSS job call CMS directly with session auth

### DIFF
--- a/packages/api-gateway/src/utils/format-axios-error.ts
+++ b/packages/api-gateway/src/utils/format-axios-error.ts
@@ -15,7 +15,7 @@ export const formatAxiosError = (err: unknown): Error => {
 
   let message = 'failed to make an axios request'
   if (err.response) {
-    message = `an axios request was made but response with status ${err.response?.status}`
+    message = `an axios request was made but responded with status ${err.response?.status}`
   } else if (err.request) {
     message = 'an axios request was made but no response was received'
   }

--- a/packages/cronjob/configs.js
+++ b/packages/cronjob/configs.js
@@ -19,7 +19,6 @@ export const config = {
     keyFilename: process.env.KEY_FILENAME || '',
   },
 
-  // scheduled-post
   cronjobAccount: {
     email: process.env.CRONJOB_ACCOUNT_EMAIL,
     password: process.env.CRONJOB_ACCOUNT_PASSWORD,

--- a/packages/cronjob/index.js
+++ b/packages/cronjob/index.js
@@ -2,6 +2,6 @@ console.log(
   JSON.stringify({
     severity: 'NOTICE',
     message:
-      'This is the default cronjob entrypoint.  Please specify a cronjob to run.',
+      'This is the default cronjob entrypoint. Please specify a cronjob to run.',
   })
 )

--- a/packages/cronjob/index.js
+++ b/packages/cronjob/index.js
@@ -1,3 +1,7 @@
 console.log(
-  'This is the default cronjob entrypoint.  Please specify a cronjob to run.'
+  JSON.stringify({
+    severity: 'NOTICE',
+    message:
+      'This is the default cronjob entrypoint.  Please specify a cronjob to run.',
+  })
 )

--- a/packages/cronjob/rss.js
+++ b/packages/cronjob/rss.js
@@ -3,7 +3,14 @@ import axios from 'axios'
 import RSS from 'rss'
 
 import { config } from './configs.js'
-import { errorHandling, errors, logWithSlack } from './utils.js'
+import { errorHandling, errors, logWithSlack, TokenManager } from './utils.js'
+
+// fetch keystone session cookie token
+const tokenManager = new TokenManager(
+  config.cronjobAccount.email,
+  config.cronjobAccount.password,
+  config.apiUrl
+)
 
 const storage =
   config.gcs.projectId && config.gcs.keyFilename
@@ -65,7 +72,13 @@ const fetchData = async () => {
     },
   }
   try {
-    const dataRes = await axios.post(config.apiUrl, payload)
+    const token = await tokenManager.getToken()
+    const dataRes = await axios.post(config.apiUrl, payload, {
+      withCredentials: true,
+      headers: {
+        Cookie: `keystonejs-session=${token}`,
+      },
+    })
     const data = [
       ...(dataRes?.data?.data?.posts || []),
       ...(dataRes?.data?.data?.projects || []),

--- a/packages/cronjob/rss.js
+++ b/packages/cronjob/rss.js
@@ -3,7 +3,13 @@ import axios from 'axios'
 import RSS from 'rss'
 
 import { config } from './configs.js'
-import { errorHandling, errors, logWithSlack, TokenManager } from './utils.js'
+import {
+  errorHandling,
+  errors,
+  formatAxiosError,
+  logWithSlack,
+  TokenManager,
+} from './utils.js'
 
 // fetch keystone session cookie token
 const tokenManager = new TokenManager(
@@ -88,7 +94,7 @@ const fetchData = async () => {
     })
     return data
   } catch (err) {
-    throw errors.helpers.annotateAxiosError(err)
+    throw formatAxiosError(err)
   }
 }
 
@@ -151,7 +157,12 @@ const main = async () => {
   } catch (err) {
     errorHandling(err)
   }
-  console.log(`Cronjob RSS feed completed.`)
+  console.log(
+    JSON.stringify({
+      severity: 'NOTICE',
+      message: 'Cronjob RSS feed completed.',
+    })
+  )
 }
 
 main()

--- a/packages/cronjob/scheduled-post.js
+++ b/packages/cronjob/scheduled-post.js
@@ -1,7 +1,12 @@
 import axios from 'axios'
 
 import { config } from './configs.js'
-import { errorHandling, errors, TokenManager } from './utils.js'
+import {
+  errorHandling,
+  errors,
+  formatAxiosError,
+  TokenManager,
+} from './utils.js'
 
 // fetch keystone session cookie token
 const tokenManager = new TokenManager(
@@ -43,7 +48,7 @@ const getScheduledPosts = async () => {
     const idArray = data?.map((post) => post.id) || []
     return idArray
   } catch (err) {
-    throw errors.helpers.annotateAxiosError(err)
+    throw formatAxiosError(err)
   }
 }
 
@@ -75,7 +80,12 @@ const updatePostStatus = async (postIds) => {
 
   // update post status
   try {
-    console.log(`Update post ${postIds} status to published.`)
+    console.log(
+      JSON.stringify({
+        severity: 'INFO',
+        message: `Update post ${postIds} status to published.`,
+      })
+    )
     const token = await tokenManager.getToken()
     const update = await axios.post(config.apiUrl, updatePayload, {
       withCredentials: true,
@@ -96,7 +106,7 @@ const updatePostStatus = async (postIds) => {
       throw annotatedErr
     }
   } catch (err) {
-    throw errors.helpers.annotateAxiosError(err)
+    throw formatAxiosError(err)
   }
 }
 
@@ -104,15 +114,30 @@ const main = async () => {
   try {
     const scheduledPosts = await getScheduledPosts()
     if (scheduledPosts.length === 0) {
-      console.log(`No scheduled posts.`)
+      console.log(
+        JSON.stringify({
+          severity: 'INFO',
+          message: 'No scheduled posts.',
+        })
+      )
     } else {
-      console.log(`Scheduled posts: ${scheduledPosts}`)
+      console.log(
+        JSON.stringify({
+          severity: 'INFO',
+          message: `Scheduled posts: ${scheduledPosts}`,
+        })
+      )
       await updatePostStatus(scheduledPosts)
     }
   } catch (err) {
     errorHandling(err)
   }
-  console.log(`Cronjob scheduled-post completed.`)
+  console.log(
+    JSON.stringify({
+      severity: 'NOTICE',
+      message: 'Cronjob scheduled-post completed.',
+    })
+  )
 }
 
 main()

--- a/packages/cronjob/utils.js
+++ b/packages/cronjob/utils.js
@@ -8,6 +8,41 @@ import { config } from './configs.js'
 // @twreporter/errors is a cjs module, therefore, we need to use its default property
 export const errors = _errors.default
 
+/**
+ * Format axios errors for consistent logging (aligned with api-gateway).
+ * @see packages/api-gateway/src/utils/format-axios-error.ts
+ */
+export const formatAxiosError = (err) => {
+  if (!axios.isAxiosError(err)) {
+    return errors.helpers.wrap(
+      err,
+      err instanceof Error ? err.name : 'UnknownError',
+      err instanceof Error ? err.message : String(err)
+    )
+  }
+
+  let message = 'failed to make an axios request'
+  if (err.response) {
+    message = `an axios request was made but response with status ${err.response?.status}`
+  } else if (err.request) {
+    message = 'an axios request was made but no response was received'
+  }
+
+  const axiosError = {
+    name: 'AxiosError',
+    message,
+    code: err.code,
+    status: err.response?.status,
+    method: err.config?.method,
+    url: err.config?.url,
+    responseData: err.response?.data,
+  }
+
+  return errors.helpers.wrap(undefined, axiosError.name, axiosError.message, {
+    axiosError,
+  })
+}
+
 const sendSlackNotification = async (message) => {
   try {
     const webhook = new IncomingWebhook(config.slackLogHook)
@@ -39,7 +74,12 @@ const sendSlackNotification = async (message) => {
         },
       ],
     })
-    console.log(`Slack notification sent: ${message}`)
+    console.log(
+      JSON.stringify({
+        severity: 'INFO',
+        message: `Slack notification sent: ${message}`,
+      })
+    )
   } catch (err) {
     errorHandling(err)
   }
@@ -49,21 +89,35 @@ export const logWithSlack = async (message) => {
   if (config.slackLogHook) {
     await sendSlackNotification(message)
   }
-  console.log(message)
-}
-
-export const errorHandling = (err) => {
-  console.error(
+  console.log(
     JSON.stringify({
-      severity: 'ERROR',
-      message: errors.helpers.printAll(
-        err,
-        { withStack: true, withPayload: true },
-        0,
-        0
-      ),
+      severity: 'INFO',
+      message,
     })
   )
+}
+
+/**
+ * Log error and exit (aligned with api-gateway app-level error handler).
+ * Wraps unknown errors so all failures have a consistent annotated structure.
+ */
+export const errorHandling = (err) => {
+  const annotatingError = errors.helpers.wrap(
+    err,
+    'CronjobError',
+    'Cronjob failed'
+  )
+  const entry = {
+    severity: 'ERROR',
+    // Stack trace integrates with Error Reporting (e.g. Cloud Run).
+    message: errors.helpers.printAll(
+      annotatingError,
+      { withStack: true, withPayload: true },
+      0,
+      0
+    ),
+  }
+  console.error(JSON.stringify(entry))
   process.exit(1)
 }
 
@@ -162,7 +216,7 @@ export class TokenManager {
         },
       })
     } catch (err) {
-      throw errors.helpers.annotateAxiosError(err)
+      throw formatAxiosError(err)
     }
 
     const authenticationResult =

--- a/packages/cronjob/utils.js
+++ b/packages/cronjob/utils.js
@@ -23,7 +23,7 @@ export const formatAxiosError = (err) => {
 
   let message = 'failed to make an axios request'
   if (err.response) {
-    message = `an axios request was made but response with status ${err.response?.status}`
+    message = `an axios request was made but responded with status ${err.response?.status}`
   } else if (err.request) {
     message = 'an axios request was made but no response was received'
   }
@@ -125,6 +125,14 @@ export class TokenManager {
   static instance
 
   constructor(email, password, apiEndpoint = config.apiUrl) {
+    if (!email || !password || !apiEndpoint) {
+      const annotatedErr = errors.helpers.wrap(
+        new Error('Email, password, and apiEndpoint are required'),
+        'TokenManangerError',
+        'Email, password, and apiEndpoint are required'
+      )
+      throw annotatedErr
+    }
     this.email = email
     this.password = password
     this.apiEndpoint = apiEndpoint


### PR DESCRIPTION
## Summary

RSS cron job now calls the CMS (Keystone) GraphQL API directly with session authentication, instead of calling api-gateway. This aligns the RSS job with the scheduled-post job and works around api-gateway’s removal of the generic `/graphql` endpoint and operation-based constraints.

## Changes

- **`packages/cronjob/rss.js`**
  - Import and use `TokenManager` from `./utils.js` (same as scheduled-post).
  - Create a `tokenManager` instance with `config.cronjobAccount` and `config.apiUrl`.
  - In `fetchData()`, obtain a Keystone session token via `tokenManager.getToken()` and send it in the `Cookie: keystonejs-session=...` header when posting the GraphQL request to `config.apiUrl`.
  - Request is sent with `withCredentials: true` and the session cookie so the CMS accepts the call.
  - Improve logging align with api-gateway
- **`packages/cronjos/scheduled-post.js`**
  -  Improve logging align with api-gateway

RSS and scduled-post now both use `config.apiUrl` (CMS GraphQL) and the same TokenManager + cookie auth pattern.

## Additional Notes

- **Why**: api-gateway no longer exposes a generic `/graphql` endpoint and restricts calls to specific operations, so the RSS job cannot use it for arbitrary GraphQL (posts + projects). Calling CMS directly is the supported approach.
- **Consistency**: Aligning RSS with scheduled-post (both call CMS with TokenManager + session cookie) keeps cron jobs consistent and easier to maintain.
- **Config**: Ensure `API_URL` (and `CRONJOB_ACCOUNT_EMAIL` / `CRONJOB_ACCOUNT_PASSWORD` for auth) point to the CMS GraphQL URL and valid cronjob credentials in all environments.

## Screenshot(s)

## Reference(s)