### PR TITLE
fix(frontend): ensure topic page width is full width

### DIFF
--- a/packages/frontend/src/modules/topic/slug/index.tsx
+++ b/packages/frontend/src/modules/topic/slug/index.tsx
@@ -35,7 +35,7 @@ function TopicSlugModule({
   relatedPosts,
 }: TopicSlugModuleProps) {
   return (
-    <div>
+    <div className="w-full">
       <HeaderPostTitleSetter postTitle={title} />
       <HeroTitle
         title={title}


### PR DESCRIPTION
## Summary

Ensure the topic slug page container spans full width to match expected layout.

## Changes

- Update `TopicSlugModule` root wrapper to use `w-full` for full-width layout.

## Screenshot(s)

## Reference(s)