### PR TITLE
fix(frontend): update text and improve styling in Idea Hub components

### DIFF
--- a/packages/frontend/src/modules/idea-hub/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/index.tsx
@@ -32,7 +32,7 @@ function IdeaHub() {
           </h2>
         </div>
         <span className="text-center prose-h6-small desktop:prose-h6-large">
-          看看大家的觀點，一起想，一起長大！
+          看看大家的對話，一起想，一起長大！
         </span>
         <LatestAnswers onOpenModal={handleOpenModal} />
         <AllAnswers onOpenModal={handleOpenModal} />

--- a/packages/frontend/src/modules/idea-hub/latest-answers/answer-card.tsx
+++ b/packages/frontend/src/modules/idea-hub/latest-answers/answer-card.tsx
@@ -27,13 +27,13 @@ function AnswerCard({
   onClick,
 }: AnswerCardProps) {
   return (
-    <div
-      className="cursor-pointer p-5 desktop:p-0 desktop:px-5 desktop:pt-5 desktop:last:pb-5"
-      onClick={onClick}
-      role="button"
-      aria-label={`View answer: ${content}`}
-    >
-      <div className="flex flex-col gap-3 transition-all duration-300 hover:bg-neutral-200 desktop:m-5">
+    <div className="p-5 desktop:p-0 desktop:px-5 desktop:first:pt-5 desktop:last:pb-5">
+      <div
+        className="flex cursor-pointer flex-col gap-3 transition-all duration-300 hover:bg-neutral-200 desktop:m-5"
+        onClick={onClick}
+        role="button"
+        aria-label={`View answer: ${content}`}
+      >
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <div className="relative size-[52px] shrink-0 overflow-hidden rounded-full border-2 border-neutral-200">

--- a/packages/frontend/src/modules/idea-hub/latest-answers/answer-card.tsx
+++ b/packages/frontend/src/modules/idea-hub/latest-answers/answer-card.tsx
@@ -28,43 +28,47 @@ function AnswerCard({
 }: AnswerCardProps) {
   return (
     <div
-      className="flex cursor-pointer flex-col gap-3 p-5"
+      className="cursor-pointer p-5 desktop:p-0 desktop:px-5 desktop:pt-5 desktop:last:pb-5"
       onClick={onClick}
       role="button"
       aria-label={`View answer: ${content}`}
     >
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div className="relative size-[52px] shrink-0 overflow-hidden rounded-full border-2 border-neutral-200">
-            <Image
-              src={memberAvatar || DEFAULT_AVATAR}
-              alt={memberName}
-              className="size-full bg-white object-cover"
-              fill
-              sizes="52px"
-            />
+      <div className="flex flex-col gap-3 transition-all duration-300 hover:bg-neutral-200 desktop:m-5">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="relative size-[52px] shrink-0 overflow-hidden rounded-full border-2 border-neutral-200">
+              <Image
+                src={memberAvatar || DEFAULT_AVATAR}
+                alt={memberName}
+                className="size-full bg-white object-cover"
+                fill
+                sizes="52px"
+              />
+            </div>
+            <div className="flex flex-col">
+              <span className="prose-p1-bold text-neutral-900 desktop:prose-h6-small desktop:font-swei!">
+                {memberName}
+              </span>
+              <span className="prose-p2 text-neutral-600">
+                {formatChineseDate(createdAt)}
+              </span>
+            </div>
           </div>
-          <div className="flex flex-col">
-            <span className="prose-p1-bold text-neutral-900 desktop:prose-h6-small desktop:font-swei!">
-              {memberName}
-            </span>
-            <span className="prose-p2 text-neutral-600">
-              {formatChineseDate(createdAt)}
+          <div className="flex w-14 items-center gap-1 text-neutral-600">
+            <StarIcon />
+            <span className="w-7 prose-p2">
+              {getDisplayLikesCount(likesCount)}
             </span>
           </div>
         </div>
-        <div className="flex w-14 items-center gap-1 text-neutral-600">
-          <StarIcon />
-          <span className="w-7 prose-p2">
-            {getDisplayLikesCount(likesCount)}
-          </span>
+        <div className="flex flex-col gap-1">
+          <p className="line-clamp-3 prose-p1-bold text-neutral-900">
+            {content}
+          </p>
+          <p className="truncate prose-p1 text-neutral-800">
+            回應問題：{questionTitle}
+          </p>
         </div>
-      </div>
-      <div className="flex flex-col gap-1">
-        <p className="line-clamp-3 prose-p1-bold text-neutral-900">{content}</p>
-        <p className="truncate prose-p1 text-neutral-800">
-          回應問題：{questionTitle}
-        </p>
       </div>
     </div>
   )

--- a/packages/frontend/src/modules/idea-hub/latest-answers/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/latest-answers/index.tsx
@@ -63,7 +63,7 @@ function LatestAnswers({ onOpenModal }: LatestAnswersProps) {
           <div className="flex flex-col">
             {answers.map((answer, index) => (
               <Fragment key={answer.id}>
-                {index > 0 && <Divider className="mx-5 w-auto" />}
+                {index > 0 && <Divider className="mx-5 w-auto desktop:mx-10" />}
                 <AnswerCard
                   {...answer}
                   onClick={() => handleAnswerCardClick(answer.postSlug)}

--- a/packages/frontend/src/modules/idea-hub/latest-answers/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/latest-answers/index.tsx
@@ -3,6 +3,7 @@
 import { Fragment, memo } from 'react'
 
 import { useAllPostEssayAnswersQuery } from '@/api-utils/react-query/hooks/post-essay-answer'
+import Divider from '@/components/divider'
 
 import { getMemberDisplayName } from '../utils'
 import AnswerCard from './answer-card'
@@ -38,7 +39,7 @@ function LatestAnswers({ onOpenModal }: LatestAnswersProps) {
   }
 
   return (
-    <div className="mt-10 mb-14 flex w-[calc(100%+48px)] flex-col gap-6 tablet:mt-12 tablet:mb-16 tablet:w-full tablet:gap-8 desktop:mt-18 desktop:mb-24 desktop:w-screen desktop:max-w-300 desktop:gap-10 desktop:px-14 hd:mt-24 hd:mb-30 hd:max-w-none hd:px-[calc(50vw-600px+56px)]">
+    <div className="mt-10 mb-14 flex w-[calc(100%+48px)] flex-col gap-6 tablet:mt-12 tablet:mb-16 tablet:w-full tablet:gap-8 desktop:mt-18 desktop:mb-24 desktop:w-200 desktop:max-w-300 desktop:gap-10 desktop:px-14 hd:mt-24 hd:mb-30 hd:w-220 hd:max-w-none">
       <div className="flex items-center gap-3 pl-6 tablet:pl-0">
         <div className="h-8 w-1.5 rounded-md bg-yellow-400" />
         <h3 className="prose-h3-small font-swei! text-neutral-900 desktop:prose-h3-large">
@@ -62,9 +63,7 @@ function LatestAnswers({ onOpenModal }: LatestAnswersProps) {
           <div className="flex flex-col">
             {answers.map((answer, index) => (
               <Fragment key={answer.id}>
-                {index > 0 && (
-                  <hr className="mx-5 border-t border-neutral-200" />
-                )}
+                {index > 0 && <Divider className="mx-5 w-auto" />}
                 <AnswerCard
                   {...answer}
                   onClick={() => handleAnswerCardClick(answer.postSlug)}


### PR DESCRIPTION
## Summary

Fix styling defects and update copy text in the Idea Hub's latest answers section, including hover effects, layout adjustments, and consistent divider usage.

## Changes

- Update subtitle text from「觀點」to「對話」in Idea Hub main page
- Add hover background effect (`hover:bg-neutral-200`) with transition on `AnswerCard`
- Adjust `AnswerCard` padding and spacing for desktop responsiveness (`desktop:last:pb-5`, `desktop:m-5`)
- Replace container `desktop:w-screen` with fixed widths (`desktop:w-200`, `hd:w-220`) and remove complex padding calc in `LatestAnswers`
- Replace raw `<hr>` element with reusable `<Divider>` component for consistent styling

## Additional Notes

## Screenshot(s)

## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/defect-4-35c1dab229d02e35?source=copy_link)