### PR TITLE
fix(frontend): mask member email in display name

### DIFF
--- a/packages/frontend/src/modules/article/index.tsx
+++ b/packages/frontend/src/modules/article/index.tsx
@@ -388,7 +388,7 @@ const ArticleModule = ({
       />
       {postQuestions && (
         <BaodaozaiQAModal
-          memberDisplayName={getMemberDisplayName(member)}
+          memberDisplayName={getMemberDisplayName(member, true)}
           questions={postQuestions}
           onClose={handleQAModalClose}
           onSubmit={handleQAModalSubmit}

--- a/packages/frontend/src/modules/idea-hub/utils.ts
+++ b/packages/frontend/src/modules/idea-hub/utils.ts
@@ -1,12 +1,25 @@
 import { Member } from '__generated__/types'
 
 import { DEFAULT_TEXT_HOLDER } from '@/constants/input-field'
+import maskEmail from '@/utils/mask-email'
 
 type MemberDisplay = Partial<Pick<Member, 'nickname' | 'name' | 'email'>>
 
-export const getMemberDisplayName = (member: MemberDisplay | undefined) => {
+export const getMemberDisplayName = (
+  member: MemberDisplay | undefined,
+  shouldMaskEmail = false
+) => {
   if (!member) return DEFAULT_TEXT_HOLDER
-  return member.nickname || member.name || member.email || DEFAULT_TEXT_HOLDER
+  if (member.nickname) {
+    return member.nickname
+  }
+  if (member.name) {
+    return member.name
+  }
+  if (member.email) {
+    return shouldMaskEmail ? maskEmail(member.email) : member.email
+  }
+  return DEFAULT_TEXT_HOLDER
 }
 
 export const formatChineseDate = (dateStr: string) => {

--- a/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/essay-answer-item.tsx
+++ b/packages/frontend/src/modules/membership/my-reading/post-question-answers-list/essay-answer-item.tsx
@@ -126,7 +126,7 @@ function EssayAnswerItem({
           onSubmit={handleSubmit}
           isOpen={isOpen}
           mode="update"
-          memberDisplayName={getMemberDisplayName(member)}
+          memberDisplayName={getMemberDisplayName(member, true)}
         />
       </CallBaodaozaiProvider>
     </>

--- a/packages/frontend/src/services/call-baodaozai/components/qa-modal/index.tsx
+++ b/packages/frontend/src/services/call-baodaozai/components/qa-modal/index.tsx
@@ -498,8 +498,8 @@ function QAModal({
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    {memberDisplayName}
-                  </Link>
+                    {memberDisplayName} (你)
+                  </Link>{' '}
                   送出的回答：
                 </p>
                 <div className="w-full rounded-2xl border-2 border-neutral-200 bg-white p-4">

--- a/packages/frontend/src/utils/mask-email.ts
+++ b/packages/frontend/src/utils/mask-email.ts
@@ -1,0 +1,7 @@
+const MASKED_EMAIL_LENGTH = 8
+const MASKED_VISIBLE_PREFIX = 3
+
+export default function maskEmail(email: string): string {
+  if (!email) return ''.padEnd(MASKED_EMAIL_LENGTH, '*')
+  return email.slice(0, MASKED_VISIBLE_PREFIX).padEnd(MASKED_EMAIL_LENGTH, '*')
+}


### PR DESCRIPTION
## Summary

Mask member email addresses when display name falls back to email, improving privacy in UI surfaces that show the current member name.

## Changes

- Add `maskEmail` utility (`packages/frontend/src/utils/mask-email.ts`)
- Update `getMemberDisplayName(member, shouldMaskEmail)` to optionally mask email fallback (`packages/frontend/src/modules/idea-hub/utils.ts`)
- Enable masking in `ArticleModule` and `EssayAnswerItem` when passing `memberDisplayName` into QA modal
- Adjust QA modal copy to display member name as "(你)" when rendering the link

## Additional Notes

- Masking only applies when the display name resolves to `email` and `shouldMaskEmail=true` (nickname/name remain unchanged).

## Screenshot(s)


## Reference(s)

