### PR TITLE
chore(db,api-types): make db and api-types packages public

### DIFF
--- a/packages/api-types/package.json
+++ b/packages/api-types/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "type": "module",
   "license": "MIT",
-  "private": true,
   "files": [
     "dist"
   ],

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "type": "module",
   "license": "MIT",
-  "private": true,
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary

Removes `private: true` from the `packages/db` and `packages/api-types` package manifests so these workspaces are no longer marked npm-private. That aligns them with publishing or consumption patterns that skip or block private packages.

## Changes

- `packages/db/package.json`: removed the `private` field.
- `packages/api-types/package.json`: removed the `private` field.

## Screenshot(s)



## Reference(s)


