### PR TITLE
fix(frontend): topic page layout and related posts grid defects

### DIFF
--- a/packages/frontend/src/modules/topic/all/index.tsx
+++ b/packages/frontend/src/modules/topic/all/index.tsx
@@ -118,7 +118,7 @@ function TopicAllModule({
             <div
               className={cn(
                 'mt-10 mb-5 flex w-full flex-col items-center justify-center gap-6 tablet:mt-12 tablet:mb-8 tablet:grid tablet:grid-cols-4 tablet:gap-x-6 tablet:gap-y-8 desktop:mt-14 desktop:mb-10 desktop:gap-x-8 desktop:gap-y-10 hd:mt-20 hd:mb-12 hd:gap-y-14 hd:px-14',
-                !featuredTopic && 'mt-0'
+                !featuredTopic && 'mt-0 tablet:mt-0 desktop:mt-0 hd:mt-0'
               )}
             >
               {topicsForListing.map((topic, index) => {

--- a/packages/frontend/src/modules/topic/components/related-posts.tsx
+++ b/packages/frontend/src/modules/topic/components/related-posts.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMediaQuery } from '@kids-reporter/routing-ui'
+import { cn, useMediaQuery } from '@kids-reporter/routing-ui'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
@@ -10,8 +10,35 @@ import { FALLBACK_IMG } from '@/constants'
 import { Breakpoint } from '@/types'
 import { getFormattedDate } from '@/utils'
 
-import { RELATED_POSTS_PER_ROW } from '../constants'
-import { groupPostsByRow } from '../utils'
+function getRelatedPostGridColumn(
+  viewPort: Breakpoint,
+  index: number,
+  total: number
+): string {
+  if (viewPort === 'mobile') return ''
+  if (viewPort === 'tablet') {
+    const perRow = 2
+    const lastRowCount = total % perRow || perRow
+    const lastRowStart = total - lastRowCount
+    if (index >= lastRowStart && lastRowCount === 1) {
+      return 'tablet:col-start-2 tablet:col-end-4'
+    }
+    return ''
+  }
+  // desktop (and hd)
+  const perRow = 3
+  const lastRowCount = total % perRow || perRow
+  const lastRowStart = total - lastRowCount
+  if (index < lastRowStart) return ''
+  if (lastRowCount === 1) return 'desktop:col-start-3 desktop:col-end-5'
+  if (lastRowCount === 2) {
+    const posInLastRow = index - lastRowStart
+    return posInLastRow === 0
+      ? 'desktop:col-start-2 desktop:col-end-4'
+      : 'desktop:col-start-4 desktop:col-end-6'
+  }
+  return ''
+}
 
 const ImageWithFallback = dynamic(
   () => import('@/components/image-with-fallback'),
@@ -78,33 +105,20 @@ function RelatedPosts({ posts = [] }: RelatedPostsProps) {
     return null
   }
 
-  const groupedPosts = groupPostsByRow(posts, viewPort)
-  const perRow = RELATED_POSTS_PER_ROW[viewPort]
-
   return (
     <section className="mx-auto w-screen bg-neutral-100 px-6 py-10 tablet:px-8 tablet:py-16 desktop:px-12 desktop:py-20 hd:px-0">
-      <div className="flex flex-col gap-6 tablet:gap-8 desktop:gap-10 hd:gap-14">
-        {groupedPosts.map((row, index) => {
-          return (
-            <div
-              key={`row-${index}`}
-              className="mx-auto flex max-w-300 justify-center gap-8 hd:px-14"
-            >
-              {row.map((post) => (
-                <div
-                  key={post.url}
-                  className="min-w-0 shrink-0 grow-0"
-                  style={{
-                    // 100% - (perRow - 1) * gapPx / perRow
-                    flexBasis: `calc((100% - (${perRow - 1} * 32px)) / ${perRow})`,
-                  }}
-                >
-                  <RelatedPostCard post={post} />
-                </div>
-              ))}
-            </div>
-          )
-        })}
+      <div className="mx-auto grid max-w-300 grid-cols-1 gap-x-6 gap-y-6 tablet:grid-cols-4 tablet:gap-x-6 tablet:gap-y-8 desktop:grid-cols-6 desktop:gap-x-8 desktop:gap-y-10 hd:gap-x-8 hd:gap-y-14 hd:px-14">
+        {posts.map((post, index) => (
+          <div
+            key={post.url}
+            className={cn(
+              'min-w-0 tablet:col-span-2 desktop:col-span-2',
+              getRelatedPostGridColumn(viewPort, index, posts.length)
+            )}
+          >
+            <RelatedPostCard post={post} />
+          </div>
+        ))}
       </div>
     </section>
   )

--- a/packages/frontend/src/modules/topic/constants.ts
+++ b/packages/frontend/src/modules/topic/constants.ts
@@ -1,8 +1,0 @@
-import { Breakpoint } from '@/types'
-
-export const RELATED_POSTS_PER_ROW: Record<Breakpoint, number> = {
-  mobile: 1,
-  tablet: 2,
-  desktop: 3,
-  hd: 3,
-}

--- a/packages/frontend/src/modules/topic/utils.ts
+++ b/packages/frontend/src/modules/topic/utils.ts
@@ -1,8 +1,4 @@
-import { PostSummary } from '@/components/types'
 import { FALLBACK_IMG } from '@/constants'
-import { Breakpoint } from '@/types'
-
-import { RELATED_POSTS_PER_ROW } from './constants'
 
 export const normalizePhoto = (photo: {
   resized?: { small?: string; medium?: string; large?: string }
@@ -18,18 +14,4 @@ export const normalizePhoto = (photo: {
         FALLBACK_IMG,
     },
   }
-}
-
-export const groupPostsByRow = (
-  posts: PostSummary[],
-  breakpoint: Breakpoint
-) => {
-  return posts.reduce((acc, post, index) => {
-    const row = Math.floor(index / RELATED_POSTS_PER_ROW[breakpoint])
-    if (!acc[row]) {
-      acc[row] = []
-    }
-    acc[row].push(post)
-    return acc
-  }, [] as PostSummary[][])
 }


### PR DESCRIPTION
## Summary

Fixes topic page layout defects: (1) corrects top margin when no featured topic is present so the topic grid stays flush at all breakpoints, and (2) refactors the Related Posts section from a row-based flex layout to a CSS Grid layout with proper last-row centering for tablet and desktop.

## Changes

- **`topic/all/index.tsx`**: When there is no featured topic, apply `mt-0` at tablet, desktop, and HD breakpoints (in addition to the base mobile `mt-0`) so the topic listing grid does not show unwanted top margin on larger screens.
- **`topic/components/related-posts.tsx`**: Replaced the previous row-based layout (flex + `groupPostsByRow` + `calc`-based `flexBasis`) with a single CSS Grid. Added `getRelatedPostGridColumn()` to return Tailwind classes that center the last row when there are fewer items than a full row (e.g. 1 item on tablet → center in 4-col grid; 1 or 2 items on desktop → center in 6-col grid). Uses `cn` for conditional grid column classes.
- **`topic/constants.ts`**: Removed. `RELATED_POSTS_PER_ROW` is no longer used; per-row logic is inlined in `getRelatedPostGridColumn`.
- **`topic/utils.ts`**: Removed `groupPostsByRow` and related imports; kept `normalizePhoto` and existing exports.

## Additional Notes

- No other references to `RELATED_POSTS_PER_ROW` or `groupPostsByRow` exist in the frontend package.
- Grid column centering follows the same breakpoint behavior as before (2 per row on tablet, 3 on desktop/HD) but is implemented with grid placement instead of manual row grouping and flex basis.

## Screenshot(s)


## Reference(s)

