### PR TITLE
fix(api-gateway): retry CMS GraphQL request on timeout caused by Cloud Run scale-up

### DIFF
--- a/packages/api-gateway/src/graphql/cms-client.ts
+++ b/packages/api-gateway/src/graphql/cms-client.ts
@@ -3,7 +3,7 @@ import axios from 'axios'
 import { formatAxiosError } from '../utils/format-axios-error.js'
 import { appendSessionCookie, TokenManager } from './auth.js'
 
-const CMS_REQUEST_TIMEOUT_MS = 10000
+const CMS_REQUEST_TIMEOUT_MS = 5000
 
 export async function callCmsGraphql({
   apiOrigin,
@@ -40,6 +40,35 @@ export async function callCmsGraphql({
   try {
     return await doCall()
   } catch (err) {
+    // During Cloud Run scale-up (e.g. 1 → 2 instances), the load balancer may
+    // assign one incoming request to the new instance before its startup probe
+    // passes. That request is held in a queue until the instance is ready
+    // (~20s for Keystone), which exceeds the 5s timeout and triggers an
+    // ECONNABORTED error. Subsequent requests go to the existing warm instance
+    // and complete normally. Retrying once is therefore very likely to succeed.
+    if (axios.isAxiosError(err) && err.code === 'ECONNABORTED') {
+      console.warn(
+        JSON.stringify({
+          severity: 'WARNING',
+          message:
+            `CMS GraphQL request timed out for operation "${operationName}". ` +
+            'Retrying once (likely caused by Cloud Run scale-up queuing).',
+        })
+      )
+      try {
+        return await doCall()
+      } catch (retryErr) {
+        console.error(
+          JSON.stringify({
+            severity: 'ERROR',
+            message:
+              `CMS GraphQL retry also failed for operation "${operationName}". ` +
+              'Both the initial request and the retry timed out.',
+          })
+        )
+        throw formatAxiosError(retryErr)
+      }
+    }
     if (
       mode === 'cookie' &&
       axios.isAxiosError(err) &&


### PR DESCRIPTION
## Problem
During Cloud Run scale-up (e.g. 1 → 2 instances), the load balancer may assign one incoming request to the new instance before its startup probe passes. That request is queued until the instance is ready (~20s for Keystone), exceeding the previous 10s timeout and causing the request to fail with ECONNABORTED.

## Changes:
- Reduce CMS_REQUEST_TIMEOUT_MS from 10s to 5s for faster failure detection
- On ECONNABORTED (timeout), automatically retry once with a WARNING log. We hope that subsequent requests go to existing warm instances, so the retry could succeed quickly.
- Log an ERROR if the retry also times out, to aid observability in Cloud Logging.

## Related Error Reporting
https://console.cloud.google.com/errors/detail/CNal3KO77euE2wE;locations=global;time=P30D?project=kids-reporter&utm_source=error-reporting-notification&utm_medium=slack&utm_content=resolved-error
