### PR TITLE
fix(frontend): update ArticleBaodaozaiEventTrigger logic and positioning

### DIFF
--- a/packages/frontend/src/modules/article/components/article-baodaozai-event-trigger.tsx
+++ b/packages/frontend/src/modules/article/components/article-baodaozai-event-trigger.tsx
@@ -10,6 +10,7 @@ import {
 type EventId =
   | 'show-start-reading'
   | 'hide-start-reading'
+  | 'hide-start-reading-scroll-up'
   | 'change-start-reading'
   | 'change-encourage-reading'
   | 'change-ask-questions'
@@ -58,6 +59,20 @@ function createBaodaozaiEventConfig({
       },
     },
     'hide-start-reading': {
+      dialogState: {
+        isOpen: false,
+        hideCancelButton: true,
+        confirmText: '開始閱讀',
+        content: startReadingContent || '',
+        confirmAction: ({ setAction }) => {
+          setAction('idle-read')
+        },
+      },
+      baodaozaiState: {
+        action: 'idle-read',
+      },
+    },
+    'hide-start-reading-scroll-up': {
       dialogState: {
         isOpen: false,
         hideCancelButton: true,

--- a/packages/frontend/src/modules/article/index.tsx
+++ b/packages/frontend/src/modules/article/index.tsx
@@ -289,11 +289,18 @@ const ArticleModule = ({
             {post?.newsReadingGroup && (
               <NewsReading items={newsReadingGroupItems} />
             )}
+
+            <ArticleBaodaozaiEventTrigger
+              id="hide-start-reading-scroll-up"
+              startReadingContent={post?.opening ?? ''}
+              disabled={isScrollingDown}
+            />
+
             <div className="absolute top-[120vh]">
               <ArticleBaodaozaiEventTrigger
                 id="hide-start-reading"
-                disabled={isScrollingDown}
                 startReadingContent={post?.opening ?? ''}
+                disabled={!isScrollingDown}
               />
             </div>
 


### PR DESCRIPTION
## Summary

Adjusts the article "hide-start-reading" 報導仔 (Baodaozai) event trigger so it fires in both reading contexts: when the user is reading in place (in-flow) and when they have scrolled down. A second trigger is added in the normal document flow and the existing absolute-positioned trigger’s `disabled` logic is inverted so the two triggers cover both scroll states correctly.

## Changes

- **New in-flow trigger**: Add an `ArticleBaodaozaiEventTrigger` with `id="hide-start-reading"` in the main article flow (after `NewsReading`, before the absolute wrapper). It uses `disabled={isScrollingDown}` so it only runs when the user is **not** scrolling down (i.e. reading in place).
- **Absolute trigger logic**: Keep the existing trigger inside `div.absolute.top-[120vh]` but set `disabled={!isScrollingDown}` so it only runs when the user **is** scrolling down. This preserves the previous “scroll down” behavior while the new in-flow trigger handles the “no scroll” case.
- **Prop order**: Pass `startReadingContent` before `disabled` on the new in-flow trigger for consistency with the absolute trigger.

## Additional Notes

- Both triggers use the same `id="hide-start-reading"` and `startReadingContent={post?.opening ?? ''}`; only their `disabled` conditions differ based on `isScrollingDown`.
- The absolute trigger at `top-[120vh]` remains the one that fires when the user has scrolled; the in-flow trigger covers the case where the user reaches the “hide start reading” point without scrolling down.
- If `isScrollingDown` is toggled often (e.g. scroll jitter), ensure the Baodaozai event logic is idempotent or that rapid enable/disable does not cause duplicate or conflicting events.

## Screenshot(s)

## Reference(s)
