### PR TITLE
fix(frontend): refine tag and search page layout

### DIFF
--- a/packages/frontend/src/modules/search/index.tsx
+++ b/packages/frontend/src/modules/search/index.tsx
@@ -24,7 +24,7 @@ function SearchModule({
   emptyState?: ReactNode
 }) {
   return (
-    <main className="relative mx-auto flex w-full max-w-300 flex-col items-center px-6 pt-8 pb-14 tablet:px-8 tablet:pt-12 tablet:pb-16 desktop:px-12 desktop:pt-16 desktop:pb-24 hd:pt-20 hd:pb-30">
+    <main className="relative mx-auto flex w-full max-w-[950px] flex-col items-center px-6 pt-8 pb-14 tablet:px-8 tablet:pt-12 tablet:pb-16 desktop:px-12 desktop:pt-16 desktop:pb-24 hd:pt-20 hd:pb-30">
       <div className="flex w-full flex-col items-center">
         <SearchHero />
         <SearchInput value={query} />
@@ -50,7 +50,7 @@ function SearchModule({
         <div className="w-full">{emptyState}</div>
       )}
 
-      <div className="absolute right-0 bottom-0 left-0">
+      <div className="absolute right-0 bottom-0 left-1/2 w-screen -translate-x-1/2">
         <Divider />
       </div>
     </main>

--- a/packages/frontend/src/modules/tag/collection/index.tsx
+++ b/packages/frontend/src/modules/tag/collection/index.tsx
@@ -22,8 +22,8 @@ export default function TagCollectionModule({
         hero={{
           type: 'customized',
           content: (
-            <div className="flex h-[260px] w-full items-start justify-center desktop:h-[320px] hd:mb-10">
-              <h1 className="mt-20 px-6 text-center prose-h1-small font-swei! text-neutral-900 desktop:mt-24 desktop:prose-h1-large">
+            <div className="flex h-[200px] w-full items-start justify-center tablet:h-[260px] desktop:h-[320px] hd:mb-10">
+              <h1 className="mt-12 px-6 text-center prose-h1-small font-swei! text-neutral-900 tablet:mt-20 desktop:mt-24 desktop:prose-h1-large">
                 {`#${tagName}`}
               </h1>
             </div>


### PR DESCRIPTION
## Summary

Refines UI layout on Tag Collection and Search pages to improve spacing and responsiveness.

## Changes

- Adjust Tag Collection hero height and headline top margin across breakpoints
- Update SearchModule max width and make the bottom divider span full viewport width

## Additional Notes

- Commits were created with \`--no-verify\` (per terminal history)

## Screenshot(s)

## Reference(s)

- [Notion Page Collection](https://www.notion.so/twreporter/2f68dbdca93280199267f4c3a641803a?source=copy_link)
- [Notion Page Search](https://www.notion.so/twreporter/2f78dbdca93280f5aa58d61b94268343?source=copy_link)