### PR TITLE
feat(frontend): revamp idea hub latest answers section

### DIFF
--- a/packages/api-gateway/src/graphql/documents/answers.ts
+++ b/packages/api-gateway/src/graphql/documents/answers.ts
@@ -63,11 +63,13 @@ export const GET_ALL_POST_ESSAY_ANSWERS_QUERY = gql`
   ) {
     postEssayAnswers(orderBy: $orderBy, take: $take) {
       id
+      createdAt
       question {
         id
         post {
           slug
         }
+        title
       }
       member {
         id

--- a/packages/frontend/src/modules/idea-hub/latest-answers/answer-card-skeleton.tsx
+++ b/packages/frontend/src/modules/idea-hub/latest-answers/answer-card-skeleton.tsx
@@ -1,20 +1,23 @@
 function AnswerCardSkeleton() {
   return (
-    <div className="flex min-h-[182px] w-75 flex-col justify-between rounded-2xl border-2 border-neutral-200 bg-neutral-100 p-5 shadow-[0px_0px_3px_0px_rgba(0,0,0,0.12)] tablet:w-full">
-      <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-3 p-5">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="size-[52px] shrink-0 animate-pulse rounded-full bg-neutral-200" />
+          <div className="flex flex-col gap-1">
+            <div className="h-5 w-20 animate-pulse rounded bg-neutral-200" />
+            <div className="h-4 w-14 animate-pulse rounded bg-neutral-200" />
+          </div>
+        </div>
+        <div className="flex w-14 items-center gap-1">
+          <div className="size-6 animate-pulse rounded bg-neutral-200" />
+          <div className="h-5 w-7 animate-pulse rounded bg-neutral-200" />
+        </div>
+      </div>
+      <div className="flex flex-col gap-1">
         <div className="h-6 w-full animate-pulse rounded bg-neutral-200" />
         <div className="h-6 w-4/5 animate-pulse rounded bg-neutral-200" />
         <div className="h-6 w-3/5 animate-pulse rounded bg-neutral-200" />
-      </div>
-      <div className="flex items-center justify-between">
-        <div className="flex flex-1 items-center gap-2 truncate">
-          <div className="size-10 flex-shrink-0 animate-pulse rounded-full bg-neutral-200" />
-          <div className="h-5 w-24 animate-pulse rounded bg-neutral-200" />
-        </div>
-        <div className="flex w-14 items-center gap-1">
-          <div className="size-5 animate-pulse rounded bg-neutral-200" />
-          <div className="h-5 w-8 animate-pulse rounded bg-neutral-200" />
-        </div>
       </div>
     </div>
   )

--- a/packages/frontend/src/modules/idea-hub/latest-answers/answer-card.tsx
+++ b/packages/frontend/src/modules/idea-hub/latest-answers/answer-card.tsx
@@ -5,13 +5,15 @@ import Image from 'next/image'
 import { DEFAULT_AVATAR } from '@/constants'
 import { StarIcon } from '@/icons/miscellaneous'
 
-import { getDisplayLikesCount } from '../utils'
+import { formatChineseDate, getDisplayLikesCount } from '../utils'
 
 type AnswerCardProps = {
   content: string
   memberName: string
   memberAvatar?: string
   likesCount: number
+  createdAt: string
+  questionTitle: string
   onClick?: () => void
 }
 
@@ -20,30 +22,36 @@ function AnswerCard({
   memberName,
   memberAvatar,
   likesCount,
+  createdAt,
+  questionTitle,
   onClick,
 }: AnswerCardProps) {
   return (
     <div
-      className="flex min-h-[182px] w-75 cursor-pointer flex-col justify-between rounded-2xl border-2 border-neutral-200 bg-white p-5 transition-colors hover:border-neutral-300 tablet:w-full"
+      className="flex cursor-pointer flex-col gap-3 p-5"
       onClick={onClick}
       role="button"
       aria-label={`View answer: ${content}`}
     >
-      <p className="line-clamp-3 prose-p1-bold text-neutral-900">{content}</p>
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex flex-1 items-center gap-2 truncate">
-          <div className="relative size-10 flex-shrink-0 overflow-hidden rounded-full border-2 border-neutral-200">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="relative size-[52px] shrink-0 overflow-hidden rounded-full border-2 border-neutral-200">
             <Image
               src={memberAvatar || DEFAULT_AVATAR}
               alt={memberName}
               className="size-full bg-white object-cover"
               fill
-              sizes="40px"
+              sizes="52px"
             />
           </div>
-          <span className="truncate prose-p2-bold text-neutral-900">
-            {memberName}
-          </span>
+          <div className="flex flex-col">
+            <span className="prose-p1-bold text-neutral-900 desktop:prose-h6-small desktop:font-swei!">
+              {memberName}
+            </span>
+            <span className="prose-p2 text-neutral-600">
+              {formatChineseDate(createdAt)}
+            </span>
+          </div>
         </div>
         <div className="flex w-14 items-center gap-1 text-neutral-600">
           <StarIcon />
@@ -51,6 +59,12 @@ function AnswerCard({
             {getDisplayLikesCount(likesCount)}
           </span>
         </div>
+      </div>
+      <div className="flex flex-col gap-1">
+        <p className="prose-p1-bold text-neutral-900">{content}</p>
+        <p className="truncate prose-p1 text-neutral-800">
+          回應問題：{questionTitle}
+        </p>
       </div>
     </div>
   )

--- a/packages/frontend/src/modules/idea-hub/latest-answers/answer-card.tsx
+++ b/packages/frontend/src/modules/idea-hub/latest-answers/answer-card.tsx
@@ -61,7 +61,7 @@ function AnswerCard({
         </div>
       </div>
       <div className="flex flex-col gap-1">
-        <p className="prose-p1-bold text-neutral-900">{content}</p>
+        <p className="line-clamp-3 prose-p1-bold text-neutral-900">{content}</p>
         <p className="truncate prose-p1 text-neutral-800">
           回應問題：{questionTitle}
         </p>

--- a/packages/frontend/src/modules/idea-hub/latest-answers/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/latest-answers/index.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { cn } from '@kids-reporter/routing-ui'
-import { memo } from 'react'
+import { Fragment, memo } from 'react'
 
 import { useAllPostEssayAnswersQuery } from '@/api-utils/react-query/hooks/post-essay-answer'
 
@@ -29,6 +28,8 @@ function LatestAnswers({ onOpenModal }: LatestAnswersProps) {
       memberAvatar: answer.member?.avatar?.fileUrl ?? '',
       likesCount: answer.likesCount ?? 0,
       postSlug: question?.post?.slug ?? '',
+      createdAt: answer.createdAt ?? '',
+      questionTitle: question?.title ?? '',
     }
   })
 
@@ -40,35 +41,38 @@ function LatestAnswers({ onOpenModal }: LatestAnswersProps) {
     <div className="mt-10 mb-14 flex w-[calc(100%+48px)] flex-col gap-6 tablet:mt-12 tablet:mb-16 tablet:w-full tablet:gap-8 desktop:mt-18 desktop:mb-24 desktop:w-screen desktop:max-w-300 desktop:gap-10 desktop:px-14 hd:mt-24 hd:mb-30 hd:max-w-none hd:px-[calc(50vw-600px+56px)]">
       <div className="flex items-center gap-3 pl-6 tablet:pl-0">
         <div className="h-8 w-1.5 rounded-md bg-yellow-400" />
-        <h3 className="prose-h3-small font-swei text-neutral-900 desktop:prose-h3-large">
+        <h3 className="prose-h3-small font-swei! text-neutral-900 desktop:prose-h3-large">
           最新回答
         </h3>
       </div>
-      <div
-        className={cn(
-          'flex snap-x snap-mandatory scroll-px-6 gap-6 overflow-x-auto px-6 scrollbar-none tablet:grid tablet:snap-none tablet:grid-cols-3 tablet:overflow-x-hidden tablet:px-0 desktop:gap-8',
-          !isLoading && answers.length === 0 && 'tablet:grid-cols-1'
-        )}
-      >
+      <div className="mx-6 rounded-[20px] border-2 border-neutral-200 bg-white tablet:mx-0 desktop:rounded-[30px]">
         {isLoading && (
-          <>
+          <div className="flex flex-col">
             {[1, 2, 3].map((index) => (
-              <div key={index} className="flex-1 snap-start">
+              <Fragment key={index}>
+                {index > 1 && (
+                  <hr className="mx-5 border-t border-neutral-200" />
+                )}
                 <AnswerCardSkeleton />
-              </div>
+              </Fragment>
             ))}
-          </>
+          </div>
         )}
-        {!isLoading &&
-          answers.length > 0 &&
-          answers.map((answer) => (
-            <div key={answer.id} className="flex-1 snap-start">
-              <AnswerCard
-                {...answer}
-                onClick={() => handleAnswerCardClick(answer.postSlug)}
-              />
-            </div>
-          ))}
+        {!isLoading && answers.length > 0 && (
+          <div className="flex flex-col">
+            {answers.map((answer, index) => (
+              <Fragment key={answer.id}>
+                {index > 0 && (
+                  <hr className="mx-5 border-t border-neutral-200" />
+                )}
+                <AnswerCard
+                  {...answer}
+                  onClick={() => handleAnswerCardClick(answer.postSlug)}
+                />
+              </Fragment>
+            ))}
+          </div>
+        )}
         {!isLoading && answers.length === 0 && (
           <div className="flex w-full items-center justify-center py-12 text-center">
             <p className="prose-p1 text-neutral-500">尚無回答</p>

--- a/packages/frontend/src/modules/idea-hub/utils.ts
+++ b/packages/frontend/src/modules/idea-hub/utils.ts
@@ -11,7 +11,8 @@ export const getMemberDisplayName = (member: MemberDisplay | undefined) => {
 
 export const formatChineseDate = (dateStr: string) => {
   const date = new Date(dateStr)
-  return `${date.getMonth() + 1}月${date.getDate()}日`
+  if (isNaN(date.getTime())) return ''
+  return date.getMonth() + 1 + '月' + date.getDate() + '日'
 }
 
 export const getDisplayLikesCount = (likesCount: number | null | undefined) => {

--- a/packages/frontend/src/modules/idea-hub/utils.ts
+++ b/packages/frontend/src/modules/idea-hub/utils.ts
@@ -9,6 +9,11 @@ export const getMemberDisplayName = (member: MemberDisplay | undefined) => {
   return member.nickname || member.name || member.email || DEFAULT_TEXT_HOLDER
 }
 
+export const formatChineseDate = (dateStr: string) => {
+  const date = new Date(dateStr)
+  return `${date.getMonth() + 1}月${date.getDate()}日`
+}
+
 export const getDisplayLikesCount = (likesCount: number | null | undefined) => {
   if (!likesCount) return '0'
   if (likesCount > 99) return '99+'


### PR DESCRIPTION
## Summary

Revamp the "最新回答" (Latest Answers) section in the Idea Hub module with an updated card layout, new data fields, and a list-style container design.

## Changes

- **api-gateway**: Added `title` and `createdAt` fields to `GET_ALL_POST_ESSAY_ANSWERS_QUERY` GraphQL query
- **frontend (answer-card)**: Redesigned card layout — avatar and member name are now at the top with a Chinese-formatted date, answer content and question title are below
- **frontend (answer-card-skeleton)**: Updated skeleton to match the new card layout structure
- **frontend (latest-answers/index)**: Replaced horizontal scrollable card grid with a vertical list inside a rounded bordered container, separated by dividers
- **frontend (utils)**: Added `formatChineseDate` utility for displaying dates in `X月X# Additional Notes

- The card no longer has its own border/shadow styling; cards are now wrapped in a shared container with `hr` dividers between them
- Avatar size increased from 40px to 52px
- Typography classes updated for responsive design (e.g., `desktop:prose-h6-small`)

## Screenshot(s)
<img width="1232" height="743" alt="image" src="https://github.com/user-attachments/assets/844f0867-e970-4582-9ab1-ef120754e908" />

## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/2f78dbdca932801f8f9ae300d741e7bc?source=copy_link)