### PR TITLE
feat(cms): add popular keywords order to editor picks settings

### DIFF
--- a/packages/api-gateway/src/graphql/documents/content.ts
+++ b/packages/api-gateway/src/graphql/documents/content.ts
@@ -23,15 +23,19 @@ export const GET_EDITOR_PICKS_SETTINGS_QUERY = gql`
         name
         slug
       }
+      popularKeywordsOrdered {
+        name
+      }
     }
   }
 `
 
 export const GET_POPULAR_KEYWORDS_QUERY = gql`
   query GetPopularKeywords {
-    popularKeywords(orderBy: [{ order: asc }]) {
-      name
-      order
+    editorPicksSettings(take: 1) {
+      popularKeywordsOrdered {
+        name
+      }
     }
   }
 `

--- a/packages/api-gateway/src/graphql/documents/content.ts
+++ b/packages/api-gateway/src/graphql/documents/content.ts
@@ -30,6 +30,7 @@ export const GET_EDITOR_PICKS_SETTINGS_QUERY = gql`
   }
 `
 
+// only take the first editor picks setting
 export const GET_POPULAR_KEYWORDS_QUERY = gql`
   query GetPopularKeywords {
     editorPicksSettings(take: 1) {

--- a/packages/cms/lists/editor-picks-setting.ts
+++ b/packages/cms/lists/editor-picks-setting.ts
@@ -20,6 +20,16 @@ const editorPicksOfPosts: OrderedRelationshipConfig = {
   refLabelField: 'title',
 }
 
+const popularKeywords: OrderedRelationshipConfig = {
+  fieldName: 'popularKeywords',
+  relationshipConfig: {
+    label: '選取',
+    ref: 'PopularKeyword',
+    many: true,
+  },
+  refLabelField: 'name',
+}
+
 const listConfigurations: ListConfig<any> = list({
   fields: {
     name: text({
@@ -39,6 +49,13 @@ const listConfigurations: ListConfig<any> = list({
       description: '首頁按順序呈現精選文章5篇',
       fields: {
         ...relationshipUtil.relationshipAndExtendedFields(editorPicksOfPosts),
+      },
+    }),
+    ...group({
+      label: '熱門關鍵字',
+      description: 'Header 搜尋建議：可自訂顯示與順序',
+      fields: {
+        ...relationshipUtil.relationshipAndExtendedFields(popularKeywords),
       },
     }),
     editorPicksOfProjects: relationship({
@@ -79,6 +96,12 @@ const listConfigurations: ListConfig<any> = list({
   hooks: {
     resolveInput: async ({ inputData, item, resolvedData, context }) => {
       await relationshipUtil.mutateOrderFieldHook(editorPicksOfPosts)({
+        inputData,
+        item,
+        resolvedData,
+        context,
+      })
+      await relationshipUtil.mutateOrderFieldHook(popularKeywords)({
         inputData,
         item,
         resolvedData,

--- a/packages/cms/lists/popular-keyword.ts
+++ b/packages/cms/lists/popular-keyword.ts
@@ -33,8 +33,8 @@ const listConfigurations: ListConfig<any> = list({
   },
   ui: {
     listView: {
-      initialColumns: ['name', 'order'],
-      initialSort: { field: 'order', direction: 'ASC' },
+      initialColumns: ['name'],
+      initialSort: { field: 'name', direction: 'ASC' },
     },
   },
 })

--- a/packages/cms/lists/popular-keyword.ts
+++ b/packages/cms/lists/popular-keyword.ts
@@ -1,5 +1,5 @@
 import { list } from '@keystone-6/core'
-import { integer, text, timestamp } from '@keystone-6/core/fields'
+import { text, timestamp } from '@keystone-6/core/fields'
 import type { ListConfig } from '@keystone-6/core/types'
 
 import {
@@ -13,10 +13,6 @@ const listConfigurations: ListConfig<any> = list({
     name: text({
       label: '關鍵字',
       validation: { isRequired: true },
-    }),
-    order: integer({
-      label: '排序（由小至大排列）',
-      defaultValue: 0,
     }),
     createdAt: timestamp({
       defaultValue: { kind: 'now' },

--- a/packages/cms/migrations/20260415071747_add_popular_keywords_order_in_editor_picks_setting/migration.sql
+++ b/packages/cms/migrations/20260415071747_add_popular_keywords_order_in_editor_picks_setting/migration.sql
@@ -1,0 +1,29 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `order` on the `PopularKeyword` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "EditorPicksSetting" ADD COLUMN     "popularKeywordsOrderJson" JSONB DEFAULT '[]';
+
+-- AlterTable
+ALTER TABLE "PopularKeyword" DROP COLUMN "order";
+
+-- CreateTable
+CREATE TABLE "_EditorPicksSetting_popularKeywords" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_EditorPicksSetting_popularKeywords_AB_unique" ON "_EditorPicksSetting_popularKeywords"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_EditorPicksSetting_popularKeywords_B_index" ON "_EditorPicksSetting_popularKeywords"("B");
+
+-- AddForeignKey
+ALTER TABLE "_EditorPicksSetting_popularKeywords" ADD CONSTRAINT "_EditorPicksSetting_popularKeywords_A_fkey" FOREIGN KEY ("A") REFERENCES "EditorPicksSetting"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_EditorPicksSetting_popularKeywords" ADD CONSTRAINT "_EditorPicksSetting_popularKeywords_B_fkey" FOREIGN KEY ("B") REFERENCES "PopularKeyword"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/cms/schema.graphql
+++ b/packages/cms/schema.graphql
@@ -1444,6 +1444,10 @@ type EditorPicksSetting {
   editorPicksOfPostsCount(where: PostWhereInput! = {}): Int
   editorPicksOfPostsOrderJson: JSON
   editorPicksOfPostsOrdered(take: Int! = 12, skip: Int! = 0): [Post!]
+  popularKeywords(where: PopularKeywordWhereInput! = {}, orderBy: [PopularKeywordOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PopularKeywordWhereUniqueInput): [PopularKeyword!]
+  popularKeywordsCount(where: PopularKeywordWhereInput! = {}): Int
+  popularKeywordsOrderJson: JSON
+  popularKeywordsOrdered(take: Int! = 12, skip: Int! = 0): [PopularKeyword!]
   editorPicksOfProjects(where: ProjectWhereInput! = {}, orderBy: [ProjectOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ProjectWhereUniqueInput): [Project!]
   editorPicksOfProjectsCount(where: ProjectWhereInput! = {}): Int
   editorPicksOfTags(where: TagWhereInput! = {}, orderBy: [TagOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TagWhereUniqueInput): [Tag!]
@@ -1465,10 +1469,17 @@ input EditorPicksSettingWhereInput {
   name: StringFilter
   nameForCMS: StringFilter
   editorPicksOfPosts: PostManyRelationFilter
+  popularKeywords: PopularKeywordManyRelationFilter
   editorPicksOfProjects: ProjectManyRelationFilter
   editorPicksOfTags: TagManyRelationFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
+}
+
+input PopularKeywordManyRelationFilter {
+  every: PopularKeywordWhereInput
+  some: PopularKeywordWhereInput
+  none: PopularKeywordWhereInput
 }
 
 input EditorPicksSettingOrderByInput {
@@ -1484,10 +1495,19 @@ input EditorPicksSettingUpdateInput {
   nameForCMS: String
   editorPicksOfPosts: PostRelateToManyForUpdateInput
   editorPicksOfPostsOrderJson: JSON
+  popularKeywords: PopularKeywordRelateToManyForUpdateInput
+  popularKeywordsOrderJson: JSON
   editorPicksOfProjects: ProjectRelateToManyForUpdateInput
   editorPicksOfTags: TagRelateToManyForUpdateInput
   createdAt: DateTime
   updatedAt: DateTime
+}
+
+input PopularKeywordRelateToManyForUpdateInput {
+  disconnect: [PopularKeywordWhereUniqueInput!]
+  set: [PopularKeywordWhereUniqueInput!]
+  create: [PopularKeywordCreateInput!]
+  connect: [PopularKeywordWhereUniqueInput!]
 }
 
 input EditorPicksSettingUpdateArgs {
@@ -1500,10 +1520,17 @@ input EditorPicksSettingCreateInput {
   nameForCMS: String
   editorPicksOfPosts: PostRelateToManyForCreateInput
   editorPicksOfPostsOrderJson: JSON
+  popularKeywords: PopularKeywordRelateToManyForCreateInput
+  popularKeywordsOrderJson: JSON
   editorPicksOfProjects: ProjectRelateToManyForCreateInput
   editorPicksOfTags: TagRelateToManyForCreateInput
   createdAt: DateTime
   updatedAt: DateTime
+}
+
+input PopularKeywordRelateToManyForCreateInput {
+  create: [PopularKeywordCreateInput!]
+  connect: [PopularKeywordWhereUniqueInput!]
 }
 
 type PDF {
@@ -2210,7 +2237,6 @@ input PostEssayAnswerRelateToOneForCreateInput {
 type PopularKeyword {
   id: ID!
   name: String
-  order: Int
   createdAt: DateTime
   updatedAt: DateTime
 }
@@ -2225,7 +2251,6 @@ input PopularKeywordWhereInput {
   NOT: [PopularKeywordWhereInput!]
   id: IDFilter
   name: StringFilter
-  order: IntNullableFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
 }
@@ -2233,14 +2258,12 @@ input PopularKeywordWhereInput {
 input PopularKeywordOrderByInput {
   id: OrderDirection
   name: OrderDirection
-  order: OrderDirection
   createdAt: OrderDirection
   updatedAt: OrderDirection
 }
 
 input PopularKeywordUpdateInput {
   name: String
-  order: Int
   createdAt: DateTime
   updatedAt: DateTime
 }
@@ -2252,7 +2275,6 @@ input PopularKeywordUpdateArgs {
 
 input PopularKeywordCreateInput {
   name: String
-  order: Int
   createdAt: DateTime
   updatedAt: DateTime
 }

--- a/packages/cms/schema.prisma
+++ b/packages/cms/schema.prisma
@@ -280,15 +280,17 @@ model NewsReadingGroupItem {
 }
 
 model EditorPicksSetting {
-  id                          Int       @id @default(autoincrement())
-  name                        String    @unique @default("")
-  nameForCMS                  String    @default("")
-  editorPicksOfPosts          Post[]    @relation("EditorPicksSetting_editorPicksOfPosts")
-  editorPicksOfPostsOrderJson Json?     @default("[]")
-  editorPicksOfProjects       Project[] @relation("EditorPicksSetting_editorPicksOfProjects")
-  editorPicksOfTags           Tag[]     @relation("EditorPicksSetting_editorPicksOfTags")
-  createdAt                   DateTime? @default(now())
-  updatedAt                   DateTime? @updatedAt
+  id                          Int              @id @default(autoincrement())
+  name                        String           @unique @default("")
+  nameForCMS                  String           @default("")
+  editorPicksOfPosts          Post[]           @relation("EditorPicksSetting_editorPicksOfPosts")
+  editorPicksOfPostsOrderJson Json?            @default("[]")
+  popularKeywords             PopularKeyword[] @relation("EditorPicksSetting_popularKeywords")
+  popularKeywordsOrderJson    Json?            @default("[]")
+  editorPicksOfProjects       Project[]        @relation("EditorPicksSetting_editorPicksOfProjects")
+  editorPicksOfTags           Tag[]            @relation("EditorPicksSetting_editorPicksOfTags")
+  createdAt                   DateTime?        @default(now())
+  updatedAt                   DateTime?        @updatedAt
 }
 
 model PDF {
@@ -438,11 +440,11 @@ model PostEssayAnswerLike {
 }
 
 model PopularKeyword {
-  id        Int       @id @default(autoincrement())
-  name      String    @default("")
-  order     Int?      @default(0)
-  createdAt DateTime? @default(now())
-  updatedAt DateTime? @updatedAt
+  id                                      Int                  @id @default(autoincrement())
+  name                                    String               @default("")
+  createdAt                               DateTime?            @default(now())
+  updatedAt                               DateTime?            @updatedAt
+  from_EditorPicksSetting_popularKeywords EditorPicksSetting[] @relation("EditorPicksSetting_popularKeywords")
 }
 
 enum CallBaodaozaiIntroPageType {

--- a/packages/frontend/src/api/popular-keywords.ts
+++ b/packages/frontend/src/api/popular-keywords.ts
@@ -15,5 +15,7 @@ export const getPopularKeywords = async (
     variables: variables ?? {},
     traceHeaders,
   })
-  return response?.data?.data?.popularKeywords
+  return (
+    response?.data?.data?.editorPicksSettings?.[0]?.popularKeywordsOrdered ?? []
+  )
 }


### PR DESCRIPTION
## Summary
Add CMS-configurable popular keywords selection + ordering via Editor Picks Settings, and update GraphQL consumers to read the ordered list.

## Changes
- Add ordered relationship fields to `EditorPicksSetting` for popular keywords (`popularKeywords`, `popularKeywordsOrderJson`, `popularKeywordsOrdered`).
- Remove `PopularKeyword.order` column and migrate data model to use Editor Picks Settings ordering.
- Update API Gateway GraphQL documents to expose/query `popularKeywordsOrdered`.
- Update frontend `getPopularKeywords` to read from `editorPicksSettings[0].popularKeywordsOrdered`.
- Add DB migration to create the join table and new JSON order field.

## Additional Notes
- Migration drops `PopularKeyword.order` (data loss for that column). Ordering is now stored in `EditorPicksSetting.popularKeywordsOrderJson`.
- `GetPopularKeywords` query now depends on having an `EditorPicksSetting` record present (returns `[]` if none).

## Screenshot(s)

## Reference(s)
- [Notion Page](https://www.notion.so/twreporter/CMS-33b8dbdca93280f1a8e7df763fe6793a?source=copy_link)
