### PR TITLE
fix(frontend): call-in Baodaozai defect fixes - default action and Rive layout

### DIFF
--- a/packages/frontend/src/modules/article/index.tsx
+++ b/packages/frontend/src/modules/article/index.tsx
@@ -195,6 +195,7 @@ const ArticleModule = ({
           } else {
             router.push(getLoginUrl())
           }
+          events.setAction('default')
         },
         cancelAction: () => {
           events.setAction('default')

--- a/packages/frontend/src/services/call-baodaozai/components/qa-modal/enlighten-baodaozai.tsx
+++ b/packages/frontend/src/services/call-baodaozai/components/qa-modal/enlighten-baodaozai.tsx
@@ -4,6 +4,7 @@ import {
   Alignment,
   Fit,
   Layout,
+  RiveFile,
   useRive,
   useViewModel,
   useViewModelInstance,
@@ -12,25 +13,26 @@ import {
 } from '@rive-app/react-webgl2'
 import { useCallback, useEffect } from 'react'
 
-import envVars from '@/environment-variables'
-
 import { STATE_MACHINE_NAME, VIEW_MODEL_NAME } from '../../context/constants'
 import { QaBaodaozaiState } from '../../types'
 import { mapQaActionToEyesAndMouthArtboard } from './utils'
 
 type EnlightenBaodaozaiProps = {
   state: QaBaodaozaiState
+  riveFile: RiveFile
 }
 
-function EnlightenBaodaozai({ state }: EnlightenBaodaozaiProps) {
+const RIVE_LAYOUT = new Layout({
+  fit: Fit.Layout,
+  alignment: Alignment.Center,
+})
+
+function EnlightenBaodaozai({ state, riveFile }: EnlightenBaodaozaiProps) {
   const { RiveComponent, rive } = useRive({
-    src: envVars.baodaozaiRiveFilePath,
+    riveFile,
     stateMachines: STATE_MACHINE_NAME,
     autoplay: true,
-    layout: new Layout({
-      fit: Fit.Layout,
-      alignment: Alignment.Center,
-    }),
+    layout: RIVE_LAYOUT,
   })
 
   const rootViewModel = useViewModel(rive, { name: VIEW_MODEL_NAME })

--- a/packages/frontend/src/services/call-baodaozai/components/qa-modal/index.tsx
+++ b/packages/frontend/src/services/call-baodaozai/components/qa-modal/index.tsx
@@ -1,7 +1,10 @@
 'use client'
 
 import { Button, cn, useBodyScrollLock } from '@kids-reporter/routing-ui'
+import { useRiveFile } from '@rive-app/react-webgl2'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import envVars from '@/environment-variables'
 
 import { CallBaodaozaiProps, useCallBaodaozaiContext } from '../../context'
 import { BaodaozaiAction, BaodaozaiQuestions } from '../../types'
@@ -44,6 +47,9 @@ function QAModal({
   isOpen,
   mode = 'default',
 }: QAModalProps) {
+  const { riveFile } = useRiveFile({
+    src: envVars.baodaozaiRiveFilePath,
+  })
   const [currentModalStepIndex, setCurrentModalStepIndex] = useState(0)
   const defaultAnswers = useMemo(
     () => getDefaultAnswerFromQuestions(questions),
@@ -309,11 +315,16 @@ function QAModal({
               <div className="mb-6 flex w-full justify-center px-6">
                 <div className="flex h-[120px] w-[300px] items-center justify-center">
                   <div className="flex h-full w-full items-center justify-center">
-                    {answers[currentModalStep.questionIndex] ===
-                    currentModalStep.correctAnswerIndex.toString() ? (
-                      <EnlightenBaodaozai state="enlighten-correct" />
-                    ) : (
-                      <EnlightenBaodaozai state="enlighten-fault" />
+                    {riveFile && (
+                      <EnlightenBaodaozai
+                        state={
+                          answers[currentModalStep.questionIndex] ===
+                          currentModalStep.correctAnswerIndex.toString()
+                            ? 'enlighten-correct'
+                            : 'enlighten-fault'
+                        }
+                        riveFile={riveFile}
+                      />
                     )}
                   </div>
                 </div>
@@ -350,7 +361,12 @@ function QAModal({
               <div className="mb-6 flex w-full justify-center px-6">
                 <div className="flex h-[120px] w-[300px] items-center justify-center">
                   <div className="flex h-full w-full items-center justify-center">
-                    <EnlightenBaodaozai state="enlighten-send" />
+                    {riveFile && (
+                      <EnlightenBaodaozai
+                        state="enlighten-send"
+                        riveFile={riveFile}
+                      />
+                    )}
                   </div>
                 </div>
               </div>
@@ -376,6 +392,7 @@ function QAModal({
     handleAnswerChange,
     isLeaving,
     mode,
+    riveFile,
   ])
 
   const renderModalButtons = useMemo(() => {
@@ -478,7 +495,9 @@ function QAModal({
       case 'essay':
         return (
           <div className="pointer-events-none absolute -top-20 -left-12 z-4 tablet:-top-18 tablet:-left-6">
-            <EnlightenBaodaozai state="enlighten-ask" />
+            {riveFile && (
+              <EnlightenBaodaozai state="enlighten-ask" riveFile={riveFile} />
+            )}
           </div>
         )
       case 'choice-result':
@@ -487,7 +506,7 @@ function QAModal({
       default:
         return null
     }
-  }, [currentModalStep, isLeaving])
+  }, [currentModalStep, isLeaving, riveFile])
 
   if (!isOpen) return null
 


### PR DESCRIPTION
## Summary

Fixes two call-in 報到仔 (Baodaozai) defects: (1) reset the action to default after the user clicks the confirm button so follow-up behavior is correct, and (2) cache the Rive file at the QA modal level and pass it into the animation component to avoid unstable layout when the animation loads.

## Changes

- **Article module** (\`packages/frontend/src/modules/article/index.tsx\`): Call \`events.setAction('default')\` inside the confirm action callback so the action is reset to default after the user confirms (e.g. login redirect or other confirm flow).
- **Enlighten Baodaozai** (\`enlighten-baodaozai.tsx\`): Accept a pre-loaded \`riveFile\` prop instead of loading from \`src\`; use a shared \`RIVE_LAYOUT\` constant; remove direct use of \`envVars\` (loading iled by the parent).
- **QA modal** (\`qa-modal/index.tsx\`): Use \`useRiveFile\` to load and cache the Rive file once; pass the cached \`riveFile\` into all \`EnlightenBaodaozai\` instances; render \`EnlightenBaodaozai\` only when \`riveFile\` is ready to prevent layout shift; add \`riveFile\` to the relevant \`useMemo\` dependency arrays.

## Additional Notes

- Caching the Rive file at the modal level ensures a single load and stable layout when switching between steps (choice result, send, ask) that show the animation.
- Resetting the action to default after confirm avoids leaving the UI in a stale action state.

## Screenshot(s)

## Reference(s)