### PR TITLE
fix(frontend): update text and adjust styling in Idea Hub components

### DIFF
--- a/packages/frontend/src/modules/idea-hub/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/index.tsx
@@ -32,7 +32,7 @@ function IdeaHub() {
           </h2>
         </div>
         <span className="text-center prose-h6-small desktop:prose-h6-large">
-          看看大家的對話，一起想，一起長大！
+          看看大家的觀點，一起對話，一起長大！
         </span>
         <LatestAnswers onOpenModal={handleOpenModal} />
         <AllAnswers onOpenModal={handleOpenModal} />

--- a/packages/frontend/src/modules/idea-hub/latest-answers/answer-card.tsx
+++ b/packages/frontend/src/modules/idea-hub/latest-answers/answer-card.tsx
@@ -29,7 +29,7 @@ function AnswerCard({
   return (
     <div className="p-5 desktop:p-0 desktop:px-5 desktop:first:pt-5 desktop:last:pb-5">
       <div
-        className="flex cursor-pointer flex-col gap-3 transition-all duration-300 hover:bg-neutral-200 desktop:m-5"
+        className="flex cursor-pointer flex-col gap-3 transition-all duration-300 hover:bg-neutral-100 desktop:p-5"
         onClick={onClick}
         role="button"
         aria-label={`View answer: ${content}`}

--- a/packages/frontend/src/modules/idea-hub/latest-answers/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/latest-answers/index.tsx
@@ -39,7 +39,7 @@ function LatestAnswers({ onOpenModal }: LatestAnswersProps) {
   }
 
   return (
-    <div className="mt-10 mb-14 flex w-[calc(100%+48px)] flex-col gap-6 tablet:mt-12 tablet:mb-16 tablet:w-full tablet:gap-8 desktop:mt-18 desktop:mb-24 desktop:w-228 desktop:max-w-300 desktop:gap-10 desktop:px-14 hd:mt-24 hd:mb-30 hd:w-248 hd:max-w-none">
+    <div className="mt-10 mb-14 flex w-[calc(100%+48px)] flex-col gap-6 tablet:mt-12 tablet:mb-16 tablet:w-full tablet:gap-8 desktop:mt-18 desktop:mb-24 desktop:w-228 desktop:gap-10 desktop:px-14 hd:mt-24 hd:mb-30 hd:w-248 hd:max-w-none">
       <div className="flex items-center gap-3 pl-6 tablet:pl-0">
         <div className="h-8 w-1.5 rounded-md bg-yellow-400" />
         <h3 className="prose-h3-small font-swei! text-neutral-900 desktop:prose-h3-large">
@@ -63,7 +63,7 @@ function LatestAnswers({ onOpenModal }: LatestAnswersProps) {
           <div className="flex flex-col">
             {answers.map((answer, index) => (
               <Fragment key={answer.id}>
-                {index > 0 && <Divider className="mx-5 w-auto desktop:mx-5" />}
+                {index > 0 && <Divider className="mx-5 w-auto" />}
                 <AnswerCard
                   {...answer}
                   onClick={() => handleAnswerCardClick(answer.postSlug)}

--- a/packages/frontend/src/modules/idea-hub/latest-answers/index.tsx
+++ b/packages/frontend/src/modules/idea-hub/latest-answers/index.tsx
@@ -39,7 +39,7 @@ function LatestAnswers({ onOpenModal }: LatestAnswersProps) {
   }
 
   return (
-    <div className="mt-10 mb-14 flex w-[calc(100%+48px)] flex-col gap-6 tablet:mt-12 tablet:mb-16 tablet:w-full tablet:gap-8 desktop:mt-18 desktop:mb-24 desktop:w-200 desktop:max-w-300 desktop:gap-10 desktop:px-14 hd:mt-24 hd:mb-30 hd:w-220 hd:max-w-none">
+    <div className="mt-10 mb-14 flex w-[calc(100%+48px)] flex-col gap-6 tablet:mt-12 tablet:mb-16 tablet:w-full tablet:gap-8 desktop:mt-18 desktop:mb-24 desktop:w-228 desktop:max-w-300 desktop:gap-10 desktop:px-14 hd:mt-24 hd:mb-30 hd:w-248 hd:max-w-none">
       <div className="flex items-center gap-3 pl-6 tablet:pl-0">
         <div className="h-8 w-1.5 rounded-md bg-yellow-400" />
         <h3 className="prose-h3-small font-swei! text-neutral-900 desktop:prose-h3-large">
@@ -63,7 +63,7 @@ function LatestAnswers({ onOpenModal }: LatestAnswersProps) {
           <div className="flex flex-col">
             {answers.map((answer, index) => (
               <Fragment key={answer.id}>
-                {index > 0 && <Divider className="mx-5 w-auto desktop:mx-10" />}
+                {index > 0 && <Divider className="mx-5 w-auto desktop:mx-5" />}
                 <AnswerCard
                   {...answer}
                   onClick={() => handleAnswerCardClick(answer.postSlug)}


### PR DESCRIPTION
## Summary

Fix defects in the Idea Hub latest answers section by updating subtitle copy and adjusting styling for better visual consistency on desktop breakpoints.

## Changes

- Update Idea Hub subtitle text from「看看大家的對話，一起想，一起長大！」to「看看大家的觀點，一起對話，一起長大！」
- Adjust `AnswerCard` hover background from `neutral-200` to `neutral-100` and change desktop spacing from margin (`m-5`) to padding (`p-5`)
- Widen the `LatestAnswers` container on desktop (`w-200` → `w-228`) and HD (`w-220` → `w-248`) breakpoints
- Reduce `Divider` horizontal margin on desktop from `mx-10` to `mx-5` to align with updated card padding

## Additional Notes

These are minor styling and copy tweaks following design feedback on the revamped Idea Hub latest answers section.

## Screenshot(s)

## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/defect-4-3448dbdca932805ab5c1dab229d02e35?source=copy_link)