### PR TITLE
feat(cms): include category/subcategory in TWReporter related posts

### DIFF
--- a/packages/cms/graphql/extend-schema.ts
+++ b/packages/cms/graphql/extend-schema.ts
@@ -219,9 +219,9 @@ export const extendGraphqlSchema = graphql.extend(() => {
         type: graphql.list(
           graphql.object<{
             src: string
-            ogImgSrc: string
-            ogTitle: string
-            ogDescription: string
+            ogImgSrc: string | null
+            ogTitle: string | null
+            ogDescription: string | null
             publishedDate: string | null
             subcategory: string | null
             category: string | null
@@ -299,7 +299,14 @@ export const extendGraphqlSchema = graphql.extend(() => {
                     item?.link?.includes('/topics/'))
               )
               ?.map((item: any) => {
-                const metaTag = item?.pagemap?.metatags?.[0]
+                const metaTag = item?.pagemap?.metatags?.[0] ?? {}
+                const toNonEmptyStringOrNull = (
+                  value: unknown
+                ): string | null => {
+                  if (typeof value !== 'string') return null
+                  const trimmed = value.trim()
+                  return trimmed.length > 0 ? trimmed : null
+                }
                 const publishedDateObj = new Date(
                   item?.snippet
                     ?.split('...')?.[0]
@@ -311,15 +318,32 @@ export const extendGraphqlSchema = graphql.extend(() => {
                 const publishedDate = isNaN(publishedDateObj.getTime())
                   ? null
                   : publishedDateObj.toISOString()
+
+                const articlePublishedTimeRaw = toNonEmptyStringOrNull(
+                  metaTag['article:published_time']
+                )
+                const articlePublishedTimeObj = articlePublishedTimeRaw
+                  ? new Date(articlePublishedTimeRaw)
+                  : null
+                const articlePublishedTimeIso =
+                  articlePublishedTimeObj &&
+                  !isNaN(articlePublishedTimeObj.getTime())
+                    ? articlePublishedTimeObj.toISOString()
+                    : null
                 return {
                   src: item.link,
-                  ogImgSrc: metaTag['og:image'],
-                  ogTitle: metaTag['og:title'],
-                  ogDescription: metaTag['og:description'],
-                  publishedDate:
-                    metaTag['article:published_time'] ?? publishedDate,
-                  subcategory: metaTag['twreporter:subcategory'] ?? null,
-                  category: metaTag['twreporter:category'] ?? null,
+                  ogImgSrc: toNonEmptyStringOrNull(metaTag['og:image']),
+                  ogTitle: toNonEmptyStringOrNull(metaTag['og:title']),
+                  ogDescription: toNonEmptyStringOrNull(
+                    metaTag['og:description']
+                  ),
+                  publishedDate: articlePublishedTimeIso ?? publishedDate,
+                  subcategory: toNonEmptyStringOrNull(
+                    metaTag['twreporter:subcategory']
+                  ),
+                  category: toNonEmptyStringOrNull(
+                    metaTag['twreporter:category']
+                  ),
                 }
               })
 

--- a/packages/cms/graphql/extend-schema.ts
+++ b/packages/cms/graphql/extend-schema.ts
@@ -216,7 +216,28 @@ export const extendGraphqlSchema = graphql.extend(() => {
     },
     query: {
       searchTWReporterPosts: graphql.field({
-        type: graphql.list(graphql.JSON),
+        type: graphql.list(
+          graphql.object<{
+            src: string
+            ogImgSrc: string
+            ogTitle: string
+            ogDescription: string
+            publishedDate: string
+            subcategory: string | null
+            category: string | null
+          }>()({
+            name: 'searchTWReporterPostsResult',
+            fields: {
+              src: graphql.field({ type: graphql.String }),
+              ogImgSrc: graphql.field({ type: graphql.String }),
+              ogTitle: graphql.field({ type: graphql.String }),
+              ogDescription: graphql.field({ type: graphql.String }),
+              publishedDate: graphql.field({ type: graphql.String }),
+              subcategory: graphql.field({ type: graphql.String }),
+              category: graphql.field({ type: graphql.String }),
+            },
+          })
+        ),
         args: {
           keywords: graphql.arg({ type: graphql.nonNull(graphql.String) }),
         },
@@ -290,13 +311,15 @@ export const extendGraphqlSchema = graphql.extend(() => {
                 const publishedDate = isNaN(publishedDateObj.getTime())
                   ? null
                   : publishedDateObj.toISOString()
-
                 return {
                   src: item.link,
                   ogImgSrc: metaTag['og:image'],
                   ogTitle: metaTag['og:title'],
                   ogDescription: metaTag['og:description'],
-                  publishedDate,
+                  publishedDate:
+                    metaTag['article:published_time'] ?? publishedDate ?? null,
+                  subcategory: metaTag['twreporter:subcategory'] ?? null,
+                  category: metaTag['twreporter:category'] ?? null,
                 }
               })
 

--- a/packages/cms/graphql/extend-schema.ts
+++ b/packages/cms/graphql/extend-schema.ts
@@ -222,7 +222,7 @@ export const extendGraphqlSchema = graphql.extend(() => {
             ogImgSrc: string
             ogTitle: string
             ogDescription: string
-            publishedDate: string
+            publishedDate: string | null
             subcategory: string | null
             category: string | null
           }>()({
@@ -317,7 +317,7 @@ export const extendGraphqlSchema = graphql.extend(() => {
                   ogTitle: metaTag['og:title'],
                   ogDescription: metaTag['og:description'],
                   publishedDate:
-                    metaTag['article:published_time'] ?? publishedDate ?? null,
+                    metaTag['article:published_time'] ?? publishedDate,
                   subcategory: metaTag['twreporter:subcategory'] ?? null,
                   category: metaTag['twreporter:category'] ?? null,
                 }

--- a/packages/cms/lists/views/twreporter-related-posts.tsx
+++ b/packages/cms/lists/views/twreporter-related-posts.tsx
@@ -23,7 +23,9 @@ type TWReporterPost = {
   ogImgSrc: string
   ogTitle: string
   ogDescription: string
-  publishedDate?: string
+  publishedDate: string
+  subcategory?: string
+  category?: string
 }
 
 type PostTag = {
@@ -87,7 +89,15 @@ const SearchResultItem = styled.div`
 
 const SearchTWReporterPostsQuery = `
 query SearchTWReporterPosts($keywords: String!) {
-  searchTWReporterPosts(keywords: $keywords)
+  searchTWReporterPosts(keywords: $keywords) {
+   src
+   ogImgSrc
+   ogTitle
+   ogDescription
+   publishedDate
+   subcategory
+   category
+  }
 }
 `
 

--- a/packages/cms/lists/views/twreporter-related-posts.tsx
+++ b/packages/cms/lists/views/twreporter-related-posts.tsx
@@ -20,9 +20,9 @@ import styled, { css } from 'styled-components'
 
 type TWReporterPost = {
   src: string
-  ogImgSrc: string
-  ogTitle: string
-  ogDescription: string
+  ogImgSrc: string | null
+  ogTitle: string | null
+  ogDescription: string | null
   publishedDate: string | null
   subcategory: string | null
   category: string | null
@@ -111,7 +111,7 @@ const PostComponent = (props: {
     post && (
       <AuthorContainer>
         {`${props.index}.`}
-        <img width="100px" src={post.ogImgSrc} />
+        <img width="100px" src={post.ogImgSrc ?? ''} />
         <div style={{ flex: '2' }}>{post.ogTitle}</div>
         <a href={post.src} target="_blank" rel="noreferrer">
           <CornerUpRightIcon size="small" />
@@ -318,7 +318,11 @@ export const Field = ({
         return (
           <SearchResultItem key={post.src}>
             <span>{index + 1}.</span>
-            <img width="60px" src={post.ogImgSrc} alt={post.ogTitle} />
+            <img
+              width="60px"
+              src={post.ogImgSrc ?? ''}
+              alt={post.ogTitle ?? ''}
+            />
             <div style={{ flex: '2', fontSize: '14px' }}>{post.ogTitle}</div>
             <a href={post.src} target="_blank" rel="noreferrer">
               <CornerUpRightIcon size="small" />

--- a/packages/cms/lists/views/twreporter-related-posts.tsx
+++ b/packages/cms/lists/views/twreporter-related-posts.tsx
@@ -23,9 +23,9 @@ type TWReporterPost = {
   ogImgSrc: string
   ogTitle: string
   ogDescription: string
-  publishedDate: string
-  subcategory?: string
-  category?: string
+  publishedDate: string | null
+  subcategory: string | null
+  category: string | null
 }
 
 type PostTag = {

--- a/packages/cms/schema.graphql
+++ b/packages/cms/schema.graphql
@@ -2535,9 +2535,19 @@ type Query {
   popularKeywordsCount(where: PopularKeywordWhereInput! = {}): Int
   keystone: KeystoneMeta!
   authenticatedItem: AuthenticatedItem
-  searchTWReporterPosts(keywords: String!): [JSON]
+  searchTWReporterPosts(keywords: String!): [searchTWReporterPostsResult]
   getMemberPostsWithAnswers(take: Int = 5, cursor: String): JSON
   getMemberEssayAnswersHasLiked(essayAnswerIds: [ID]): [getMemberEssayAnswersHasLikedResult]
+}
+
+type searchTWReporterPostsResult {
+  src: String
+  ogImgSrc: String
+  ogTitle: String
+  ogDescription: String
+  publishedDate: String
+  subcategory: String
+  category: String
 }
 
 type getMemberEssayAnswersHasLikedResult {

--- a/packages/frontend/src/components/article-card.tsx
+++ b/packages/frontend/src/components/article-card.tsx
@@ -46,8 +46,8 @@ function ArticleCard({ article, showOverImageCover = false }: ArticleCardProp) {
           <div className="flex items-center justify-between gap-4 self-stretch">
             <span
               className={cn(
-                'inline-flex items-center rounded-full px-3 py-1 prose-p3-bold text-neutral-900',
-                hasCategoryOrSubcategory ? 'bg-neutral-200' : 'transparent'
+                'inline-flex items-center rounded-full prose-p3-bold text-neutral-900',
+                hasCategoryOrSubcategory && 'bg-neutral-200 px-3 py-1'
               )}
             >
               {article.subSubcategory ?? article.category}

--- a/packages/frontend/src/components/article-card.tsx
+++ b/packages/frontend/src/components/article-card.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@kids-reporter/routing-ui'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
 
@@ -43,11 +44,14 @@ function ArticleCard({ article, showOverImageCover = false }: ArticleCardProp) {
 
         <div className="flex min-w-0 flex-1 flex-col gap-2">
           <div className="flex items-center justify-between gap-4 self-stretch">
-            {hasCategoryOrSubcategory && (
-              <span className="inline-flex items-center rounded-full bg-neutral-200 px-3 py-1 prose-p3-bold text-neutral-900">
-                {article.subSubcategory ?? article.category}
-              </span>
-            )}
+            <span
+              className={cn(
+                'inline-flex items-center rounded-full px-3 py-1 prose-p3-bold text-neutral-900',
+                hasCategoryOrSubcategory ? 'bg-neutral-200' : 'transparent'
+              )}
+            >
+              {article.subSubcategory ?? article.category}
+            </span>
 
             <span className="prose-p2 text-neutral-500">
               {getFormattedDate(article.publishedDate)}

--- a/packages/frontend/src/modules/article/utils/parse-post-to-content.ts
+++ b/packages/frontend/src/modules/article/utils/parse-post-to-content.ts
@@ -108,13 +108,15 @@ function parsePostToContent(post: NonNullable<GetPostQuery['post']>) {
         ogImgSrc: string
         ogDescription: string
         publishedDate: string
+        subcategory?: string
+        category?: string
       }) => ({
         title: twReporterPost.ogTitle,
         url: twReporterPost.src,
         image: twReporterPost.ogImgSrc,
         desc: twReporterPost.ogDescription,
-        category: '',
-        subSubcategory: '',
+        category: twReporterPost.category ?? '',
+        subSubcategory: twReporterPost.subcategory ?? '',
         publishedDate: twReporterPost.publishedDate,
       })
     ) ?? []

--- a/packages/frontend/src/modules/article/utils/parse-post-to-content.ts
+++ b/packages/frontend/src/modules/article/utils/parse-post-to-content.ts
@@ -103,21 +103,21 @@ function parsePostToContent(post: NonNullable<GetPostQuery['post']>) {
   const twReporterRelatedPosts: PostSummary[] =
     post?.TWReporterRelatedPostsJSON?.map(
       (twReporterPost: {
-        ogTitle: string
+        ogTitle?: string
         src: string
-        ogImgSrc: string
-        ogDescription: string
-        publishedDate: string
+        ogImgSrc?: string
+        ogDescription?: string
+        publishedDate?: string
         subcategory?: string
         category?: string
       }) => ({
-        title: twReporterPost.ogTitle,
+        title: twReporterPost.ogTitle ?? '',
         url: twReporterPost.src,
-        image: twReporterPost.ogImgSrc,
-        desc: twReporterPost.ogDescription,
+        image: twReporterPost.ogImgSrc ?? '',
+        desc: twReporterPost.ogDescription ?? '',
         category: twReporterPost.category ?? '',
         subSubcategory: twReporterPost.subcategory ?? '',
-        publishedDate: twReporterPost.publishedDate,
+        publishedDate: twReporterPost.publishedDate ?? '',
       })
     ) ?? []
 


### PR DESCRIPTION
## Summary

Enhance TWReporter related-post search results to return structured fields (including category/subcategory) and wire them through CMS + frontend parsing for richer related-post rendering.

## Changes

- Update `searchTWReporterPosts` GraphQL schema to return a typed object list instead of `[JSON]`
- Include `category` and `subcategory` (plus improved `publishedDate` fallback) in the resolver results
- Update CMS `twreporter-related-posts` view query/types to consume structured fields
- Map TWReporter category/subcategory into frontend related-post parsing
- Tweak frontend `article-card` category pill rendering to avoid conditional markup

## Additional Notes

- `publishedDate` now prefers `article:published_time` meta when present, falling back to RSS/parsed date.

## Screenshot(s)


## Reference(s)
