### PR TITLE
fix(draft-renderer): remove annotation list bottom margin

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/cms-core",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "",
   "main": "lib/index.js",
   "types": "src/index.ts",
@@ -36,7 +36,7 @@
     "@keystone-ui/button": "^7.0.2",
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",
-    "@kids-reporter/draft-editor": "^1.0.31",
+    "@kids-reporter/draft-editor": "^1.0.32",
     "@twreporter/errors": "^1.1.1",
     "axios": "^0.26.0",
     "draft-convert": "^2.1.12",

--- a/packages/draft-editor/package.json
+++ b/packages/draft-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/draft-editor",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -29,7 +29,7 @@
     "@keystone-ui/button": "^7.0.2",
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",
-    "@kids-reporter/draft-renderer": "^1.0.27",
+    "@kids-reporter/draft-renderer": "^1.0.28",
     "@twreporter/errors": "^1.1.2",
     "axios": "^1.12.2",
     "draft-js": "^0.11.7"

--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/draft-renderer",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/src/block-render-maps/annotation.tsx
+++ b/packages/draft-renderer/src/block-render-maps/annotation.tsx
@@ -9,24 +9,24 @@ import { Atomic, Heading, List, Paragraph } from './article-content'
 const HeadingForAnnotation = styled(Heading)`
   margin: 0 auto 40px auto;
 
-  margin-bottom: 0px;
+  margin-bottom: 0px !important;
 
   ${mediaQuery.smallOnly} {
     padding-left: 0px;
     padding-right: 0px;
-    margin-bottom: 0px;
+    margin-bottom: 0px !important;
   }
 `
 
 const ListForAnnotation = styled(List)`
   color: #575757;
 
-  margin-bottom: 0px;
+  margin-bottom: 0px !important;
 
   ${mediaQuery.smallOnly} {
     padding-left: 0px;
     padding-right: 0px;
-    margin-bottom: 0px;
+    margin-bottom: 0px !important;
   }
 `
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5058,7 +5058,7 @@ __metadata:
     "@keystone-ui/button": "npm:^7.0.2"
     "@keystone-ui/fields": "npm:^7.2.0"
     "@keystone-ui/modals": "npm:^6.0.3"
-    "@kids-reporter/draft-editor": "npm:^1.0.31"
+    "@kids-reporter/draft-editor": "npm:^1.0.32"
     "@twreporter/errors": "npm:^1.1.1"
     axios: "npm:^0.26.0"
     draft-convert: "npm:^2.1.12"
@@ -5123,7 +5123,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/draft-editor@npm:^1.0.31, @kids-reporter/draft-editor@workspace:packages/draft-editor":
+"@kids-reporter/draft-editor@npm:^1.0.32, @kids-reporter/draft-editor@workspace:packages/draft-editor":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/draft-editor@workspace:packages/draft-editor"
   dependencies:
@@ -5136,7 +5136,7 @@ __metadata:
     "@keystone-ui/button": "npm:^7.0.2"
     "@keystone-ui/fields": "npm:^7.2.0"
     "@keystone-ui/modals": "npm:^6.0.3"
-    "@kids-reporter/draft-renderer": "npm:^1.0.27"
+    "@kids-reporter/draft-renderer": "npm:^1.0.28"
     "@twreporter/errors": "npm:^1.1.2"
     axios: "npm:^1.12.2"
     babel-loader: "npm:^8.3.0"
@@ -5155,7 +5155,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/draft-renderer@npm:^1.0.13, @kids-reporter/draft-renderer@npm:^1.0.27, @kids-reporter/draft-renderer@workspace:packages/draft-renderer":
+"@kids-reporter/draft-renderer@npm:^1.0.13, @kids-reporter/draft-renderer@npm:^1.0.28, @kids-reporter/draft-renderer@workspace:packages/draft-renderer":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/draft-renderer@workspace:packages/draft-renderer"
   dependencies:


### PR DESCRIPTION
## Summary

Fixes unwanted bottom spacing for annotation headings/lists, and bumps related workspace package versions to publish the change.

## Changes

- Force `margin-bottom: 0` for annotation `Heading` and `List` styles (including small breakpoint) using `!important`
- Bump `@kids-reporter/draft-renderer` to `1.0.28`
- Bump `@kids-reporter/draft-editor` to `1.0.32` and update its renderer dependency
- Bump `@kids-reporter/cms-core` to `1.0.32` and update its editor dependency
- Update `yarn.lock` to reflect version changes

## Screenshot(s)

## Reference(s)