### PR TITLE
feat(draft-editor): add trailing buffer for link editing

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/cms-core",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "",
   "main": "lib/index.js",
   "types": "src/index.ts",
@@ -36,7 +36,7 @@
     "@keystone-ui/button": "^7.0.2",
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",
-    "@kids-reporter/draft-editor": "^1.0.33",
+    "@kids-reporter/draft-editor": "^1.0.34",
     "@twreporter/errors": "^1.1.1",
     "axios": "^0.26.0",
     "draft-convert": "^2.1.12",

--- a/packages/draft-editor/package.json
+++ b/packages/draft-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/draft-editor",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-editor/src/buttons/link.tsx
+++ b/packages/draft-editor/src/buttons/link.tsx
@@ -3,6 +3,7 @@ import { EditorState, RichUtils } from 'draft-js'
 import { useState } from 'react'
 
 import { LinkEditor } from '../entity-decorators/link'
+import { appendLinkCreateTrailingBuffer } from '../utils/link-trailing-buffer'
 
 export const LinkButton = (props: {
   className?: string
@@ -35,13 +36,13 @@ export const LinkButton = (props: {
     const newEditorState = EditorState.set(editorState, {
       currentContent: contentStateWithEntity,
     })
-    onChange(
-      RichUtils.toggleLink(
-        newEditorState,
-        newEditorState.getSelection(),
-        entityKey
-      )
+    let next = RichUtils.toggleLink(
+      newEditorState,
+      newEditorState.getSelection(),
+      entityKey
     )
+    next = appendLinkCreateTrailingBuffer(next)
+    onChange(next)
 
     setToShowUrlInput(false)
     props.onEditFinish()

--- a/packages/draft-editor/src/utils/link-trailing-buffer.ts
+++ b/packages/draft-editor/src/utils/link-trailing-buffer.ts
@@ -1,0 +1,32 @@
+import { EditorState, Modifier } from 'draft-js'
+
+/** Draft has no zero-length entity; ZWSP gives a neutral tail after a new link. */
+const LINK_TRAILING_BUFFER = '\u200b'
+
+/**
+ * After toggleLink, collapse to range end and insert a zero-width buffer
+ * without link entity so IME / typing can continue outside the link span.
+ */
+export function appendLinkCreateTrailingBuffer(
+  editorState: EditorState
+): EditorState {
+  const sel = editorState.getSelection()
+  const collapsed = sel.merge({
+    anchorKey: sel.getEndKey(),
+    anchorOffset: sel.getEndOffset(),
+    focusKey: sel.getEndKey(),
+    focusOffset: sel.getEndOffset(),
+    isBackward: false,
+  })
+
+  const withSelection = EditorState.acceptSelection(editorState, collapsed)
+  const content = Modifier.insertText(
+    withSelection.getCurrentContent(),
+    withSelection.getSelection(),
+    LINK_TRAILING_BUFFER,
+    withSelection.getCurrentInlineStyle(),
+    undefined
+  )
+
+  return EditorState.push(withSelection, content, 'insert-characters')
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5058,7 +5058,7 @@ __metadata:
     "@keystone-ui/button": "npm:^7.0.2"
     "@keystone-ui/fields": "npm:^7.2.0"
     "@keystone-ui/modals": "npm:^6.0.3"
-    "@kids-reporter/draft-editor": "npm:^1.0.33"
+    "@kids-reporter/draft-editor": "npm:^1.0.34"
     "@twreporter/errors": "npm:^1.1.1"
     axios: "npm:^0.26.0"
     draft-convert: "npm:^2.1.12"
@@ -5123,7 +5123,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/draft-editor@npm:^1.0.33, @kids-reporter/draft-editor@workspace:packages/draft-editor":
+"@kids-reporter/draft-editor@npm:^1.0.34, @kids-reporter/draft-editor@workspace:packages/draft-editor":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/draft-editor@workspace:packages/draft-editor"
   dependencies:


### PR DESCRIPTION
## Summary

When users create a hyperlink from a selection in the Draft.js editor, the collapsed caret can still behave as if typing continues inside the link entity, which breaks or confuses further input (including IME). This change adds a zero-width space (U+200B) immediately after the new link and clears the link entity from that character when Draft incorrectly extends the link onto it, establishing a stable insertion point outside the link span.

## Changes

- Add `packages/draft-editor/src/utils/link-trailing-buffer.ts` exporting `appendLinkCreateTrailingBuffer()`: collapse selection to the range end, insert ZWSP via `Modifier.insertText`, and if the inserted character has the link entity, strip it with `Modifier.applyEntity(..., null)` on that one-character range; includes defensive `safeEntityType` for missing or invalid entity keys.
- Update `packages/draft-editor/src/buttons/link.tsx` to apply the helper after `RichUtils.toggleLink` and before `onChange` when finishing link creation from the URL flow.

## Screenshot(s)


## Reference(s)

- [Notion – CMS bug](https://www.notion.so/twreporter/CMS-bug-25a8dbdca932808b99e5fe51b3894c47?source=copy_link)