### PR TITLE
fix(frontend): adjust baodaozai position and actions

### DIFF
--- a/packages/frontend/src/modules/article/components/article-baodaozai-event-trigger.tsx
+++ b/packages/frontend/src/modules/article/components/article-baodaozai-event-trigger.tsx
@@ -98,7 +98,7 @@ function createBaodaozaiEventConfig({
       },
       baodaozaiState: {
         action: 'idle-read',
-        clickBaodaozaiAction: 'dialog-speaker',
+        clickBaodaozaiAction: 'dialog-read',
       },
     },
     'change-ask-questions': {

--- a/packages/frontend/src/modules/article/index.tsx
+++ b/packages/frontend/src/modules/article/index.tsx
@@ -290,6 +290,12 @@ const ArticleModule = ({
               <NewsReading items={newsReadingGroupItems} />
             )}
 
+            <ArticleBaodaozaiEventTrigger
+              id="hide-start-reading"
+              disabled={isScrollingDown}
+              startReadingContent={post?.opening ?? ''}
+            />
+
             {trimmedBrief.blocks.length > 0 ? (
               <>
                 <ArticleSummary
@@ -307,12 +313,6 @@ const ArticleModule = ({
             ) : (
               <div className="mb-10 tablet:mb-15"></div>
             )}
-
-            <ArticleBaodaozaiEventTrigger
-              id="hide-start-reading"
-              disabled={isScrollingDown}
-              startReadingContent={post?.opening ?? ''}
-            />
 
             <div className="relative w-full">
               <PostRenderer

--- a/packages/frontend/src/services/call-baodaozai/components/baodaozai.tsx
+++ b/packages/frontend/src/services/call-baodaozai/components/baodaozai.tsx
@@ -95,15 +95,15 @@ function Baodaozai() {
     let bottomValue
     if (isMobile) {
       bottomValue = dialogProps.isOpen
-        ? `calc(${dialogBoxHeight}px - 20px)`
-        : '2px'
+        ? `calc(${dialogBoxHeight}px - 52px)`
+        : '-22px'
     } else {
       if (dialogProps.isOpen) {
-        bottomValue = '0'
+        bottomValue = '-24px'
       } else if (isTablet) {
-        bottomValue = '8px'
+        bottomValue = '-16px'
       } else {
-        bottomValue = '12px'
+        bottomValue = '-12px'
       }
     }
     setBaodaozaiBottom(bottomValue)
@@ -132,9 +132,9 @@ function Baodaozai() {
       </div>
       <button
         className={cn(
-          'absolute -right-1 z-12 transition-all duration-1000 tablet:right-4',
+          'absolute -right-50 z-12 transition-all duration-1000 tablet:-right-48',
           !dialogProps.isOpen && 'cursor-pointer',
-          dialogProps.isOpen && 'right-6 z-10'
+          dialogProps.isOpen && '-right-42 z-10'
         )}
         onClick={dialogProps.isOpen ? undefined : handleOpenDialog}
         style={{

--- a/packages/frontend/src/services/call-baodaozai/components/qa-modal/enlighten-baodaozai.tsx
+++ b/packages/frontend/src/services/call-baodaozai/components/qa-modal/enlighten-baodaozai.tsx
@@ -1,9 +1,6 @@
 'use client'
 
 import {
-  Alignment,
-  Fit,
-  Layout,
   RiveFile,
   useRive,
   useViewModel,
@@ -22,17 +19,11 @@ type EnlightenBaodaozaiProps = {
   riveFile: RiveFile
 }
 
-const RIVE_LAYOUT = new Layout({
-  fit: Fit.Layout,
-  alignment: Alignment.Center,
-})
-
 function EnlightenBaodaozai({ state, riveFile }: EnlightenBaodaozaiProps) {
   const { RiveComponent, rive } = useRive({
     riveFile,
     stateMachines: STATE_MACHINE_NAME,
     autoplay: true,
-    layout: RIVE_LAYOUT,
   })
 
   const rootViewModel = useViewModel(rive, { name: VIEW_MODEL_NAME })


### PR DESCRIPTION
## Summary

Fixes call-in 報到仔 (Baodaozai) defect #3: improves character positioning, dialog action behavior, and article trigger placement. The 報到仔 character’s position is adjusted for mobile/tablet/desktop, the click action is aligned with read mode, the event trigger is moved for better timing, and unused Rive layout code is removed.

## Changes

- **Article module**
  - **`article-baodaozai-event-trigger.tsx`**: In the idle-read config, `clickBaodaozaiAction` is changed from `dialog-speaker` to `dialog-read` so opening the dialog uses read mode consistently.
  - **`article/index.tsx`**: `ArticleBaodaozaiEventTrigger` ("hide-start-reading") is moved from below the article summary/brief to directly after `NewsReading`, so the trigger fires at the right point in the reading flow.

- **Call 報到仔 service**
  - **`baodaozai.tsx`**: Positioning updates for the floating 報到仔:
    - **Bottom**: More negative values so the character sits lower (e.g. mobile open: `-52px` offset from dialog height, closed: `-22px`; desktop open: `-24px`, tablet closed: `-16px`, desktop closed: `-12px`).
    - **Right**: Button position shifted with Tailwind classes (e.g. `-right-50` / `tablet:-right-48` when closed, `-right-42` when open) for correct placement relative to the dialog.
  - **`enlighten-baodaozai.tsx`**: Removed unused Rive layout setup: `Alignment`, `Fit`, `Layout` imports and `RIVE_LAYOUT` (and its use in `useRive`), simplifying the component.

## Additional Notes

- Positioning values are tuned for the current 報到仔 asset and dialog; if the asset or dialog size changes, these values may need another pass.
- The trigger move may affect when "hide-start-reading" fires; worth confirming in QA that it still matches product expectations.

## Screenshot(s)

## Reference(s)