### PR TITLE
fix(frontend): fix Baodaozai QA modal leave flow and leaving layout

### DIFF
--- a/packages/frontend/src/services/call-baodaozai/components/qa-modal/index.tsx
+++ b/packages/frontend/src/services/call-baodaozai/components/qa-modal/index.tsx
@@ -201,11 +201,16 @@ function QAModal({
   const shouldByPassOnLeaving = mode === 'update' && isCleanAnswers
   const handleShowLeaving = useCallback(() => {
     setIsLeaving(true)
-  }, [])
+    if (isMobile) return
+    setDisplayState('fullscreen')
+    previousNonMobileDisplayState.current = displayState
+  }, [displayState, isMobile])
 
   const handleCancelLeaving = useCallback(() => {
     setIsLeaving(false)
-  }, [])
+    if (isMobile) return
+    setDisplayState(previousNonMobileDisplayState.current)
+  }, [isMobile])
 
   const events = useMemo(
     () => ({
@@ -713,7 +718,7 @@ function QAModal({
         >
           <div
             className={cn(
-              'flex-1 text-neutral-900',
+              'flex h-full flex-1 items-center text-neutral-900',
               isLeaving && 'text-center'
             )}
           >

--- a/packages/frontend/src/services/call-baodaozai/components/qa-modal/index.tsx
+++ b/packages/frontend/src/services/call-baodaozai/components/qa-modal/index.tsx
@@ -132,6 +132,7 @@ function QAModal({
 
   const previousNonMobileDisplayState =
     useRef<QAModalDisplayState>(displayState)
+  const displayStateBeforeLeaving = useRef<QAModalDisplayState>(displayState)
 
   const handleTitleClick = useCallback(() => {
     switch (displayState) {
@@ -202,14 +203,14 @@ function QAModal({
   const handleShowLeaving = useCallback(() => {
     setIsLeaving(true)
     if (isMobile) return
+    displayStateBeforeLeaving.current = displayState
     setDisplayState('fullscreen')
-    previousNonMobileDisplayState.current = displayState
   }, [displayState, isMobile])
 
   const handleCancelLeaving = useCallback(() => {
     setIsLeaving(false)
     if (isMobile) return
-    setDisplayState(previousNonMobileDisplayState.current)
+    setDisplayState(displayStateBeforeLeaving.current)
   }, [isMobile])
 
   const events = useMemo(


### PR DESCRIPTION
## Summary

On non-mobile, the Baodaozai Q&A modal now switches to fullscreen when the user starts the leave/discard flow, remembers the previous display mode, and restores it if they cancel. On mobile, display state is left unchanged to avoid layout jumps. The leaving confirmation text container is also aligned with full height and vertical centering.

## Changes

- Update `handleShowLeaving` to set `displayState` to `fullscreen` and store the prior `displayState` in `previousNonMobileDisplayState` when not on mobile; on mobile, only set `isLeaving` and return early.
- Update `handleCancelLeaving` to restore `displayState` from `previousNonMobileDisplayState` when not on mobile; on mobile, only clear `isLeaving` and return early.
- Adjust the leaving message wrapper classes from `flex-1` to `flex h-full flex-1 items-center` for consistent vertical centering with centered copy when `isLeaving` is true.

## Additional Notes

- `handleShowLeaving` now depends on `displayState` and `isMobile`; `handleCancelLeaving` on `isMobile`, so both stay in sync with the values they read.
- If users toggle leave/cancel very quickly, confirm there are no edge cases with `previousNonMobileDisplayState` vs. external display changes (same risk as any ref-stashed UI mode).

## Screenshot(s)


## Reference(s)

- [Defect (Notion)](https://www.notion.so/twreporter/defect-3488dbdca932804391dbd2d4731a6d92?source=copy_link)