### PR TITLE
chore(cms): slim Dockerfile apt installs and cleanup package lists

### DIFF
--- a/packages/cms/Dockerfile
+++ b/packages/cms/Dockerfile
@@ -4,7 +4,7 @@ RUN corepack enable
 
 ## Install system dependencies, `gcsfuse` in particular.
 RUN set -e; \
-    apt-get update -y && apt-get install -y \
+    apt-get update -y && apt-get install -y --no-install-recommends \
     build-essential \
     curl \
     wget \
@@ -20,8 +20,8 @@ RUN set -e; \
     # apt-get update; \
     # apt-get install -y gcsfuse \
     # TODO: remove wget workaround for gcsfuse due to missing registry & restore with apt-get
-    wget https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v1.2.0/gcsfuse_1.2.0_amd64.deb -O gcsfuse.deb && apt-get install -y ./gcsfuse.deb && rm -f ./gcsfuse.deb \
-    && apt-get clean
+    wget https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v1.2.0/gcsfuse_1.2.0_amd64.deb -O gcsfuse.deb && apt-get install -y --no-install-recommends ./gcsfuse.deb && rm -f ./gcsfuse.deb \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ENV APP_DIR /app
 ## Set fallback mount directory


### PR DESCRIPTION
## Changes
- Update packages/cms/Dockerfile to use apt-get install --no-install-recommends for both system packages and gcsfuse deb install.
- Replace apt-get clean with rm -rf /var/lib/apt/lists/* to remove apt metadata layers and reduce final image size.
- Keep existing runtime behavior intact while optimizing image footprint.