### PR TITLE
feat(frontend): integrate member display name in QA modal and article components

### DIFF
--- a/packages/frontend/src/modules/article/index.tsx
+++ b/packages/frontend/src/modules/article/index.tsx
@@ -32,6 +32,7 @@ import {
 import getLoginUrl from '@/utils/get-login-url'
 
 import SupportAction from '../../components/support-action'
+import { getMemberDisplayName } from '../idea-hub/utils'
 import ArticleBaodaozaiEventTrigger from './components/article-baodaozai-event-trigger'
 import ArticleSummary from './components/article-summary'
 import Authors from './components/authors'
@@ -387,6 +388,7 @@ const ArticleModule = ({
       />
       {postQuestions && (
         <BaodaozaiQAModal
+          memberDisplayName={getMemberDisplayName(member)}
           questions={postQuestions}
           onClose={handleQAModalClose}
           onSubmit={handleQAModalSubmit}

--- a/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/essay-answer-item.tsx
+++ b/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/essay-answer-item.tsx
@@ -15,7 +15,10 @@ import {
 } from '@/api-utils/react-query/hooks/post-essay-answer'
 import Divider from '@/components/divider'
 import { StarIcon } from '@/icons/miscellaneous'
-import { getDisplayLikesCount } from '@/modules/idea-hub/utils'
+import {
+  getDisplayLikesCount,
+  getMemberDisplayName,
+} from '@/modules/idea-hub/utils'
 import { useHydratedAuthStore } from '@/services/auth/use-hydrated-auth-store'
 import BaodaozaiQAModal from '@/services/call-baodaozai/components/qa-modal'
 import { CallBaodaozaiProvider } from '@/services/call-baodaozai/context'
@@ -123,6 +126,7 @@ function EssayAnswerItem({
           onSubmit={handleSubmit}
           isOpen={isOpen}
           mode="update"
+          memberDisplayName={getMemberDisplayName(member)}
         />
       </CallBaodaozaiProvider>
     </>

--- a/packages/frontend/src/services/call-baodaozai/components/qa-modal/index.tsx
+++ b/packages/frontend/src/services/call-baodaozai/components/qa-modal/index.tsx
@@ -7,6 +7,7 @@ import {
   useMediaQuery,
 } from '@kids-reporter/routing-ui'
 import { useRiveFile } from '@rive-app/react-webgl2'
+import Link from 'next/link'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import envVars from '@/environment-variables'
@@ -50,6 +51,7 @@ type QAModalProps = {
   onSubmit: (answers: Record<number, string>, events: QAModalEvent) => void
   isOpen: boolean
   mode?: QAModalMode
+  memberDisplayName: string
 }
 
 const SWIPE_THRESHOLD = 50
@@ -60,6 +62,7 @@ function QAModal({
   onSubmit,
   isOpen,
   mode = 'default',
+  memberDisplayName,
 }: QAModalProps) {
   const { riveFile } = useRiveFile({
     src: envVars.baodaozaiRiveFilePath,
@@ -396,13 +399,14 @@ function QAModal({
                 )
               }
             />
-            <span className="mt-5 flex items-center gap-2 prose-p1 text-neutral-400">
+            <span className="mt-5 flex items-start gap-2 prose-p1 text-neutral-400">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 width="24"
                 height="24"
                 viewBox="0 0 24 24"
                 fill="none"
+                className="mt-0.5 shrink-0"
               >
                 <path
                   d="M12 17C12.2833 17 12.5208 16.9042 12.7125 16.7125C12.9042 16.5208 13 16.2833 13 16V12C13 11.7167 12.9042 11.4792 12.7125 11.2875C12.5208 11.0958 12.2833 11 12 11C11.7167 11 11.4792 11.0958 11.2875 11.2875C11.0958 11.4792 11 11.7167 11 12V16C11 16.2833 11.0958 16.5208 11.2875 16.7125C11.4792 16.9042 11.7167 17 12 17ZM12 9C12.2833 9 12.5208 8.90417 12.7125 8.7125C12.9042 8.52083 13 8.28333 13 8C13 7.71667 12.9042 7.47917 12.7125 7.2875C12.5208 7.09583 12.2833 7 12 7C11.7167 7 11.4792 7.09583 11.2875 7.2875C11.0958 7.47917 11 7.71667 11 8C11 8.28333 11.0958 8.52083 11.2875 8.7125C11.4792 8.90417 11.7167 9 12 9ZM12 22C10.6167 22 9.31667 21.7375 8.1 21.2125C6.88333 20.6875 5.825 19.975 4.925 19.075C4.025 18.175 3.3125 17.1167 2.7875 15.9C2.2625 14.6833 2 13.3833 2 12C2 10.6167 2.2625 9.31667 2.7875 8.1C3.3125 6.88333 4.025 5.825 4.925 4.925C5.825 4.025 6.88333 3.3125 8.1 2.7875C9.31667 2.2625 10.6167 2 12 2C13.3833 2 14.6833 2.2625 15.9 2.7875C17.1167 3.3125 18.175 4.025 19.075 4.925C19.975 5.825 20.6875 6.88333 21.2125 8.1C21.7375 9.31667 22 10.6167 22 12C22 13.3833 21.7375 14.6833 21.2125 15.9C20.6875 17.1167 19.975 18.175 19.075 19.075C18.175 19.975 17.1167 20.6875 15.9 21.2125C14.6833 21.7375 13.3833 22 12 22ZM12 20C14.2333 20 16.125 19.225 17.675 17.675C19.225 16.125 20 14.2333 20 12C20 9.76667 19.225 7.875 17.675 6.325C16.125 4.775 14.2333 4 12 4C9.76667 4 7.875 4.775 6.325 6.325C4.775 7.875 4 9.76667 4 12C4 14.2333 4.775 16.125 6.325 17.675C7.875 19.225 9.76667 20 12 20Z"
@@ -487,7 +491,17 @@ function QAModal({
 
             <div className="w-full bg-neutral-100 p-6 pb-10 tablet:pb-6">
               <div className="mb-4">
-                <p className="mb-4 prose-p1 text-neutral-700">你送出的回答：</p>
+                <p className="mb-4 prose-p1 text-neutral-700">
+                  <Link
+                    href="/account"
+                    className="underline"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {memberDisplayName}
+                  </Link>
+                  送出的回答：
+                </p>
                 <div className="w-full rounded-2xl border-2 border-neutral-200 bg-white p-4">
                   <span className="prose-p1-bold text-wrap wrap-break-word text-neutral-900">
                     {currentAnswer}
@@ -506,6 +520,7 @@ function QAModal({
     isLeaving,
     mode,
     riveFile,
+    memberDisplayName,
   ])
 
   const renderModalButtons = useMemo(() => {


### PR DESCRIPTION
## Summary

The Baodaozai QA modal used static copy when showing the member submitted answer in update mode. The modal now shows the same display string used elsewhere (nickname, then name, then email via `getMemberDisplayName`), linked to the account page, so the label matches other member-facing UI and avoids relying on misleading or masked-only email presentation.

## Changes

- Add required `memberDisplayName` to `BaodaozaiQAModal` / `QAModal` and render it with `next/link` to `/account` (`target="_blank"`) before the existing Chinese label in update mode.
- Pass `getMemberDisplayName(member)` from `packages/frontend/src/modules/article/index.tsx` and `essay-answer-item.tsx`.
- Tweak the info notice row (`items-start`, icon `shrink-0` / `mt-0.5`) and add `memberDisplayName` to the relevant `useMemo` dependency list.

## Additional Notes

- Only two call sites use `BaodaozaiQAModal` today; both pass the new prop, so the prop stays type-safe for the current tree.
- If `member` is missing, `getMemberDisplayName` still resolves to the shared default placeholder.
- Follow-ups worth sanity-checking: account link opening a new tab on mobile, and any future third call site remembering to pass `memberDisplayName`.

## Screenshot(s)


## Reference(s)

