### PR TITLE
fix(frontend): inject deploymentId at build time to mitigate App Route

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -51,6 +51,8 @@ steps:
 
         -f "$_DOCKERFILE" \
 
+        --build-arg DEPLOYMENT_ID=${SHORT_SHA} \
+
         --cache-from gcr.io/$PROJECT_ID/$_IMAGE_NAME:latest .
     entrypoint: bash
 

--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -24,3 +24,11 @@ NEXT_PUBLIC_LOGIN_WIDGET_URL=https://accounts.twreporter.org/signin-widget
 
 # Baodaozai Rive File Url
 NEXT_PUBLIC_BAODAOZAI_RIVE_FILE_PATH=https://kids-storage.twreporter.org/callinbaodaozai.riv
+
+# Deployment ID (injected at build time via Cloud Build SHORT_SHA; used by Next.js to detect deployment skew)
+DEPLOYMENT_ID=
+
+# Server Actions (set in Cloud Run environment variables, not in .env.local)
+# Used to encrypt/decrypt Server Actions payloads; must be identical across all instances in a deployment.
+# Generate with: openssl rand -base64 32
+NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -2,6 +2,8 @@ ARG NODE_VERSION=20.19.5
 
 FROM node:${NODE_VERSION} AS build
 
+ARG DEPLOYMENT_ID
+
 RUN corepack enable
 
 WORKDIR /build
@@ -12,7 +14,7 @@ RUN yarn install --immutable --ignore-scripts
 
 COPY . /build/
 
-RUN yarn build:cloudbuild
+RUN DEPLOYMENT_ID=${DEPLOYMENT_ID} yarn build:cloudbuild
 
 
 FROM node:${NODE_VERSION}

--- a/packages/frontend/next.config.mjs
+++ b/packages/frontend/next.config.mjs
@@ -2,6 +2,7 @@
 const nextConfig = {
   basePath:
     process.env.NEXT_PUBLIC_IS_PREVIEW_MODE === 'true' ? '/preview-server' : '',
+  deploymentId: process.env.DEPLOYMENT_ID || undefined,
   output: 'standalone',
   compiler: {
     styledComponents: true,


### PR DESCRIPTION
 ## Summary

  This PR mitigates App Router deployment skew issues in packages/frontend by injecting a build-specific deploymentId and documenting Server Actions key requirements for multi-instance Cloud Run deployments.

  ## Changes

  - Add deploymentId: process.env.DEPLOYMENT_ID in packages/frontend/next.config.mjs.
  - Pass DEPLOYMENT_ID from Cloud Build (SHORT_SHA) into Docker build:
      - cloudbuild.yaml: --build-arg DEPLOYMENT_ID=${SHORT_SHA}
      - packages/frontend/Dockerfile: accept ARG DEPLOYMENT_ID and run DEPLOYMENT_ID=${DEPLOYMENT_ID} yarn build:cloudbuild
  - Update packages/frontend/.env.example with NEXT_SERVER_ACTIONS_ENCRYPTION_KEY notes and key generation command.

  ## Why

  During rolling updates, clients may send requests with stale action/runtime references to newer instances, causing:
  Failed to find Server Action "x". This request might be from an older or newer deployment.

  deploymentId helps Next.js detect deployment mismatch and recover via reload to the correct version.

  ## Impact

  - Reduces deployment-skew-related runtime errors for frontend users.
  - No functional API/schema changes.
  - Build/deploy pipeline now stamps frontend builds with commit-based deployment identity.

  ## Related Error Reporting

  - https://console.cloud.google.com/errors/detail/CLXFnNa_icnPwAE;locations=global?project=kids-reporter