### PR TITLE
fix(frontend): polish category collection layout and intro behavior

### DIFF
--- a/packages/frontend/src/app/(general)/category/[[...path]]/page.tsx
+++ b/packages/frontend/src/app/(general)/category/[[...path]]/page.tsx
@@ -274,7 +274,7 @@ export default async function Category({
       categorySlug={category}
       title={collectionTitle}
       introContent={introContent ?? ''}
-      showIntro={Boolean(pageEnum)}
+      showIntro={Boolean(pageEnum) && currentPage === 1}
       posts={posts}
       navigationItems={navigationItems}
       totalPages={totalPages}

--- a/packages/frontend/src/components/category-pill-nav.tsx
+++ b/packages/frontend/src/components/category-pill-nav.tsx
@@ -22,7 +22,7 @@ export function CategoryPillNav({ items }: CategoryPillNavProps) {
           key={`category-pill-${item.path}-${index}`}
           href={item.path}
           className={cn(
-            'inline-flex shrink-0 items-center rounded-[30px] px-3 py-1 prose-p1-bold transition-colors duration-120',
+            'inline-flex shrink-0 items-center rounded-[30px] px-3 py-1 prose-p1-bold transition-all duration-300 hover:bg-neutral-300 hover:text-neutral-900',
             item.active ? 'bg-red-400 text-neutral-white' : 'text-neutral-900'
           )}
         >

--- a/packages/frontend/src/components/category-pill-nav.tsx
+++ b/packages/frontend/src/components/category-pill-nav.tsx
@@ -11,7 +11,7 @@ type CategoryPillNavProps = {
   items: CategoryPillNavItem[]
 }
 
-export function CategoryPillNav({ items }: CategoryPillNavProps) {
+function CategoryPillNav({ items }: CategoryPillNavProps) {
   return (
     <nav
       className="flex w-full flex-row flex-wrap items-center gap-4"

--- a/packages/frontend/src/components/common-collection/index.tsx
+++ b/packages/frontend/src/components/common-collection/index.tsx
@@ -70,11 +70,11 @@ function CommonCollection(props: CommonCollectionProps) {
   const { hero, morePostsMode, posts, subcategoryNav } = props
   return (
     <div className="w-screen bg-neutral-100 pb-14 tablet:pb-16 desktop:pb-24 hd:pb-30">
-      <div className="mx-auto flex w-full flex-col items-center justify-center px-6 tablet:px-8 desktop:px-12 hd:max-w-300 hd:px-0">
+      <div className="mx-auto flex w-full flex-col items-center justify-center px-6 tablet:px-8 desktop:max-w-300 desktop:px-12 hd:px-0">
         {hero.type === 'illustrated' && (
           <CommonCollectionHeroShell className="flex flex-col items-center justify-center tablet:flex-row tablet:justify-between hd:px-14">
             <div className="relative z-2 mt-6 flex items-center gap-4 self-start tablet:mt-16 desktop:mt-20 desktop:gap-5 hd:mt-24">
-              <div className="h-10 w-1 rounded-[8px] bg-red-400 desktop:h-12 desktop:w-3" />
+              <div className="h-10 w-2 rounded-[8px] bg-red-400 desktop:h-12 desktop:w-3" />
               <h1 className="prose-h1-small font-swei! text-neutral-900 desktop:prose-h1-large">
                 {hero.title}
               </h1>
@@ -103,17 +103,15 @@ function CommonCollection(props: CommonCollectionProps) {
         )}
 
         {subcategoryNav != null && (
-          <div className="mb-14 w-full px-6 tablet:px-8 desktop:px-12 hd:max-w-300 hd:px-0">
+          <div className="mb-14 w-full">
             <div className="hd:px-14">{subcategoryNav}</div>
           </div>
         )}
 
-        <div className="px-6 tablet:px-8 desktop:px-12 hd:max-w-300 hd:px-0">
-          <div className="grid w-full grid-cols-1 gap-y-6 tablet:grid-cols-2 tablet:gap-x-6 tablet:gap-y-8 desktop:grid-cols-3 desktop:gap-x-8 desktop:gap-y-10 hd:gap-y-14 hd:px-14">
-            {posts.map((post) => (
-              <CommonCollectionPostCard key={post.url} post={post} />
-            ))}
-          </div>
+        <div className="grid w-full grid-cols-1 gap-y-6 tablet:grid-cols-2 tablet:gap-x-6 tablet:gap-y-8 desktop:grid-cols-3 desktop:gap-x-8 desktop:gap-y-10 hd:gap-y-14 hd:px-14">
+          {posts.map((post) => (
+            <CommonCollectionPostCard key={post.url} post={post} />
+          ))}
         </div>
 
         {morePostsMode === 'pagination' && props.totalPages > 0 && (

--- a/packages/frontend/src/components/common-collection/post-card.tsx
+++ b/packages/frontend/src/components/common-collection/post-card.tsx
@@ -14,7 +14,7 @@ function CommonCollectionPostCard({ post }: CommonCollectionPostCardProps) {
   return (
     <div
       className={
-        'min-h-30 w-[calc(100vw-96px)] flex-shrink-0 snap-start tablet:min-h-auto tablet:w-auto'
+        'min-h-30 w-[calc(100vw-48px)] flex-shrink-0 snap-start tablet:min-h-auto tablet:w-auto'
       }
     >
       <Link href={post.url} className="group relative flex h-full flex-col">

--- a/packages/frontend/src/modules/author/collection/index.tsx
+++ b/packages/frontend/src/modules/author/collection/index.tsx
@@ -48,7 +48,7 @@ export default function AuthorCollectionModule({
                     {author.email != null && author.email !== '' && (
                       <a
                         href={`mailto:${author.email}`}
-                        className="prose-p2 text-blue-400 underline decoration-neutral-400 underline-offset-2 desktop:prose-p1"
+                        className="prose-p2 text-blue-400 underline decoration-neutral-400 decoration-1 underline-offset-3 transition-all duration-300 hover:decoration-blue-400 desktop:prose-p1"
                       >
                         {author.email}
                       </a>

--- a/packages/frontend/src/modules/category-collection/index.tsx
+++ b/packages/frontend/src/modules/category-collection/index.tsx
@@ -42,7 +42,6 @@ function CategoryCollectionModule({
   const illustrations = CATEGORY_COLLECTION_ILLUSTRATIONS[categorySlug]
   const showSubcategoryNav =
     categorySlug !== 'classroom' && navigationItems.length > 0
-
   return (
     <main>
       {showIntro && (

--- a/packages/frontend/src/modules/tag/collection/index.tsx
+++ b/packages/frontend/src/modules/tag/collection/index.tsx
@@ -23,7 +23,7 @@ export default function TagCollectionModule({
           type: 'customized',
           content: (
             <div className="flex h-[260px] w-full items-start justify-center desktop:h-[320px] hd:mb-10">
-              <h1 className="mt-24 px-6 text-center prose-h1-small font-swei! text-neutral-900 desktop:prose-h1-large">
+              <h1 className="mt-20 px-6 text-center prose-h1-small font-swei! text-neutral-900 desktop:prose-h1-large">
                 {`#${tagName}`}
               </h1>
             </div>

--- a/packages/frontend/src/modules/topic/all/index.tsx
+++ b/packages/frontend/src/modules/topic/all/index.tsx
@@ -51,10 +51,10 @@ function TopicAllModule({
         </div>
       </div>
       <div className="w-screen bg-neutral-100 pb-14 tablet:pb-16 desktop:pb-24 hd:pb-30">
-        <div className="mx-auto flex w-full flex-col items-center justify-center px-6 tablet:px-8 desktop:px-12 hd:max-w-300 hd:px-0">
+        <div className="mx-auto flex w-full flex-col items-center justify-center px-6 tablet:px-8 desktop:max-w-300 desktop:px-12 hd:px-0">
           <div className="relative mb-5 flex w-full flex-col items-center justify-center tablet:flex-row tablet:justify-between hd:mb-10 hd:px-14">
             <div className="relative z-2 mt-6 flex items-center gap-4 self-start tablet:mt-16 desktop:mt-20 desktop:gap-5 hd:mt-24">
-              <div className="h-10 w-1 rounded-[8px] bg-red-400 desktop:h-12 desktop:w-3" />
+              <div className="h-10 w-2 rounded-[8px] bg-red-400 desktop:h-12 desktop:w-3" />
               <h1 className="prose-h1-small font-swei! text-neutral-900 desktop:prose-h1-large">
                 專題
               </h1>


### PR DESCRIPTION
## Summary

Polish collection-page UI/layout and fix category intro visibility so it only shows on the first page.

## Changes

- Show category intro only when currentPage === 1
- Improve CategoryPillNav hover/transition styling
- Refine CommonCollection container/grid spacing and hero accent bar width
- Adjust post-card mobile width calculation for better alignment
- Tweak author email underline styling and hover affordance
- Align tag hero title spacing
- Match TopicAll module layout to updated collection patterns

## Additional Notes


## Screenshot(s)


## Reference(s)
https://www.notion.so/defect-11-3408dbdca932805b91c0dc2082e07adc?source=copy_link
