### PR TITLE
fix(frontend): adjust baodaozai article trigger position

### DIFF
--- a/packages/frontend/src/modules/article/index.tsx
+++ b/packages/frontend/src/modules/article/index.tsx
@@ -290,17 +290,16 @@ const ArticleModule = ({
               <NewsReading items={newsReadingGroupItems} />
             )}
 
-            <ArticleBaodaozaiEventTrigger
-              id="hide-start-reading-scroll-up"
-              startReadingContent={post?.opening ?? ''}
-              disabled={isScrollingDown}
-            />
-
-            <div className="absolute top-[120vh]">
+            <div className="absolute top-[150vh]">
               <ArticleBaodaozaiEventTrigger
                 id="hide-start-reading"
                 startReadingContent={post?.opening ?? ''}
                 disabled={!isScrollingDown}
+              />
+              <ArticleBaodaozaiEventTrigger
+                id="hide-start-reading-scroll-up"
+                startReadingContent={post?.opening ?? ''}
+                disabled={isScrollingDown}
               />
             </div>
 


### PR DESCRIPTION
## Summary

Adjusts the article Baodaozai event trigger placement so the "hide start reading" and "hide start reading (scroll up)" triggers share one positioned container and fire lower on the page (150vh instead of 120vh), improving when the reading-state UI updates during scroll.

## Changes

- **Trigger position**: Wrapper div position changed from `top-[120vh]` to `top-[150vh]` so triggers fire after the user has scrolled further into the article.
- **Trigger grouping**: Both `ArticleBaodaozaiEventTrigger` instances (`hide-start-reading` and `hide-start-reading-scroll-up`) are now inside the same `absolute top-[150vh]` wrapper instead of one being outside.
- **Behavior unchanged**: `hide-start-reading` still uses `disabled={!isScrollingDown}`; `hide-start-reading-scroll-up` still uses `disabled={isScrollingDown}`.

## Additional Notes

- Single file change in `packages/frontend/src/modules/article/index.tsx`.
- Consider verifying 150vh works well across viewport sizes; the offset could be made configurable later if needed.

## Screenshot(s)

## Reference(s)