### PR TITLE
chore(logger): switch build to Babel and bump to 0.0.2

### DIFF
--- a/packages/api-gateway/package.json
+++ b/packages/api-gateway/package.json
@@ -13,7 +13,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@kids-reporter/logger": "^0.0.1",
+    "@kids-reporter/logger": "^0.0.2",
     "@twreporter/errors": "^1.1.2",
     "axios": "^1.4.0",
     "busboy": "^1.6.0",

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -22,7 +22,7 @@
     "@keystone-6/auth": "8.1.0",
     "@keystone-6/core": "6.5.1",
     "@kids-reporter/cms-core": "^1.0.17",
-    "@kids-reporter/logger": "^0.0.1",
+    "@kids-reporter/logger": "^0.0.2",
     "@twreporter/errors": "^1.1.2",
     "@types/react-beautiful-dnd": "^13.1.4",
     "axios": "^1.6.2",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -13,7 +13,7 @@
     "type-check": "tsc --noEmit",
     "codegen:local": "graphql-codegen --config codegen.local.ts",
     "codegen:cloudbuild": "graphql-codegen --config codegen.cloudbuild.ts",
-    "postinstall": "yarn codegen:local && cd ../logger && yarn build && cd ../routing-ui && yarn build"
+    "postinstall": "yarn codegen:local && yarn workspace @kids-reporter/logger build && yarn workspace @kids-reporter/routing-ui build"
   },
   "dependencies": {
     "@googleapis/customsearch": "^1.0.4",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -19,7 +19,7 @@
     "@googleapis/customsearch": "^1.0.4",
     "@hookform/resolvers": "^5.2.2",
     "@kids-reporter/draft-renderer": "^1.0.13",
-    "@kids-reporter/logger": "^0.0.1",
+    "@kids-reporter/logger": "^0.0.2",
     "@kids-reporter/routing-ui": "0.1.20",
     "@next/third-parties": "^14.1.1",
     "@radix-ui/react-accordion": "^1.2.12",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -13,7 +13,7 @@
     "type-check": "tsc --noEmit",
     "codegen:local": "graphql-codegen --config codegen.local.ts",
     "codegen:cloudbuild": "graphql-codegen --config codegen.cloudbuild.ts",
-    "postinstall": "yarn codegen:local && cd ../routing-ui && yarn build"
+    "postinstall": "yarn codegen:local && cd ../logger && yarn build && cd ../routing-ui && yarn build"
   },
   "dependencies": {
     "@googleapis/customsearch": "^1.0.4",

--- a/packages/logger/babel.config.cjs
+++ b/packages/logger/babel.config.cjs
@@ -1,0 +1,21 @@
+module.exports = {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          node: '18',
+          browsers: ['> 1%', 'last 2 versions', 'not dead'],
+        },
+        modules: false, // Output ESM for "type": "module"
+      },
+    ],
+    [
+      '@babel/preset-typescript',
+      {
+        allExtensions: true,
+      },
+    ],
+  ],
+  plugins: ['@babel/plugin-transform-runtime'],
+}

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -15,7 +15,6 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "postinstall": "yarn build",
     "lint:check": "eslint src --config ./eslint.config.mjs --ext .ts",
     "type-check": "tsc --noEmit -p tsconfig.json"
   },

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,9 +1,12 @@
 {
   "name": "@kids-reporter/logger",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "license": "MIT",
   "description": "Shared structured logger for Kids Reporter services",
+  "files": [
+    "dist"
+  ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -14,12 +17,19 @@
     }
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "./scripts/build.sh",
     "lint:check": "eslint src --config ./eslint.config.mjs --ext .ts",
     "type-check": "tsc --noEmit -p tsconfig.json"
   },
   "devDependencies": {
-    "eslint": "^9.0.0",
+    "@babel/cli": "^7.18.5",
+    "@babel/core": "^7.18.5",
+    "@babel/plugin-transform-runtime": "^7.18.5",
+    "@babel/preset-env": "^7.18.2",
+    "@babel/preset-typescript": "^7.17.12",
     "typescript": "^5.9.2"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.18.5"
   }
 }

--- a/packages/logger/scripts/build.sh
+++ b/packages/logger/scripts/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+echo "Cleaning dist directory..."
+rm -rf ./dist
+mkdir -p ./dist
+
+echo "Building with Babel..."
+npx babel src --out-dir dist --extensions ".ts" --source-maps
+
+echo "Generating TypeScript declarations..."
+npx tsc --emitDeclarationOnly --declaration --declarationMap --outDir dist
+
+echo "Build completed successfully!"

--- a/packages/logger/scripts/build.sh
+++ b/packages/logger/scripts/build.sh
@@ -7,9 +7,9 @@ rm -rf ./dist
 mkdir -p ./dist
 
 echo "Building with Babel..."
-npx babel src --out-dir dist --extensions ".ts" --source-maps
+yarn babel src --out-dir dist --extensions ".ts" --source-maps
 
 echo "Generating TypeScript declarations..."
