### PR TITLE
fix(cms,api-gateway): reduce scale-up timeouts by splitting CMS into dedicated GQL service

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -49,6 +49,8 @@ steps:
 
         -t gcr.io/$PROJECT_ID/$_IMAGE_NAME:latest \
 
+        -f "$_DOCKERFILE" \
+
         --cache-from gcr.io/$PROJECT_ID/$_IMAGE_NAME:latest .
     entrypoint: bash
 
@@ -106,3 +108,4 @@ substitutions:
   _CLOUD_RUN_SERVICE_NAMES: '' # default value
   _ENV_FILE: '' # default value
   _DEPLOYMENT_TYPE: 'service' # default value
+  _DOCKERFILE: 'Dockerfile' # default value

--- a/packages/cms/.env.example
+++ b/packages/cms/.env.example
@@ -12,9 +12,6 @@ SESSION_MAX_AGE=86400
 # UI Configuration
 IS_UI_DISABLED=false
 
-# Access Control Strategy (options: 'cms', 'gql', 'preview')
-ACCESS_CONTROL_STRATEGY=cms
-
 # Preview Server Configuration
 PREVIEW_SERVER_ORIGIN=http://localhost:3001
 PREVIEW_SERVER_PATH=/preview-server

--- a/packages/cms/Dockerfile.gql-only
+++ b/packages/cms/Dockerfile.gql-only
@@ -1,0 +1,38 @@
+FROM node:20.19.5-slim
+
+RUN corepack enable
+
+## Install minimal system dependencies (no gcsfuse needed for GQL-only service).
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        tini \
+        openssl \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV APP_DIR /app
+ENV HOST 0.0.0.0
+ENV PORT 3000
+
+RUN mkdir -p $APP_DIR
+
+WORKDIR $APP_DIR
+
+COPY . $APP_DIR
+
+## Install application dependencies
+RUN SKIP_BUILD_DEPS=true yarn install --immutable
+
+## Build application bundles
+RUN yarn build
+
+RUN yarn cache clean
+
+EXPOSE 3000
+
+## Use tini to manage zombie processes and signal forwarding
+## https://github.com/krallin/tini
+ENTRYPOINT ["/usr/bin/tini", "--"]
+
+## Skip gcsfuse mount and db migration: prod-cms handles migrations on startup.
+## This service only runs the GQL server for faster cold starts.
+CMD ["yarn", "start"]

--- a/packages/cms/README.md
+++ b/packages/cms/README.md
@@ -16,8 +16,28 @@ cloud builds:
 cloud runs:
 
 - [dev-cms](https://console.cloud.google.com/run/detail/asia-east1/dev-cms?project=kids-reporter)
+- [dev-gql](https://console.cloud.google.com/run/detail/asia-east1/dev-gql?project=kids-reporter)
 - [staging-cms](https://console.cloud.google.com/run/detail/asia-east1/staging-cms?project=kids-reporter)
+- [staigng-gql](https://console.cloud.google.com/run/detail/asia-east1/staging-gql?project=kids-reporter)
 - [prod-cms](https://console.cloud.google.com/run/detail/asia-east1/prod-cms?project=kids-reporter)
+- [prod-gql](https://console.cloud.google.com/run/detail/asia-east1/prod-gql?project=kids-reporter)
+
+## prod-cms vs prod-gql
+
+`prod-cms` 和 `prod-gql` 使用相同的程式碼，但有不同的啟動流程與用途：
+
+|                    | prod-cms                      | prod-gql               |
+| ------------------ | ----------------------------- | ---------------------- |
+| **用途**           | CMS 管理介面 + GraphQL server | GraphQL server only    |
+| **Dockerfile**     | `Dockerfile`                  | `Dockerfile.gql`       |
+| **gcsfuse**        | ✅（檔案上傳需要）            | ❌                     |
+| **db migration**   | ✅（每次啟動執行）            | ❌（由 prod-cms 負責） |
+| **IS_UI_DISABLED** | `false`                       | `true`                 |
+| **啟動時間**       | ~20s                          | 較短                   |
+
+`prod-gql` 的目的是讓 `prod-api-gateway` 的 GraphQL request 打到啟動快的 service，避免 Cloud Run auto-scaling 時因新 instance 啟動過慢導致 request timeout。`prod-api-gateway` 透過 `GQL_ORIGIN` 環境變數指向 `prod-gql`。
+
+**注意：** db migration 只在 `prod-cms` 執行，因此部署新版本時須確保 `prod-cms` 先完成部署（migration 跑完），再部署 `prod-gql`。
 
 ## Environment Variables
 

--- a/packages/cms/environment-variables.ts
+++ b/packages/cms/environment-variables.ts
@@ -1,6 +1,5 @@
 const {
   IS_UI_DISABLED,
-  ACCESS_CONTROL_STRATEGY,
   PREVIEW_SERVER_ORIGIN,
   PREVIEW_SERVER_PATH,
   DATABASE_PROVIDER,
@@ -53,7 +52,6 @@ const environmentVariables = {
   memoryCacheSize: Number.isNaN(Number(MEMORY_CACHE_SIZE))
     ? 300
     : Number(MEMORY_CACHE_SIZE),
-  accessControlStrategy: ACCESS_CONTROL_STRATEGY || 'cms', // the value could be one of 'cms', 'gql' or 'preview'
   database: {
     provider:
       DATABASE_PROVIDER === 'sqlite'


### PR DESCRIPTION
   ## Problem

   During Cloud Run scale-up (e.g. 1 → 2 instances), the load balancer may assign one
   incoming request to the new instance before its startup probe passes. That request is
   queued until the instance is ready (~20s for Keystone), exceeding the previous 10s
   timeout and causing the request to fail with ECONNABORTED.

   The root cause is that `prod-cms` has a slow startup path:
   1. Mount GCS bucket via gcsfuse
   2. Run `db-migrate` (Prisma)
   3. Start Keystone server

   This cannot easily be optimized, so instead we split the service.

   ## Solution

   Introduce a dedicated `prod-gql` Cloud Run service that runs the same Keystone codebase
   but with a lighter startup path — skipping gcsfuse and db migration — resulting in a
   significantly shorter cold start time.

   `prod-api-gateway` routes all CMS GraphQL traffic to `prod-gql`,  
while `prod-cms` continues to serve the Admin UI and
 remains the sole service responsible for running DB migrations on deploy.

   ## Changes

   ### `packages/cms`
   - Add `Dockerfile.gql`: GraphQL-only image without gcsfuse installation; `CMD` runs
     `yarn start` directly, skipping gcsfuse mount and db migration
   - Remove unused `ACCESS_CONTROL_STRATEGY` env var from `environment-variables.ts` and
     `.env.example`
   - Update `README.md` with `prod-cms vs prod-gql` comparison table and deployment order
     requirements

   ### `cloudbuild.yaml`
   - Add `_DOCKERFILE` substitution variable (default: `Dockerfile`) so Cloud Build
     triggers can specify `Dockerfile.gql` for the `prod-gql` build

   ## Deployment Notes

   1. Create a new Cloud Build trigger for `prod-gql` with:
      - `_TARGET_PACKAGE=cms`
      - `_IMAGE_NAME=prod-gql`
      - `_CLOUD_RUN_SERVICE_NAMES=prod-gql`
      - `_DOCKERFILE=Dockerfile.gql`
      - `IS_UI_DISABLED=true` in the env file
   2. **Deploy `prod-cms` first** on each release so migrations run before `prod-gql` starts.
