### PR TITLE
fix(draft-editor): stabilize entity edit pen for hyperlinks

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/cms-core",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "description": "",
   "main": "lib/index.js",
   "types": "src/index.ts",
@@ -36,7 +36,7 @@
     "@keystone-ui/button": "^7.0.2",
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",
-    "@kids-reporter/draft-editor": "^1.0.32",
+    "@kids-reporter/draft-editor": "^1.0.33",
     "@twreporter/errors": "^1.1.1",
     "axios": "^0.26.0",
     "draft-convert": "^2.1.12",

--- a/packages/draft-editor/package.json
+++ b/packages/draft-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/draft-editor",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-editor/src/entity-decorators/wrapper.tsx
+++ b/packages/draft-editor/src/entity-decorators/wrapper.tsx
@@ -3,14 +3,20 @@ import styled from 'styled-components'
 
 const Wrapper = styled.span`
   display: inline;
+  padding-right: 1.25em;
   color: #8e8e8e;
 `
 
-const EditButton = styled.div`
-  display: inline;
+const EditButton = styled.span`
+  position: absolute;
+  right: -20px;
   cursor: pointer;
-  padding-left: 2px;
-  padding-right: 2px;
+  user-select: none;
+`
+
+const IconAnchor = styled.span`
+  display: inline;
+  position: relative;
 `
 
 export const EditableWrapper = (props: {
@@ -20,9 +26,15 @@ export const EditableWrapper = (props: {
   return (
     <Wrapper>
       {props.component}
-      <EditButton onClick={props.onClick}>
-        <i className="fas fa-pen"></i>
-      </EditButton>
+      <IconAnchor>
+        <EditButton
+          contentEditable={false}
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={props.onClick}
+        >
+          <i className="fas fa-pen"></i>
+        </EditButton>
+      </IconAnchor>
     </Wrapper>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5058,7 +5058,7 @@ __metadata:
     "@keystone-ui/button": "npm:^7.0.2"
     "@keystone-ui/fields": "npm:^7.2.0"
     "@keystone-ui/modals": "npm:^6.0.3"
-    "@kids-reporter/draft-editor": "npm:^1.0.32"
+    "@kids-reporter/draft-editor": "npm:^1.0.33"
     "@twreporter/errors": "npm:^1.1.1"
     axios: "npm:^0.26.0"
     draft-convert: "npm:^2.1.12"
@@ -5123,7 +5123,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/draft-editor@npm:^1.0.32, @kids-reporter/draft-editor@workspace:packages/draft-editor":
+"@kids-reporter/draft-editor@npm:^1.0.33, @kids-reporter/draft-editor@workspace:packages/draft-editor":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/draft-editor@workspace:packages/draft-editor"
   dependencies:


### PR DESCRIPTION
## Summary

Improves the draft editor’s inline pen control on decorated entities (for example hyperlinks): layout stays inline-friendly, clicking the pen does not disturb Draft.js selection/focus the way a raw mousedown on editable chrome can, and the pen is not itself editable.

## Changes

- **`EditableWrapper`** (`packages/draft-editor/src/entity-decorators/wrapper.tsx`): Wrapper `span` is `position: relative` with `padding-right` so the icon has room; pen control is a `styled.span` with `position: absolute` and `right: -20px` instead of an inline `styled.div` with horizontal padding.
- **Editor behavior**: `contentEditable={false}` on the pen; `onMouseDown` uses `preventDefault()` so the control does not steal focus or move the caret before `onClick`; `user-select: none` on the pen.
- **DOM**: Inner `span` with `display: inline` and `position: relative` wraps the pen for positioning.

## Screenshot(s)


https://github.com/user-attachments/assets/0c6f9fb0-15db-4457-81aa-1d416b9969b9


## Reference(s)

- [Notion Page (CMS bug)](https://www.notion.so/twreporter/CMS-bug-25a8dbdca932808b99e5fe51b3894c47?source=copy_link)