### PR TITLE
fix(frontend): streamline category tag display in ArticleCard

### DIFF
--- a/packages/frontend/src/components/article-card.tsx
+++ b/packages/frontend/src/components/article-card.tsx
@@ -19,7 +19,8 @@ type ArticleCardProp = {
 }
 
 function ArticleCard({ article, showOverImageCover = false }: ArticleCardProp) {
-  const hasCategoryOrSubcategory = article.subSubcategory ?? article.category
+  const displayCategory = article.subSubcategory || article.category
+  const hasCategoryOrSubcategory = !!displayCategory
 
   return (
     <Link href={article.url} className="group block">
@@ -50,7 +51,7 @@ function ArticleCard({ article, showOverImageCover = false }: ArticleCardProp) {
                 hasCategoryOrSubcategory && 'bg-neutral-200 px-3 py-1'
               )}
             >
-              {article.subSubcategory || article.category}
+              {displayCategory}
             </span>
 
             <span className="prose-p2 text-neutral-500">


### PR DESCRIPTION
## Summary

Simplifies `ArticleCard` category tag rendering by deriving a single `displayCategory` value (preferring `subSubcategory`, falling back to `category`) and using it consistently for both visibility checks and displayed text.

## Changes

- Refactor `packages/frontend/src/components/article-card.tsx` to compute `displayCategory = article.subSubcategory || article.category`
- Replace mixed nullish-coalescing / direct rendering logic with a single `displayCategory` source of truth
- Use boolean coercion (`!!displayCategory`) to control category tag styling/rendering conditions

## Additional Notes

This avoids subtle mismatches between the “has category” check and the value actually rendered when fields are `null`/`undefined`.

## Screenshot(s)

## Reference(s)