### PR TITLE
fix(routing-ui): correct category URL patterns

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -19,7 +19,7 @@
     "@googleapis/customsearch": "^1.0.4",
     "@hookform/resolvers": "^5.2.2",
     "@kids-reporter/draft-renderer": "^1.0.13",
-    "@kids-reporter/routing-ui": "0.1.19",
+    "@kids-reporter/routing-ui": "0.1.20",
     "@next/third-parties": "^14.1.1",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/packages/routing-ui/package.json
+++ b/packages/routing-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kids-reporter/routing-ui",
   "license": "MIT",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Routing UI for Kids Reporter",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/routing-ui/src/constants/default-values.tsx
+++ b/packages/routing-ui/src/constants/default-values.tsx
@@ -28,14 +28,14 @@ export const MENU_ITEMS: MenuItem[] = [
       { label: '人物故事', href: '/category/news/story' },
       { label: '文化報導', href: '/category/news/explore' },
       { label: '專欄', href: '/category/news/column' },
-      { label: '英文新聞', href: '/categories/news/english-version' },
+      { label: '英文新聞', href: '/category/news/english-version' },
     ],
   },
   {
     label: '多媒體',
     href: '/category/storytelling',
     subItems: [
-      { label: '圖解新聞', href: '/category/storytelling/times' },
+      { label: '圖解新聞', href: '/category/storytelling/graphic-news' },
       { label: '新聞遊戲', href: '/category/storytelling/news-game' },
       { label: '圖文故事', href: '/category/storytelling/graphic-story' },
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5166,7 +5166,7 @@ __metadata:
     "@graphql-codegen/typescript-operations": "npm:^5.0.2"
     "@hookform/resolvers": "npm:^5.2.2"
     "@kids-reporter/draft-renderer": "npm:^1.0.13"
-    "@kids-reporter/routing-ui": "npm:0.1.19"
+    "@kids-reporter/routing-ui": "npm:0.1.20"
     "@next/bundle-analyzer": "npm:^14.2.33"
     "@next/eslint-plugin-next": "npm:^14.2.33"
     "@next/third-parties": "npm:^14.1.1"
@@ -5233,7 +5233,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/routing-ui@npm:0.1.19, @kids-reporter/routing-ui@workspace:packages/routing-ui":
+"@kids-reporter/routing-ui@npm:0.1.20, @kids-reporter/routing-ui@workspace:packages/routing-ui":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/routing-ui@workspace:packages/routing-ui"
   dependencies:


### PR DESCRIPTION
## Summary

Fix category URL patterns in the routing UI package and bump the routing-ui version, updating frontend dependencies and lockfile accordingly.

## Changes

- Correct category URL patterns in routing-ui constants to generate the expected paths.
- Bump @kids-reporter/routing-ui version to 0.1.20 in the routing-ui package metadata.
- Update the frontend package dependency on @kids-reporter/routing-ui to use the new version.
- Regenerate yarn.lock to reflect the updated routing-ui version.

## Additional Notes

- No breaking changes expected; this should only affect category link generation.
- Please verify key category routes in the frontend to ensure they resolve correctly.

## Screenshot(s)


## Reference(s)

