### PR TITLE
refactor(frontend): improve QA modal titlebar button a11y

### DIFF
--- a/packages/frontend/src/services/call-baodaozai/components/qa-modal/icon-buttons.tsx
+++ b/packages/frontend/src/services/call-baodaozai/components/qa-modal/icon-buttons.tsx
@@ -2,10 +2,15 @@ import { cn } from '@kids-reporter/routing-ui'
 
 type IconButtonProps = {
   onClick: () => void
+  ariaLabel: string
   className?: string
 }
 
-export function MinimizeButton({ onClick, className }: IconButtonProps) {
+export function MinimizeButton({
+  onClick,
+  className,
+  ariaLabel,
+}: IconButtonProps) {
   return (
     <button
       onClick={onClick}
@@ -13,6 +18,7 @@ export function MinimizeButton({ onClick, className }: IconButtonProps) {
         'flex h-8 w-8 cursor-pointer items-center justify-center text-neutral-600 transition-colors hover:text-neutral-800',
         className
       )}
+      aria-label={ariaLabel}
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -34,7 +40,11 @@ export function MinimizeButton({ onClick, className }: IconButtonProps) {
   )
 }
 
-export function MaximizeButton({ onClick, className }: IconButtonProps) {
+export function MaximizeButton({
+  onClick,
+  className,
+  ariaLabel,
+}: IconButtonProps) {
   return (
     <button
       onClick={onClick}
@@ -42,6 +52,7 @@ export function MaximizeButton({ onClick, className }: IconButtonProps) {
         'flex h-8 w-8 cursor-pointer items-center justify-center text-neutral-600 transition-colors hover:text-neutral-800',
         className
       )}
+      aria-label={ariaLabel}
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -63,7 +74,11 @@ export function MaximizeButton({ onClick, className }: IconButtonProps) {
   )
 }
 
-export function FullscreenButton({ onClick, className }: IconButtonProps) {
+export function FullscreenButton({
+  onClick,
+  className,
+  ariaLabel,
+}: IconButtonProps) {
   return (
     <button
       onClick={onClick}
@@ -71,6 +86,7 @@ export function FullscreenButton({ onClick, className }: IconButtonProps) {
         'flex h-8 w-8 cursor-pointer items-center justify-center text-neutral-600 transition-colors hover:text-neutral-800',
         className
       )}
+      aria-label={ariaLabel}
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -91,7 +107,11 @@ export function FullscreenButton({ onClick, className }: IconButtonProps) {
   )
 }
 
-export function FullscreenExitButton({ onClick, className }: IconButtonProps) {
+export function FullscreenExitButton({
+  onClick,
+  className,
+  ariaLabel,
+}: IconButtonProps) {
   return (
     <button
       onClick={onClick}
@@ -99,6 +119,7 @@ export function FullscreenExitButton({ onClick, className }: IconButtonProps) {
         'flex h-8 w-8 cursor-pointer items-center justify-center text-neutral-600 transition-colors hover:text-neutral-800',
         className
       )}
+      aria-label={ariaLabel}
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -119,7 +140,11 @@ export function FullscreenExitButton({ onClick, className }: IconButtonProps) {
   )
 }
 
-export function CloseButton({ onClick, className }: IconButtonProps) {
+export function CloseButton({
+  onClick,
+  className,
+  ariaLabel,
+}: IconButtonProps) {
   return (
     <button
       onClick={onClick}
@@ -127,6 +152,7 @@ export function CloseButton({ onClick, className }: IconButtonProps) {
         'flex h-8 w-8 cursor-pointer items-center justify-center text-neutral-600 transition-colors hover:text-neutral-800',
         className
       )}
+      aria-label={ariaLabel}
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/frontend/src/services/call-baodaozai/components/qa-modal/index.tsx
+++ b/packages/frontend/src/services/call-baodaozai/components/qa-modal/index.tsx
@@ -95,7 +95,8 @@ function QAModal({
   }, [isOpen, isMobile])
 
   const isContentVisible =
-    displayState !== 'minimized' && displayState !== 'mobile-collapsed'
+    isLeaving ||
+    (displayState !== 'minimized' && displayState !== 'mobile-collapsed')
 
   const shouldLockScroll =
     isOpen &&
@@ -596,22 +597,38 @@ function QAModal({
     if (isLeaving) return null
 
     if (isMobile) {
-      return <CloseButton onClick={handleLeaving} />
+      return (
+        <div
+          onClick={(e) => {
+            e.stopPropagation()
+          }}
+        >
+          <CloseButton onClick={handleLeaving} ariaLabel="Close" />
+        </div>
+      )
     }
 
     return (
-      <div className="flex items-center gap-2">
+      <div
+        onClick={(e) => {
+          e.stopPropagation()
+        }}
+        className="flex items-center gap-2"
+      >
         {displayState === 'minimized' ? (
-          <MaximizeButton onClick={handleMaximize} />
+          <MaximizeButton onClick={handleMaximize} ariaLabel="Maximize" />
         ) : (
-          <MinimizeButton onClick={handleMinimize} />
+          <MinimizeButton onClick={handleMinimize} ariaLabel="Minimize" />
         )}
         {displayState === 'fullscreen' ? (
-          <FullscreenExitButton onClick={handleFullscreenExit} />
+          <FullscreenExitButton
+            onClick={handleFullscreenExit}
+            ariaLabel="Fullscreen Exit"
+          />
         ) : (
-          <FullscreenButton onClick={handleFullscreen} />
+          <FullscreenButton onClick={handleFullscreen} ariaLabel="Fullscreen" />
         )}
-        <CloseButton onClick={handleLeaving} />
+        <CloseButton onClick={handleLeaving} ariaLabel="Close" />
       </div>
     )
   }, [


### PR DESCRIPTION
## Summary

Improve QA modal titlebar icon button accessibility and prevent accidental titlebar-triggered interactions.

## Changes

- Add required `aria-label` prop to QA modal icon buttons (`MinimizeButton`, `MaximizeButton`, `FullscreenButton`, `FullscreenExitButton`, `CloseButton`)
- Stop click propagation from titlebar buttons so they don’t trigger the titlebar’s mobile expand/collapse behavior
- Keep content visible while showing the leaving-confirmation state (even when minimized/collapsed)

## Additional Notes

- This is a non-visual behavior/a11y refactor; no API changes outside the QA modal icon button prop contract.

## Screenshot(s)

## Reference(s)