### PR TITLE
feat(frontend): article loading skeletons and callin baodaozai trigger position

### DIFF
--- a/packages/frontend/src/modules/article/components/article-summary.tsx
+++ b/packages/frontend/src/modules/article/components/article-summary.tsx
@@ -3,6 +3,7 @@ import { cn } from '@kids-reporter/routing-ui'
 import { RawDraftContentState } from 'draft-js'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
+import Skeleton from 'react-loading-skeleton'
 
 import Divider from '@/components/divider'
 import { FontSizeLevel } from '@/constants'
@@ -68,8 +69,12 @@ function ArticleSummary({
           ]
         )}
       >
-        {content && isMounted && (
+        {content && isMounted ? (
           <ArticleIntroductionDraftRenderer rawContentState={content} />
+        ) : (
+          <div className="w-[min(512px,calc(100vw-36px))] px-6 tablet:px-0 desktop:w-[584px]">
+            <Skeleton count={5} />
+          </div>
         )}
       </div>
 

--- a/packages/frontend/src/modules/article/components/post-renderer.tsx
+++ b/packages/frontend/src/modules/article/components/post-renderer.tsx
@@ -4,6 +4,7 @@ import 'react-loading-skeleton/dist/skeleton.css'
 import { ArticleBodyDraftRenderer } from '@kids-reporter/draft-renderer'
 import { cn } from '@kids-reporter/routing-ui'
 import { RawDraftContentState } from 'draft-js'
+import Skeleton from 'react-loading-skeleton'
 
 import { FontSizeLevel, STICKY_HEADER_HEIGHT } from '@/constants'
 
@@ -43,6 +44,11 @@ function PostRenderer({ content, shouldMount }: PostProp) {
           }
           offsetTop={STICKY_HEADER_HEIGHT}
         />
+      )}
+      {!shouldMount && (
+        <div className="mx-auto w-[min(512px,calc(100vw-12px))] px-6 tablet:px-0 desktop:w-[584px]">
+          <Skeleton count={10} />
+        </div>
       )}
     </div>
   )

--- a/packages/frontend/src/modules/article/index.tsx
+++ b/packages/frontend/src/modules/article/index.tsx
@@ -256,7 +256,7 @@ const ArticleModule = ({
           }}
         >
           <Toolbar topicURL={topicURL} postSlug={slug} />
-          <div className="flex w-full max-w-256 flex-col items-center desktop:mx-auto desktop:px-12 hd:max-w-354.5">
+          <div className="relative flex w-full max-w-256 flex-col items-center desktop:mx-auto desktop:px-12 hd:max-w-354.5">
             {isDesktop && (
               <ImageModal
                 isOpen={isImgModalOpen}
@@ -289,12 +289,13 @@ const ArticleModule = ({
             {post?.newsReadingGroup && (
               <NewsReading items={newsReadingGroupItems} />
             )}
-
-            <ArticleBaodaozaiEventTrigger
-              id="hide-start-reading"
-              disabled={isScrollingDown}
-              startReadingContent={post?.opening ?? ''}
-            />
+            <div className="absolute top-[120vh]">
+              <ArticleBaodaozaiEventTrigger
+                id="hide-start-reading"
+                disabled={isScrollingDown}
+                startReadingContent={post?.opening ?? ''}
+              />
+            </div>
 
             {trimmedBrief.blocks.length > 0 ? (
               <>


### PR DESCRIPTION
## Summary

This PR improves the article page UX by (1) showing skeleton loading states for the article summary and post body while content loads, and (2) fixing the call-in 報到仔 (baodaozai) event trigger position so it fires at the intended scroll position (120vh).

## Changes

- **Article summary** (`article-summary.tsx`): Show a skeleton (5 lines) when content is not yet available or not mounted, using `react-loading-skeleton` with the same width constraints as the rendered summary.
- **Post renderer** (`post-renderer.tsx`): Show a skeleton (10 lines) when `shouldMount` is false so the article body area has a loading state before the Draft content mounts.
- **Article layout** (`article/index.tsx`): Make the main content wrapper `relative` and wrap `ArticleBaodaozaiEigger` in an absolutely positioned div with `top-[120vh]` so the trigger sits at the correct scroll position for the call-in baodaozai feature.

## Additional Notes

- Skeleton containers reuse the same responsive width classes as the article content for consistent layout.
- The baodaozai trigger is now positioned at 120vh from the top of its relative parent, which should align the "start reading" / call-in behavior with the desired scroll position.

## Screenshot(s)

## Reference(s)