### PR TITLE
fix(routing-ui): adjust copyright display

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -19,7 +19,7 @@
     "@googleapis/customsearch": "^1.0.4",
     "@hookform/resolvers": "^5.2.2",
     "@kids-reporter/draft-renderer": "^1.0.13",
-    "@kids-reporter/routing-ui": "0.1.18",
+    "@kids-reporter/routing-ui": "0.1.19",
     "@next/third-parties": "^14.1.1",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/packages/routing-ui/package.json
+++ b/packages/routing-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kids-reporter/routing-ui",
   "license": "MIT",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Routing UI for Kids Reporter",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/routing-ui/src/footer.tsx
+++ b/packages/routing-ui/src/footer.tsx
@@ -137,9 +137,7 @@ const Footer = ({
                 </a>
               </p>
               <p className="hidden desktop:inline">｜</p>
-              <p className="desktop:inline">
-                Copyright © {new Date().getFullYear()} The Reporter
-              </p>
+              <p className="desktop:inline">Copyright © The Reporter</p>
             </div>
           </div>
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5166,7 +5166,7 @@ __metadata:
     "@graphql-codegen/typescript-operations": "npm:^5.0.2"
     "@hookform/resolvers": "npm:^5.2.2"
     "@kids-reporter/draft-renderer": "npm:^1.0.13"
-    "@kids-reporter/routing-ui": "npm:0.1.18"
+    "@kids-reporter/routing-ui": "npm:0.1.19"
     "@next/bundle-analyzer": "npm:^14.2.33"
     "@next/eslint-plugin-next": "npm:^14.2.33"
     "@next/third-parties": "npm:^14.1.1"
@@ -5233,7 +5233,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/routing-ui@npm:0.1.18, @kids-reporter/routing-ui@workspace:packages/routing-ui":
+"@kids-reporter/routing-ui@npm:0.1.19, @kids-reporter/routing-ui@workspace:packages/routing-ui":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/routing-ui@workspace:packages/routing-ui"
   dependencies:


### PR DESCRIPTION
## Summary

Adjusts the footer copyright line to show a static "Copyright © The Reporter" (no year), and bumps `@kids-reporter/routing-ui` to 0.1.19 so the frontend consumes the change.

## Changes

- **packages/routing-ui/src/footer.tsx**: Replaced dynamic year copyright (`Copyright © {year} The Reporter`) with static text `Copyright © The Reporter`.
- **packages/routing-ui/package.json**: Bumped version from 0.1.18 to 0.1.19.
- **packages/frontend/package.json**: Updated dependency `@kids-reporter/routing-ui` from 0.1.18 to 0.1.19.
- **yarn.lock**: Updated lockfile for the new routing-ui version.

## Additional Notes

Removing the year from the copyright line avoids unnecessary annual updates and matches the footer spec. No functional behavior change beyond the displayed text.

## Screenshot(s)


## Reference(s)

- [Notion Page - Footer](https://www.notion.so/twreporter/footer-3138dbdca9328072adedcd687478d39a)
