### PR TITLE
feat(draft-editor): add trailing buffer for annotation editing

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/cms-core",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "description": "",
   "main": "lib/index.js",
   "types": "src/index.ts",
@@ -36,7 +36,7 @@
     "@keystone-ui/button": "^7.0.2",
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",
-    "@kids-reporter/draft-editor": "^1.0.34",
+    "@kids-reporter/draft-editor": "^1.0.35",
     "@twreporter/errors": "^1.1.1",
     "axios": "^0.26.0",
     "draft-convert": "^2.1.12",

--- a/packages/draft-editor/package.json
+++ b/packages/draft-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/draft-editor",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-editor/src/buttons/annotation.tsx
+++ b/packages/draft-editor/src/buttons/annotation.tsx
@@ -3,6 +3,7 @@ import { convertToRaw, EditorState, RichUtils } from 'draft-js'
 import { useState } from 'react'
 
 import { AnnotationEditor } from '../entity-decorators/annotation'
+import { appendLinkCreateTrailingBuffer } from '../utils/link-trailing-buffer'
 
 type AnnotationButtonProps = {
   className?: string
@@ -42,9 +43,13 @@ export const AnnotationButton = (props: AnnotationButtonProps) => {
       currentContent: contentStateWithEntity,
     })
 
-    onChange(
-      toggleEntity(newEditorState, newEditorState.getSelection(), entityKey)
+    let next = toggleEntity(
+      newEditorState,
+      newEditorState.getSelection(),
+      entityKey
     )
+    next = appendLinkCreateTrailingBuffer(next)
+    onChange(next)
 
     setToShowInput(false)
     props.onEditFinish()

--- a/packages/draft-editor/src/utils/link-trailing-buffer.ts
+++ b/packages/draft-editor/src/utils/link-trailing-buffer.ts
@@ -1,11 +1,11 @@
 import { EditorState, Modifier } from 'draft-js'
 
-/** Draft has no zero-length entity; ZWSP gives a neutral tail after a new link. */
+/** Draft has no zero-length entity; ZWSP gives a neutral tail after a new mutable inline span. */
 const LINK_TRAILING_BUFFER = '\u200b'
 
 /**
- * After toggleLink, collapse to range end and insert a zero-width buffer
- * without link entity so IME / typing can continue outside the link span.
+ * After toggleLink (link, annotation, etc.), collapse to range end and insert
+ * a zero-width buffer without inline entity so IME / typing can continue outside the span.
  */
 export function appendLinkCreateTrailingBuffer(
   editorState: EditorState

--- a/packages/draft-editor/src/utils/link-trailing-buffer.ts
+++ b/packages/draft-editor/src/utils/link-trailing-buffer.ts
@@ -6,16 +6,32 @@ const LINK_TRAILING_BUFFER = '\u200b'
 /**
  * After toggleLink (link, annotation, etc.), collapse to range end and insert
  * a zero-width buffer without inline entity so IME / typing can continue outside the span.
+ * Skips insertion when a ZWSP already sits at the insertion point, or the caret
+ * is after a trailing ZWSP at block end (avoids accumulation on repeat apply).
  */
 export function appendLinkCreateTrailingBuffer(
   editorState: EditorState
 ): EditorState {
   const sel = editorState.getSelection()
+  const endKey = sel.getEndKey()
+  const endOffset = sel.getEndOffset()
+  const block = editorState.getCurrentContent().getBlockForKey(endKey)
+  const text = block.getText()
+  const nextIsZwsp =
+    endOffset < text.length && text.charAt(endOffset) === LINK_TRAILING_BUFFER
+  const atBlockEndAfterZwsp =
+    endOffset === text.length &&
+    endOffset > 0 &&
+    text.charAt(endOffset - 1) === LINK_TRAILING_BUFFER
+  if (nextIsZwsp || atBlockEndAfterZwsp) {
+    return editorState
+  }
+
   const collapsed = sel.merge({
-    anchorKey: sel.getEndKey(),
-    anchorOffset: sel.getEndOffset(),
-    focusKey: sel.getEndKey(),
-    focusOffset: sel.getEndOffset(),
+    anchorKey: endKey,
+    anchorOffset: endOffset,
+    focusKey: endKey,
+    focusOffset: endOffset,
     isBackward: false,
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5058,7 +5058,7 @@ __metadata:
     "@keystone-ui/button": "npm:^7.0.2"
     "@keystone-ui/fields": "npm:^7.2.0"
     "@keystone-ui/modals": "npm:^6.0.3"
-    "@kids-reporter/draft-editor": "npm:^1.0.34"
+    "@kids-reporter/draft-editor": "npm:^1.0.35"
     "@twreporter/errors": "npm:^1.1.1"
     axios: "npm:^0.26.0"
     draft-convert: "npm:^2.1.12"
@@ -5123,7 +5123,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/draft-editor@npm:^1.0.34, @kids-reporter/draft-editor@workspace:packages/draft-editor":
+"@kids-reporter/draft-editor@npm:^1.0.35, @kids-reporter/draft-editor@workspace:packages/draft-editor":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/draft-editor@workspace:packages/draft-editor"
   dependencies:


### PR DESCRIPTION
## Summary

When a new annotation inline entity is applied, Draft.js leaves the caret inside the entity span, which makes continued typing or IME composition behave like it is still “inside” the annotation. This change reuses the same zero-width space (ZWSP) trailing buffer used after link creation so the selection lands in neutral text after the span, matching the link flow and improving editability.

## Changes

- `packages/draft-editor/src/buttons/annotation.tsx`: After `toggleEntity`, call `appendLinkCreateTrailingBuffer` before `onChange`, so new annotations get a trailing buffer like links.
- `packages/draft-editor/src/utils/link-trailing-buffer.ts`: Clarify JSDoc that the helper applies after toggling mutable inline spans (link, annotation, etc.), not only links.
- Version bump `1.0.34` →35` for `@kids-reporter/draft-editor` and `@kids-reporter/cms-core` dependency, plus `yarn.lock` resolution updates.

## Additional Notes

- **Publishing**: Core pins the new draft-editor range so installs pick up the published package once released.
- **Risks / edge cases**: The buffer is a literal ZWSP character in the document; downstream export or display pipelines should treat it consistently with how link creation already does. If `appendLinkCreateTrailingBuffer` were ever invoked when a buffer is already present at the caret, you could get an extra ZWSP; the current annotation flow only runs it once at create time.

## Screenshot(s)


## Reference(s)