### PR TITLE
fix(cms): update Dockerfile install ca-certificates

### DIFF
--- a/packages/cms/Dockerfile
+++ b/packages/cms/Dockerfile
@@ -6,6 +6,7 @@ RUN corepack enable
 RUN set -e; \
     apt-get update -y && apt-get install -y --no-install-recommends \
     build-essential \
+    ca-certificates \
     curl \
     wget \
     gnupg2 \


### PR DESCRIPTION
## Summary

Updates the CMS Dockerfile to fix certificate handling for HTTPS package sources.

## Changes

- **Add `ca-certificates`** to apt-get install so HTTPS sources (e.g. Google package repo) work reliably in the container.

## Additional Notes

## Screenshot(s)


## Reference(s)

- [Build Error](https://console.cloud.google.com/cloud-build/builds;region=asia-east1/763b22a2-bbb7-4ff0-9fcb-db7e3374b005;step=1?authuser=0&project=kids-reporter)