### PR TITLE
fix(frontend): align gql timeout and fetch popular keywords client-side

### DIFF
--- a/packages/frontend/src/api-utils/react-query/hooks/popular-keywords.ts
+++ b/packages/frontend/src/api-utils/react-query/hooks/popular-keywords.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { getPopularKeywords } from '@/api/popular-keywords'
+
+const POPULAR_KEYWORDS_QUERY_KEY = 'popular-keywords'
+export const usePopularKeywords = () => {
+  return useQuery({
+    queryKey: usePopularKeywords.getQueryKey(),
+    queryFn: () => getPopularKeywords(),
+  })
+}
+
+usePopularKeywords.getQueryKey = () => [POPULAR_KEYWORDS_QUERY_KEY]

--- a/packages/frontend/src/api-utils/react-query/hooks/popular-keywords.ts
+++ b/packages/frontend/src/api-utils/react-query/hooks/popular-keywords.ts
@@ -7,6 +7,8 @@ export const usePopularKeywords = () => {
   return useQuery({
     queryKey: usePopularKeywords.getQueryKey(),
     queryFn: () => getPopularKeywords(),
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
   })
 }
 

--- a/packages/frontend/src/app/layout.tsx
+++ b/packages/frontend/src/app/layout.tsx
@@ -5,7 +5,6 @@ import { GoogleTagManager } from '@next/third-parties/google'
 import { Noto_Sans_TC } from 'next/font/google'
 import localFont from 'next/font/local'
 
-import { getPopularKeywords } from '@/api/popular-keywords'
 import Providers from '@/components/providers'
 import { Toaster } from '@/components/toaster'
 import FeatureIntroDialog from '@/services/feature-intro/components/feature-info-dialog'
@@ -28,14 +27,11 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode
 }) {
-  const keywords = await getPopularKeywords()
   return (
     <html className={`${notoSansTC.variable} ${swei.variable}`}>
       <GoogleTagManager gtmId={GTM_ID} />
       <body>
-        <Providers
-          keywords={keywords?.map((keyword) => keyword?.name ?? '') ?? []}
-        >
+        <Providers>
           <FeatureIntroDialog />
           {children}
           <Footer />

--- a/packages/frontend/src/app/layout.tsx
+++ b/packages/frontend/src/app/layout.tsx
@@ -22,7 +22,7 @@ const swei = localFont({
   variable: '--font-swei-marker',
 })
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: {
   children: React.ReactNode

--- a/packages/frontend/src/components/providers.tsx
+++ b/packages/frontend/src/components/providers.tsx
@@ -19,7 +19,10 @@ function HeaderProviderWithPopularKeywords({
 }) {
   const { data: keywords } = usePopularKeywords()
   const keywordsArray = useMemo(
-    () => keywords?.map((keyword) => keyword?.name ?? '') ?? [],
+    () =>
+      keywords
+        ?.map((keyword) => keyword?.name ?? '')
+        .filter((name): name is string => Boolean(name)) ?? [],
     [keywords]
   )
   return <HeaderProvider keywords={keywordsArray}>{children}</HeaderProvider>

--- a/packages/frontend/src/components/providers.tsx
+++ b/packages/frontend/src/components/providers.tsx
@@ -3,29 +3,38 @@
 import { HeaderProvider } from '@kids-reporter/routing-ui'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { useMemo } from 'react'
 
 import { getQueryClient } from '@/api-utils/react-query/get-query-client'
+import { usePopularKeywords } from '@/api-utils/react-query/hooks/popular-keywords'
 import { AuthProvider } from '@/services/auth/auth-provider'
 import { FeatureIntroDialogProvider } from '@/services/feature-intro'
 
 import StyledComponentsRegistry from './registry'
 
-function Providers({
+function HeaderProviderWithPopularKeywords({
   children,
-  keywords,
 }: {
   children: React.ReactNode
-  keywords: string[]
 }) {
+  const { data: keywords } = usePopularKeywords()
+  const keywordsArray = useMemo(
+    () => keywords?.map((keyword) => keyword?.name ?? '') ?? [],
+    [keywords]
+  )
+  return <HeaderProvider keywords={keywordsArray}>{children}</HeaderProvider>
+}
+
+function Providers({ children }: { children: React.ReactNode }) {
   const queryClient = getQueryClient()
 
   return (
     <StyledComponentsRegistry>
       <QueryClientProvider client={queryClient}>
         <AuthProvider>
-          <HeaderProvider keywords={keywords}>
+          <HeaderProviderWithPopularKeywords>
             <FeatureIntroDialogProvider>{children}</FeatureIntroDialogProvider>
-          </HeaderProvider>
+          </HeaderProviderWithPopularKeywords>
         </AuthProvider>
         <ReactQueryDevtools
           initialIsOpen={false}

--- a/packages/frontend/src/utils/send-rest-gql.ts
+++ b/packages/frontend/src/utils/send-rest-gql.ts
@@ -5,7 +5,8 @@ import { INTERNAL_REST_GQL_ENDPOINT, REST_GQL_ENDPOINT } from '@/constants'
 
 import { log, LogLevel } from './log'
 
-export const AXIOS_TIMEOUT = 5000
+// align timeout with api-gateway
+export const AXIOS_TIMEOUT = 10000
 
 type GraphQLResponse<TData = Record<string, unknown>> = {
   data?: TData


### PR DESCRIPTION
## Summary
Moves popular keywords fetching from the server layout into a client-side React Query hook, and aligns the frontend axios timeout with the api-gateway.

## Changes
- Add `usePopularKeywords` React Query hook for popular keywords
- Remove popular keywords fetching from `app/layout.tsx` and stop passing keywords into `Providers`
- Fetch keywords inside `HeaderProvider` via a small client wrapper component
- Increase `AXIOS_TIMEOUT` from 5000ms to 10000ms to match api-gateway

## Additional Notes
- This avoids doing a keywords fetch during server layout rendering and centralizes the query via React Query caching.

## Screenshot(s)

## Reference(s)
