### PR TITLE
feat(frontend,api-gateway): show answer creation date in essay modal

### DIFF
--- a/packages/api-gateway/src/graphql/documents/answers.ts
+++ b/packages/api-gateway/src/graphql/documents/answers.ts
@@ -120,6 +120,7 @@ export const GET_ESSAY_QUESTION_ESSAY_ANSWERS_QUERY = gql`
       answers(orderBy: $answerOrderBy, take: $answerTake, skip: $answerSkip) {
         id
         content
+        createdAt
         member {
           id
           avatar {

--- a/packages/frontend/src/modules/idea-hub/latest-answers/answer-card.tsx
+++ b/packages/frontend/src/modules/idea-hub/latest-answers/answer-card.tsx
@@ -36,8 +36,8 @@ function AnswerCard({
         role="button"
         aria-label={`View answer: ${content}`}
       >
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex min-w-0 flex-1 items-center gap-3">
             <div className="relative size-[52px] shrink-0 overflow-hidden rounded-full border-2 border-neutral-200">
               <Image
                 src={memberAvatar || DEFAULT_AVATAR}
@@ -47,13 +47,13 @@ function AnswerCard({
                 sizes="52px"
               />
             </div>
-            <div className="flex flex-col">
-              <div className="flex items-center gap-1">
-                <span className="prose-p1-bold text-neutral-900 desktop:prose-h6-small desktop:font-swei!">
+            <div className="flex min-w-0 flex-col">
+              <div className="flex min-w-0 items-center gap-1">
+                <span className="truncate prose-p1-bold text-neutral-900 desktop:prose-h6-small desktop:font-swei!">
                   {memberName}
                 </span>
                 {isOwnAnswer && (
-                  <span className="prose-p1-bold text-neutral-900 desktop:prose-h6-small desktop:font-swei!">
+                  <span className="shrink-0 prose-p1-bold text-neutral-900 desktop:prose-h6-small desktop:font-swei!">
                     (你)
                   </span>
                 )}

--- a/packages/frontend/src/modules/idea-hub/post-essay-questions-modal/modal-answer-item.tsx
+++ b/packages/frontend/src/modules/idea-hub/post-essay-questions-modal/modal-answer-item.tsx
@@ -10,7 +10,11 @@ import { DEFAULT_AVATAR } from '@/constants'
 import { DEFAULT_TEXT_HOLDER } from '@/constants/input-field'
 import { StarIcon, StarIconUnfilled } from '@/icons/miscellaneous'
 
-import { getDisplayLikesCount, getMemberDisplayName } from '../utils'
+import {
+  formatChineseDate,
+  getDisplayLikesCount,
+  getMemberDisplayName,
+} from '../utils'
 import useOptimisticLikeAnswer from './hooks/use-optimistic-like-answer'
 
 export const QUESTION_ANSWER_ITEM_TAKE = 5
@@ -78,11 +82,23 @@ function ModalAnswerItem({
                   sizes="40px"
                 />
               </div>
-              <span className="w-0 min-w-0 flex-1 overflow-hidden prose-p2-bold text-ellipsis whitespace-nowrap text-neutral-900">
-                {answer.member
-                  ? getMemberDisplayName(answer.member as Member)
-                  : DEFAULT_TEXT_HOLDER}
-              </span>
+              <div className="flex min-w-0 flex-col">
+                <div className="flex min-w-0 items-center gap-1 prose-p2-bold text-neutral-900">
+                  <span className="truncate">
+                    {answer.member
+                      ? getMemberDisplayName(answer.member as Member)
+                      : DEFAULT_TEXT_HOLDER}
+                  </span>
+                  {!!memberId && answer.member?.id === memberId && (
+                    <span className="shrink-0">(你)</span>
+                  )}
+                </div>
+                {answer.createdAt && (
+                  <span className="prose-p2 text-neutral-600">
+                    {formatChineseDate(answer.createdAt)}
+                  </span>
+                )}
+              </div>
             </div>
             <button
               onClick={handleLikeClick}


### PR DESCRIPTION
## Summary

Expose and display answer creation timestamps in the Post Essay Questions modal for better context while reading answers.

## Changes

- **api-gateway**: add `createdAt` to `GET_ESSAY_QUESTION_ESSAY_ANSWERS_QUERY` answer selection
- **frontend**: render answer author as a 2-line block with created date (formatted in Chinese) and keep self indicator `(你)` next to the name

## Additional Notes

- No behavior changes outside the Post Essay Questions modal answer list; date shows only when `createdAt` is present.

## Screenshot(s)


## Reference(s)