### PR TITLE
fix(frontend): adjust topic text shadow and spacing

### DIFF
--- a/packages/frontend/src/modules/topic/components/featured-topic-card.tsx
+++ b/packages/frontend/src/modules/topic/components/featured-topic-card.tsx
@@ -30,10 +30,7 @@ function FeaturedTopicCard({
           src={topic.image ?? FALLBACK_IMG}
           loading="lazy"
         />
-        <p
-          className="text-p2 absolute top-5 left-5 leading-[1.6] font-medium tracking-[0.07em] text-white tablet:top-[34px] tablet:left-8 desktop:top-8 desktop:left-8"
-          style={{ textShadow: '0 2px 8px rgba(0, 0, 0, 0.80)' }}
-        >
+        <p className="text-p2 absolute top-5 left-5 prose-p1 text-white text-shadow-[0_2px_6px_rgba(0,0,0,0.55)] tablet:top-[34px] tablet:left-8 tablet:text-shadow-[0_2px_8px_rgba(0,0,0,0.80)] desktop:top-8 desktop:left-8">
           {metaText}
         </p>
         <div
@@ -41,17 +38,11 @@ function FeaturedTopicCard({
           aria-hidden
         />
         <div className="absolute right-5 bottom-5 left-5 flex flex-col gap-2 tablet:right-8 tablet:bottom-8 tablet:left-8 desktop:right-8 desktop:bottom-8 desktop:left-8">
-          <h2
-            className="prose-h3-small font-swei text-white tablet:prose-h3-large"
-            style={{ textShadow: '0 2px 8px rgba(0, 0, 0, 0.80)' }}
-          >
+          <h2 className="prose-h3-small font-swei text-white text-shadow-[0_2px_6px_rgba(0,0,0,0.55)] tablet:prose-h3-large tablet:text-shadow-[0_2px_8px_rgba(0,0,0,0.80)]">
             {topic.title}
           </h2>
           <div className="flex items-center gap-4 tablet:gap-8">
-            <p
-              className="line-clamp-3 min-w-0 flex-1 prose-p1 text-white"
-              style={{ textShadow: '0 2px 8px rgba(0, 0, 0, 0.80)' }}
-            >
+            <p className="line-clamp-3 min-w-0 flex-1 prose-p1 text-white text-shadow-[0_2px_6px_rgba(0,0,0,0.55)] tablet:text-shadow-[0_2px_8px_rgba(0,0,0,0.80)]">
               {topic.desc}
             </p>
             <Button className="size-11 shrink-0 rounded-full border-2 border-neutral-white p-0">

--- a/packages/frontend/src/modules/topic/components/positioned-title.tsx
+++ b/packages/frontend/src/modules/topic/components/positioned-title.tsx
@@ -34,23 +34,15 @@ function PositionedTitle({
   return (
     <div
       className={cn(
-        'absolute text-neutral-white',
+        'absolute text-neutral-white text-shadow-[0_2px_8px_rgba(0,0,0,0.45)] tablet:text-shadow-[0_2px_10px_rgba(0,0,0,0.60)]',
         getTitleClassname(titlePosition)
       )}
-      style={{
-        textShadow: '0 2px 10px rgba(0, 0, 0, 0.60)',
-      }}
     >
       {titlePosition.startsWith('left') && (
         <p className="mb-4 prose-p1-bold">{`${publishedDate} 最後更新 | 共 ${articleCount} 篇文章`}</p>
       )}
 
-      <h1
-        className="mb-2 prose-h1-small font-swei! desktop:prose-h1-large"
-        style={{
-          textShadow: '0 2px 10px rgba(0, 0, 0, 0.60)',
-        }}
-      >
+      <h1 className="mb-2 prose-h1-small font-swei! desktop:prose-h1-large">
         {title}
       </h1>
       {subtitle && (

--- a/packages/frontend/src/modules/topic/components/topic-post-slider.tsx
+++ b/packages/frontend/src/modules/topic/components/topic-post-slider.tsx
@@ -106,7 +106,7 @@ function TopicPostSlider({ posts }: { posts: PostSummary[] }) {
       </Swiper>
       {slideCount > 1 && (
         <div
-          className="flex shrink-0 items-center gap-3 tablet:mt-5"
+          className="flex shrink-0 items-center gap-3 tablet:mt-1 desktop:mt-5"
           role="tablist"
           aria-label="投影片分頁"
         >


### PR DESCRIPTION
## Summary
Improve topic UI text readability by standardizing text-shadow styling and fine-tuning slider spacing across breakpoints.

## Changes
- Replace inline textShadow styles with Tailwind arbitrary `text-shadow-[...]` utilities in topic components
- Tweak text-shadow values per breakpoint for better readability/consistency
- Adjust `TopicPostSlider` tablist top margin for tablet vs desktop spacing

## Additional Notes
- No functional logic changes; styling-only updates.

## Screenshot(s)

## Reference(s)
