### PR TITLE
chore(content-api,db): align Docker postinstall with Prisma and refresh deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
   },
   "lint-staged": {
     "packages/api-gateway/**/*.{js,ts,jsx,tsx}": "cd packages/api-gateway && eslint --config eslint.config.mjs --cache --fix",
+    "packages/content-api/**/*.{js,ts,jsx,tsx}": "cd packages/content-api && eslint --config eslint.config.mjs --cache --fix",
+    "packages/db/**/*.{js,ts,jsx,tsx}": "cd packages/db && eslint --config eslint.config.mjs --cache --fix",
+    "packages/api-types/**/*.{js,ts,jsx,tsx}": "cd packages/api-types && eslint --config eslint.config.mjs --cache --fix",
+    "packages/logger/**/*.{js,ts,jsx,tsx}": "cd packages/logger && eslint --config eslint.config.mjs --cache --fix",
     "packages/cms/**/*.{js,ts,jsx,tsx}": "cd packages/cms && eslint --config eslint.config.mjs --cache --fix",
     "packages/core/**/*.{js,ts,jsx,tsx}": "cd packages/core && eslint --config eslint.config.mjs --cache --fix",
     "packages/cronjob/**/*.{js,ts,jsx,tsx}": "cd packages/cronjob && eslint --config eslint.config.mjs --cache --fix",
@@ -59,7 +63,8 @@
   "resolutions": {
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "next": "14.2.35"
+    "next": "14.2.35",
+    "@types/express-serve-static-core": "4.19.5"
   },
   "version": "0.0.0",
   "packageManager": "yarn@4.9.4"

--- a/packages/content-api/Dockerfile
+++ b/packages/content-api/Dockerfile
@@ -6,8 +6,9 @@ RUN corepack enable
 
 WORKDIR /build
 
-# copy from root at build time (in cloudbuild.yaml)
-COPY package.json yarn.lock .yarnrc.yml /build/
+# copy from root at build time (in cloudbuild.yaml).
+# Makefile must exist before install: postinstall runs `make postinstall` (db-generate, etc.).
+COPY package.json yarn.lock .yarnrc.yml Makefile /build/
 
 RUN SKIP_BUILD_DEPS=true DB_GENERATE_LOCAL=false yarn install --immutable
 

--- a/packages/content-api/package.json
+++ b/packages/content-api/package.json
@@ -2,7 +2,6 @@
   "name": "@kids-reporter/content-api",
   "type": "module",
   "version": "0.0.1",
-  "packageManager": "yarn@4.9.4",
   "private": true,
   "scripts": {
     "dev": "make dev",
@@ -27,15 +26,19 @@
     "dotenv-cli": "^10.0.0",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.2",
-    "multer": "^1.4.5-lts.1",
+    "multer": "^2.1.1",
     "swagger-ui-express": "^5.0.1"
+  },
+  "resolutions": {
+    "@types/express": "4.17.20",
+    "@types/express-serve-static-core": "4.19.5"
   },
   "devDependencies": {
     "@types/cookie-parser": "^1.4.6",
     "@types/cors": "^2.8.15",
     "@types/express": "^4.17.20",
     "@types/jsonwebtoken": "^9.0.6",
-    "@types/multer": "^1.4.12",
+    "@types/multer": "^2.1.0",
     "@types/supertest": "^6.0.3",
     "@types/swagger-ui-express": "^4.1.8",
     "nodemon": "^3.1.10",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/db",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "license": "MIT",
   "files": [
@@ -16,10 +16,10 @@
     }
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json && sh scripts/copy-schema-to-dist.sh",
+    "build": "sh scripts/copy-schema-to-dist.sh && prisma generate --schema dist/schema.prisma && tsc -p tsconfig.json",
     "type-check": "tsc --noEmit -p tsconfig.json",
     "lint:check": "eslint src --ext .ts",
-    "db:generate": "prisma generate --schema dist/schema.prisma"
+    "db:generate": "sh scripts/copy-schema-to-dist.sh && prisma generate --schema dist/schema.prisma"
   },
   "dependencies": {
     "@prisma/client": "5.22.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5332,7 +5332,7 @@ __metadata:
     "@types/cors": "npm:^2.8.15"
     "@types/express": "npm:^4.17.20"
     "@types/jsonwebtoken": "npm:^9.0.6"
-    "@types/multer": "npm:^1.4.12"
+    "@types/multer": "npm:^2.1.0"
     "@types/supertest": "npm:^6.0.3"
     "@types/swagger-ui-express": "npm:^4.1.8"
     axios: "npm:^1.4.0"
@@ -5341,7 +5341,7 @@ __metadata:
     dotenv-cli: "npm:^10.0.0"
     express: "npm:^4.18.2"
     jsonwebtoken: "npm:^9.0.2"
-    multer: "npm:^1.4.5-lts.1"
+    multer: "npm:^2.1.1"
     nodemon: "npm:^3.1.10"
     prisma: "npm:5.22.0"
     supertest: "npm:^7.1.4"
@@ -5364,7 +5364,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/db@npm:^0.0.1, @kids-reporter/db@workspace:packages/db":
+"@kids-reporter/db@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "@kids-reporter/db@npm:0.0.1"
+  dependencies:
+    "@prisma/client": "npm:5.22.0"
+  checksum: 10c0/7596f29b9cb3c4ca902d2843fda0b6e5bcae44fbeea3e492756e0779dccc21d6e51cf54b02e42aa80095abf7d3d2e508d7e50f5527eaac85dfb4f6347d3d33ef
+  languageName: node
+  linkType: hard
+
+"@kids-reporter/db@workspace:packages/db":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/db@workspace:packages/db"
   dependencies:
@@ -8046,15 +8055,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/express-serve-static-core@npm:*, @types/express-serve-static-core@npm:^4.17.30, @types/express-serve-static-core@npm:^4.17.33":
-  version: 4.17.43
-  resolution: "@types/express-serve-static-core@npm:4.17.43"
+"@types/express-serve-static-core@npm:4.19.5":
+  version: 4.19.5
+  resolution: "@types/express-serve-static-core@npm:4.19.5"
   dependencies:
     "@types/node": "npm:*"
     "@types/qs": "npm:*"
     "@types/range-parser": "npm:*"
     "@types/send": "npm:*"
-  checksum: 10c0/12480527eef86ad9f748d785811c88e6bb89f4a76e531cf2e18f1f4f0743e46783cf4d27a939dec96aec8770c54c060d9e697bb8544ecd202098140688c3b222
+  checksum: 10c0/ba8d8d976ab797b2602c60e728802ff0c98a00f13d420d82770f3661b67fa36ea9d3be0b94f2ddd632afe1fbc6e41620008b01db7e4fabdd71a2beb5539b0725
   languageName: node
   linkType: hard
 
@@ -8170,12 +8179,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/multer@npm:^1.4.12":
-  version: 1.4.13
-  resolution: "@types/multer@npm:1.4.13"
+"@types/multer@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@types/multer@npm:2.1.0"
   dependencies:
     "@types/express": "npm:*"
-  checksum: 10c0/aed716fdc0bc8c5bfe6689bfe6569b6743b64be795140e80cab169bfe43f687027880b7fc401fca98f820dd464ad5986093ec322d865116eb31ce29a3361c469
+  checksum: 10c0/f1f512918f79c5dac007d8d30de74372ad24932b34b43d09f250178dcce6da426297e0ea9c939322545519f133cd525dca0552781967d05f43d782ff0b169333
   languageName: node
   linkType: hard
 
@@ -9805,7 +9814,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"busboy@npm:1.6.0, busboy@npm:^1.0.0, busboy@npm:^1.6.0":
+"busboy@npm:1.6.0, busboy@npm:^1.6.0":
   version: 1.6.0
   resolution: "busboy@npm:1.6.0"
   dependencies:
@@ -10320,15 +10329,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"concat-stream@npm:^1.5.2":
-  version: 1.6.2
-  resolution: "concat-stream@npm:1.6.2"
+"concat-stream@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "concat-stream@npm:2.0.0"
   dependencies:
     buffer-from: "npm:^1.0.0"
     inherits: "npm:^2.0.3"
-    readable-stream: "npm:^2.2.2"
+    readable-stream: "npm:^3.0.2"
     typedarray: "npm:^0.0.6"
-  checksum: 10c0/2e9864e18282946dabbccb212c5c7cec0702745e3671679eb8291812ca7fd12023f7d8cb36493942a62f770ac96a7f90009dc5c82ad69893438371720fa92617
+  checksum: 10c0/29565dd9198fe1d8cf57f6cc71527dbc6ad67e12e4ac9401feb389c53042b2dceedf47034cbe702dfc4fd8df3ae7e6bfeeebe732cc4fa2674e484c13f04c219a
   languageName: node
   linkType: hard
 
@@ -15418,17 +15427,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:^0.5.4":
-  version: 0.5.6
-  resolution: "mkdirp@npm:0.5.6"
-  dependencies:
-    minimist: "npm:^1.2.6"
-  bin:
-    mkdirp: bin/cmd.js
-  checksum: 10c0/e2e2be789218807b58abced04e7b49851d9e46e88a2f9539242cc8a92c9b5c3a0b9bab360bd3014e02a140fc4fbc58e31176c408b493f8a2a6f4986bd7527b01
-  languageName: node
-  linkType: hard
-
 "mrmime@npm:^2.0.0":
   version: 2.0.1
   resolution: "mrmime@npm:2.0.1"
@@ -15450,18 +15448,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"multer@npm:^1.4.5-lts.1":
-  version: 1.4.5-lts.2
-  resolution: "multer@npm:1.4.5-lts.2"
+"multer@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "multer@npm:2.1.1"
   dependencies:
     append-field: "npm:^1.0.0"
-    busboy: "npm:^1.0.0"
-    concat-stream: "npm:^1.5.2"
-    mkdirp: "npm:^0.5.4"
-    object-assign: "npm:^4.1.1"
-    type-is: "npm:^1.6.4"
-    xtend: "npm:^4.0.0"
-  checksum: 10c0/59c934621bde284e04e25aa35ef79f8a9ed0c2ac4c5bae4c2880670105ec1645480ae57a84ed92323b2a8d8f875ca3189ad8a18fa0ed0bdc6fd26553d9426883
+    busboy: "npm:^1.6.0"
+    concat-stream: "npm:^2.0.0"
+    type-is: "npm:^1.6.18"
+  checksum: 10c0/2ec4e02833b20f403cfb879d4b64d2a9070d902b9deae7aef18a6faadb707d7665385456cf540aa8a6dadfe3d4c5fc8e0e7b0675b94e1077048b1125426deee6
   languageName: node
   linkType: hard
 
@@ -17123,7 +17118,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^2.0.1, readable-stream@npm:^2.2.2":
+"readable-stream@npm:^2.0.1":
   version: 2.3.8
   resolution: "readable-stream@npm:2.3.8"
   dependencies:
@@ -17138,7 +17133,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^3.0.6, readable-stream@npm:^3.1.1, readable-stream@npm:^3.5.0":
+"readable-stream@npm:^3.0.2, readable-stream@npm:^3.0.6, readable-stream@npm:^3.1.1, readable-stream@npm:^3.5.0":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
   dependencies:
@@ -19360,7 +19355,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-is@npm:^1.6.4, type-is@npm:~1.6.18":
+"type-is@npm:^1.6.18, type-is@npm:~1.6.18":
   version: 1.6.18
   resolution: "type-is@npm:1.6.18"
   dependencies:
@@ -20438,13 +20433,6 @@ __metadata:
   version: 1.0.1
   resolution: "xml@npm:1.0.1"
   checksum: 10c0/04bcc9b8b5e7b49392072fbd9c6b0f0958bd8e8f8606fee460318e43991349a68cbc5384038d179ff15aef7d222285f69ca0f067f53d071084eb14c7fdb30411
-  languageName: node
-  linkType: hard
-
-"xtend@npm:^4.0.0":
-  version: 4.0.2
-  resolution: "xtend@npm:4.0.2"
-  checksum: 10c0/366ae4783eec6100f8a02dff02ac907bf29f9a00b82ac0264b4d8b832ead18306797e283cf19de776538babfdcb2101375ec5646b59f08c52128ac4ab812ed0e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This PR tightens the **content-api Docker image build** so `yarn install` can run root postinstall hooks that invoke the Makefile, reorders **content-api** `postinstall` so **Prisma client generation** runs before heavier build deps, bumps **multer** (and related types) with **Express type resolutions** to keep TypeScript stable, and updates **`@kids-reporter/db`** so the **build** and **`db:generate`** scripts copy the Prisma schema into `dist` and run **`prisma generate`** before **`tsc`**. Root **lint-staged** gains entries for more packages, and **`yarn.lock`** reflects the dependency refresh (large diff).

## Changes

- **packages/content-api/Dockerfile**: `COPY` the repo **Makefile** into the image before `yarn install` so postinstall can run `make postinstall` as documented in comments.
- **packages/content-api/Makefile**: `postinstall` target order is **`db-generate` then `build-deps`** (was the reverse).
- **packages/content-api/package.json**: remove redundant **`packageManager`** field; upgrade **multer** to **^2.1.1** and **@types/multer** to **^2.1.0**; add **`resolutions`** for **@types/express** and **@types/express-serve-static-core**.
- **package.json (root)**: add **lint-staged** globs for **content-api**, **db**, **api-types**, and **logger**; add root **`resolutions`** entry for **@types/express-serve-static-core** **4.19.5**.
- **packages/db/package.json**: bump version **0.0.1 → 0.0.2**; **`build`** runs **copy-schema → prisma generate → tsc**; **`db:generate`** ensures schema copy before generate.
- **yarn.lock**: regenerated for the above (wide transitive updates).

## Additional Notes


## Screenshot(s)


## Reference(s)