### PR TITLE
fix(frontend): prefer category fallback when subSubcategory is empty

### DIFF
--- a/packages/frontend/src/components/article-card.tsx
+++ b/packages/frontend/src/components/article-card.tsx
@@ -50,7 +50,7 @@ function ArticleCard({ article, showOverImageCover = false }: ArticleCardProp) {
                 hasCategoryOrSubcategory && 'bg-neutral-200 px-3 py-1'
               )}
             >
-              {article.subSubcategory ?? article.category}
+              {article.subSubcategory || article.category}
             </span>
 
             <span className="prose-p2 text-neutral-500">


### PR DESCRIPTION
## Summary

Fix `ArticleCard` to display `category` when `subSubcategory` is empty (not just null/undefined).

## Changes

- Update `packages/frontend/src/components/article-card.tsx` to use `article.subSubcategory || article.category` so empty strings correctly fall back.

## Additional Notes

This prevents rendering a blank pill when `subSubcategory` is an empty string.

## Screenshot(s)

## Reference(s)