-npx tsc --emitDeclarationOnly --declaration --declarationMap --outDir dist
+yarn tsc --emitDeclarationOnly --declaration --declarationMap --outDir dist
 
 echo "Build completed successfully!"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1079,6 +1079,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/cli@npm:^7.18.5":
+  version: 7.28.6
+  resolution: "@babel/cli@npm:7.28.6"
+  dependencies:
+    "@jridgewell/trace-mapping": "npm:^0.3.28"
+    "@nicolo-ribaudo/chokidar-2": "npm:2.1.8-no-fsevents.3"
+    chokidar: "npm:^3.6.0"
+    commander: "npm:^6.2.0"
+    convert-source-map: "npm:^2.0.0"
+    fs-readdir-recursive: "npm:^1.1.0"
+    glob: "npm:^7.2.0"
+    make-dir: "npm:^2.1.0"
+    slash: "npm:^2.0.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  dependenciesMeta:
+    "@nicolo-ribaudo/chokidar-2":
+      optional: true
+    chokidar:
+      optional: true
+  bin:
+    babel: ./bin/babel.js
+    babel-external-helpers: ./bin/babel-external-helpers.js
+  checksum: 10c0/b1bde80a44ca2f23c4786278db3faf0c41b249a67e6205bf9859debd19b58face48b8d0b57d3843b08c813b5d0b93ebbe153974b67fcea493cb9829ae76b6cb4
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/code-frame@npm:7.27.1"
@@ -4995,7 +5022,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@kids-reporter/api-gateway@workspace:packages/api-gateway"
   dependencies:
-    "@kids-reporter/logger": "npm:^0.0.1"
+    "@kids-reporter/logger": "npm:^0.0.2"
     "@twreporter/errors": "npm:^1.1.2"
     "@types/busboy": "npm:^1.5.4"
     "@types/cookie-parser": "npm:^1.4.6"
@@ -5057,7 +5084,7 @@ __metadata:
     "@keystone-6/auth": "npm:8.1.0"
     "@keystone-6/core": "npm:6.5.1"
     "@kids-reporter/cms-core": "npm:^1.0.17"
-    "@kids-reporter/logger": "npm:^0.0.1"
+    "@kids-reporter/logger": "npm:^0.0.2"
     "@twreporter/errors": "npm:^1.1.2"
     "@types/cookie-parser": "npm:^1.4.7"
     "@types/jsonwebtoken": "npm:^9.0.6"
@@ -5168,7 +5195,7 @@ __metadata:
     "@graphql-codegen/typescript-operations": "npm:^5.0.2"
     "@hookform/resolvers": "npm:^5.2.2"
     "@kids-reporter/draft-renderer": "npm:^1.0.13"
-    "@kids-reporter/logger": "npm:^0.0.1"
+    "@kids-reporter/logger": "npm:^0.0.2"
     "@kids-reporter/routing-ui": "npm:0.1.20"
     "@next/bundle-analyzer": "npm:^14.2.33"
     "@next/eslint-plugin-next": "npm:^14.2.33"
@@ -5236,11 +5263,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/logger@npm:^0.0.1, @kids-reporter/logger@workspace:packages/logger":
+"@kids-reporter/logger@npm:^0.0.2, @kids-reporter/logger@workspace:packages/logger":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/logger@workspace:packages/logger"
   dependencies:
-    eslint: "npm:^9.0.0"
+    "@babel/cli": "npm:^7.18.5"
+    "@babel/core": "npm:^7.18.5"
+    "@babel/plugin-transform-runtime": "npm:^7.18.5"
+    "@babel/preset-env": "npm:^7.18.2"
+    "@babel/preset-typescript": "npm:^7.17.12"
+    "@babel/runtime": "npm:^7.18.5"
     typescript: "npm:^5.9.2"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary

Updates `@kids-reporter/logger` to build distributable JS via Babel + emit `.d.ts`, bumps the package to `0.0.2`, and ensures `frontend` builds `logger` during `postinstall` so consumers can resolve `dist` outputs.

## Changes

- Add `packages/logger/babel.config.cjs` and a `scripts/build.sh` pipeline (clean `dist`, Babel compile, TypeScript declaration emit, align with `routing-ui`)
- Update `packages/logger/package.json` (version `0.0.2`, ship `dist`, add Babel toolchain + runtime dependency, wire `build` to the script)
- Bump `@kids-reporter/logger` dependency to `^0.0.2` in `packages/api-gateway`, `packages/cms`, and `packages/frontend`
- Update `packages/frontend/package.json` `postinstall` to build `logger` before building `routing-ui`
- Update `yarn.lock` for new Babel dependencies

## Additional Notes

- This should address cases where consuming workspaces expect `@kids-reporter/logger/dist/*` to exist after installs.
- The build outputs ESM (`"type": "module"`) and includes source maps + declaration maps.

## Screenshot(s)

## Reference(s)