### PR TITLE
fix(frontend): always show essay question in preview mode

### DIFF
--- a/packages/frontend/src/environment-variables.ts
+++ b/packages/frontend/src/environment-variables.ts
@@ -21,6 +21,8 @@ const baodaozaiRiveFilePath =
 
 const nodeEnv = process.env.NODE_ENV
 
+const isPreviewMode = process.env.NEXT_PUBLIC_IS_PREVIEW_MODE === 'true'
+
 const environmentVariables = {
   internalApiGatewayEndpoint,
   apiGatewayEndpoint,
@@ -32,6 +34,7 @@ const environmentVariables = {
   loginWidgetUrl,
   nodeEnv,
   baodaozaiRiveFilePath,
+  isPreviewMode,
 }
 
 export default environmentVariables

--- a/packages/frontend/src/modules/article/index.tsx
+++ b/packages/frontend/src/modules/article/index.tsx
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { TableOfContentSideMenu } from '@/components/table-of-content'
 import { FontSizeLevel } from '@/constants'
 import { BAODAOZAI_DEFAULT_ESSAY_QUESTION_COUNT } from '@/constants/baodaozai-question-count'
+import envVars from '@/environment-variables'
 import { SeparateIcon } from '@/icons'
 import { useHydratedAuthStore } from '@/services/auth/use-hydrated-auth-store'
 import {
@@ -111,7 +112,6 @@ const ArticleModule = ({
   const { member, tokens } = useHydratedAuthStore()
 
   const isLogin = !!member
-
   const handleQAModalClose = useCallback(
     ({ setHide, setAction }: QAModalEvent) => {
       setIsQAModalOpen(false)
@@ -132,9 +132,12 @@ const ArticleModule = ({
   const showBaodaozai =
     post?.showBaodaozai === true && (!isLogin || member?.showBaodaozai === true)
 
-  const essayQuestionCount = isLogin
-    ? (member?.essayQuestionCount ?? BAODAOZAI_DEFAULT_ESSAY_QUESTION_COUNT)
-    : 0
+  // In Preview Mode, we use the default essay question count to show all questions
+  const essayQuestionCount = envVars.isPreviewMode
+    ? BAODAOZAI_DEFAULT_ESSAY_QUESTION_COUNT
+    : isLogin
+      ? (member?.essayQuestionCount ?? BAODAOZAI_DEFAULT_ESSAY_QUESTION_COUNT)
+      : 0
 
   const postQuestions = useMemo<BaodaozaiQuestions | null>(() => {
     const essayQuestions = (post.postEssayQuestions ?? []).slice(
@@ -176,21 +179,23 @@ const ArticleModule = ({
 
   const handleQAModalSubmit = useCallback(
     async (answers: Record<number, string>, events: QAModalEvent) => {
-      if (isLogin) {
+      // In Preview Mode, we consider the user as logged in to show the dialog but not submit answers
+      if (isLogin && !envVars.isPreviewMode) {
         await onBatchSubmitAnswers(answers, postQuestions)
       }
+      const showLoginDialog = isLogin || envVars.isPreviewMode
       setIsQAModalOpen(false)
       events.setHide(false)
       events.onDialogPropsChange({
         isOpen: true,
-        content: isLogin
+        content: showLoginDialog
           ? `想知道其他讀者的答案嗎？
 大家送出的思辨題答案都會顯示在「小讀者觀點大集合」頁面喔～`
           : '登入帳號完成閱讀設定，還可以挑戰更多隱藏版的思辨題唷！',
         cancelText: '跳過',
-        confirmText: isLogin ? '立即前往' : '立即登入',
+        confirmText: showLoginDialog ? '立即前往' : '立即登入',
         confirmAction: () => {
-          if (isLogin) {
+          if (showLoginDialog) {
             window.open('/idea-hub', '_blank')
           } else {
             router.push(getLoginUrl())


### PR DESCRIPTION
## Summary

In CMS/article preview mode, essay (思辨) questions were hidden for unauthenticated users because the article module treated preview as a normal unauthenticated session. This change introduces a preview-mode flag and uses it so essay questions are always visible in preview and the post-submit dialog shows the correct message without actually submitting answers.

## Changes

- **`packages/frontend/src/environment-variables.ts`**: Added `isPreviewMode` derived from `NEXT_PUBLIC_IS_PREVIEW_MODE === 'true'` and exported it on the env object.
- **`packages/frontend/src/modules/article/index.tsx`**:
  - When `isPreviewMode` is true, `essayQuestionCount` uses the default essay question count so all essay questions are shown regardless of login state.
  - In `handleQAModalSubmit`, in preview mode we do not call `onBatchSubmitAnswers`; we still show the success-style dialog (「想知道其他讀者的答案嗎？」) and use the same confirm copy (「立即前往」) by treating preview as “logged in” for dialog content only.

## Additional Notes

- Preview builds need `NEXT_PUBLIC_IS_PREVIEW_MODE=true` (e.g. in `.env.preview.dev.public` or deployment env) for this behavior.
- No change to production behavior when the flag is unset or not `'true'`.

## Screenshot(s)


## Reference(s)