### PR TITLE
feat(content-api): add preview server ACL for post by-slug reads

### DIFF
--- a/packages/content-api/.env.example
+++ b/packages/content-api/.env.example
@@ -15,3 +15,12 @@ DATABASE_URL=postgres://user:password@localhost:5432/kids
 
 # Optional
 REQUEST_TIMEOUT_MS=10000
+
+# Preview-only content-api (internal Cloud Run). When true, GET /v1/posts/by-slug/*
+# returns draft/unpublished posts. Do not set on public content-api.
+IS_PREVIEW_SERVER=false
+
+# Preview deployment (GCP, not local dev):
+# - Deploy a separate internal content-api service with IS_PREVIEW_SERVER=true
+# - Point preview frontend INTERNAL_CONTENT_API_ENDPOINT at that service (SSR/RSC)
+# - Keep NEXT_PUBLIC_CONTENT_API_ENDPOINT on the public content-api URL for browser calls

--- a/packages/content-api/src/environment-variables.ts
+++ b/packages/content-api/src/environment-variables.ts
@@ -10,7 +10,10 @@ const {
   GO_API_JWT_ISSUER,
   GO_API_JWT_AUDIENCE,
   IMAGES_STORAGE_PATH,
+  IS_PREVIEW_SERVER,
 } = process.env
+
+const isPreviewServer = IS_PREVIEW_SERVER === 'true'
 
 const parsedRequestTimeoutMs = Number(REQUEST_TIMEOUT_MS)
 const requestTimeoutMs =
@@ -63,6 +66,7 @@ const envVar = {
     /** Local filesystem root for Keystone `images` storage (member avatars). */
     storagePath: IMAGES_STORAGE_PATH || '',
   },
+  isPreviewServer,
 }
 
 if (envVar.cors.allowOrigins === '*') {

--- a/packages/content-api/src/queries/post-detail.ts
+++ b/packages/content-api/src/queries/post-detail.ts
@@ -16,7 +16,7 @@ import {
 } from '../utils/qna-utils.js'
 import {
   asOrderJson,
-  buildPostVisibilityWhere,
+  buildPostBySlugVisibilityWhere,
   buildPublicPostWhere,
   buildResizedLarge,
   buildResizedMedium,
@@ -316,11 +316,11 @@ export async function fetchPostDetailBySlug(
   now: Date,
   opts: PostDetailQueryOpts
 ): Promise<V1PostDetailBody | null> {
-  const publicWhere = buildPostVisibilityWhere(now)
+  const where = buildPostBySlugVisibilityWhere(now)
   const newsReadingOrder = newsReadingItemsOrderBy([{ order: 'asc' }])
   const relatedPostsWhere: Prisma.PostWhereInput = { slug: { notIn: [slug] } }
   const post = await prisma.post.findFirst({
-    where: { AND: [{ slug }, publicWhere] },
+    where: { AND: [{ slug }, where] },
     select: {
       opening: true,
       title: true,
@@ -517,9 +517,9 @@ export async function fetchPostMetaBySlug(
   slug: string,
   now: Date
 ): Promise<V1PostMetaBody | null> {
-  const publicWhere = buildPostVisibilityWhere(now)
+  const where = buildPostBySlugVisibilityWhere(now)
   const post = await prisma.post.findFirst({
-    where: { AND: [{ slug }, publicWhere] },
+    where: { AND: [{ slug }, where] },
     select: {
       publishedDate: true,
       ogDescription: true,
@@ -558,9 +558,9 @@ export async function fetchPostEssayQuestionsBySlug(
   slug: string,
   now: Date
 ): Promise<V1PostEssayQuestionsBody | null> {
-  const publicWhere = buildPostVisibilityWhere(now)
+  const where = buildPostBySlugVisibilityWhere(now)
   const post = await prisma.post.findFirst({
-    where: { AND: [{ slug }, publicWhere] },
+    where: { AND: [{ slug }, where] },
     select: {
       id: true,
       slug: true,

--- a/packages/content-api/src/queries/post-detail.ts
+++ b/packages/content-api/src/queries/post-detail.ts
@@ -16,6 +16,7 @@ import {
 } from '../utils/qna-utils.js'
 import {
   asOrderJson,
+  buildPostVisibilityWhere,
   buildPublicPostWhere,
   buildResizedLarge,
   buildResizedMedium,
@@ -315,7 +316,7 @@ export async function fetchPostDetailBySlug(
   now: Date,
   opts: PostDetailQueryOpts
 ): Promise<V1PostDetailBody | null> {
-  const publicWhere = buildPublicPostWhere(now)
+  const publicWhere = buildPostVisibilityWhere(now)
   const newsReadingOrder = newsReadingItemsOrderBy([{ order: 'asc' }])
   const relatedPostsWhere: Prisma.PostWhereInput = { slug: { notIn: [slug] } }
   const post = await prisma.post.findFirst({
@@ -516,7 +517,7 @@ export async function fetchPostMetaBySlug(
   slug: string,
   now: Date
 ): Promise<V1PostMetaBody | null> {
-  const publicWhere = buildPublicPostWhere(now)
+  const publicWhere = buildPostVisibilityWhere(now)
   const post = await prisma.post.findFirst({
     where: { AND: [{ slug }, publicWhere] },
     select: {
@@ -557,7 +558,7 @@ export async function fetchPostEssayQuestionsBySlug(
   slug: string,
   now: Date
 ): Promise<V1PostEssayQuestionsBody | null> {
-  const publicWhere = buildPublicPostWhere(now)
+  const publicWhere = buildPostVisibilityWhere(now)
   const post = await prisma.post.findFirst({
     where: { AND: [{ slug }, publicWhere] },
     select: {

--- a/packages/content-api/src/utils/v1-helpers.test.ts
+++ b/packages/content-api/src/utils/v1-helpers.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('buildPostVisibilityWhere', () => {
+  const now = new Date('2026-01-01T00:00:00.000Z')
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllEnvs()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('matches buildPublicPostWhere when IS_PREVIEW_SERVER is unset', async () => {
+    const { buildPostVisibilityWhere, buildPublicPostWhere } = await import(
+      './v1-helpers.js'
+    )
+    expect(buildPostVisibilityWhere(now)).toEqual(buildPublicPostWhere(now))
+  })
+
+  it('matches buildPublicPostWhere when IS_PREVIEW_SERVER is false', async () => {
+    vi.stubEnv('IS_PREVIEW_SERVER', 'false')
+    const { buildPostVisibilityWhere, buildPublicPostWhere } = await import(
+      './v1-helpers.js'
+    )
+    expect(buildPostVisibilityWhere(now)).toEqual(buildPublicPostWhere(now))
+  })
+
+  it('returns no status filter when IS_PREVIEW_SERVER is true', async () => {
+    vi.stubEnv('IS_PREVIEW_SERVER', 'true')
+    const { buildPostVisibilityWhere } = await import('./v1-helpers.js')
+    expect(buildPostVisibilityWhere(now)).toEqual({})
+  })
+})

--- a/packages/content-api/src/utils/v1-helpers.test.ts
+++ b/packages/content-api/src/utils/v1-helpers.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-describe('buildPostVisibilityWhere', () => {
+describe('buildPostBySlugVisibilityWhere', () => {
   const now = new Date('2026-01-01T00:00:00.000Z')
 
   beforeEach(() => {
@@ -13,23 +13,25 @@ describe('buildPostVisibilityWhere', () => {
   })
 
   it('matches buildPublicPostWhere when IS_PREVIEW_SERVER is unset', async () => {
-    const { buildPostVisibilityWhere, buildPublicPostWhere } = await import(
-      './v1-helpers.js'
+    const { buildPostBySlugVisibilityWhere, buildPublicPostWhere } =
+      await import('./v1-helpers.js')
+    expect(buildPostBySlugVisibilityWhere(now)).toEqual(
+      buildPublicPostWhere(now)
     )
-    expect(buildPostVisibilityWhere(now)).toEqual(buildPublicPostWhere(now))
   })
 
   it('matches buildPublicPostWhere when IS_PREVIEW_SERVER is false', async () => {
     vi.stubEnv('IS_PREVIEW_SERVER', 'false')
-    const { buildPostVisibilityWhere, buildPublicPostWhere } = await import(
-      './v1-helpers.js'
+    const { buildPostBySlugVisibilityWhere, buildPublicPostWhere } =
+      await import('./v1-helpers.js')
+    expect(buildPostBySlugVisibilityWhere(now)).toEqual(
+      buildPublicPostWhere(now)
     )
-    expect(buildPostVisibilityWhere(now)).toEqual(buildPublicPostWhere(now))
   })
 
   it('returns no status filter when IS_PREVIEW_SERVER is true', async () => {
     vi.stubEnv('IS_PREVIEW_SERVER', 'true')
-    const { buildPostVisibilityWhere } = await import('./v1-helpers.js')
-    expect(buildPostVisibilityWhere(now)).toEqual({})
+    const { buildPostBySlugVisibilityWhere } = await import('./v1-helpers.js')
+    expect(buildPostBySlugVisibilityWhere(now)).toEqual({})
   })
 })

--- a/packages/content-api/src/utils/v1-helpers.ts
+++ b/packages/content-api/src/utils/v1-helpers.ts
@@ -1,3 +1,5 @@
+import type { Prisma } from '@kids-reporter/db'
+
 import envVar from '../environment-variables.js'
 
 /** Match Keystone manual-order virtual: only IDs listed in JSON appear, in order (no trailing extras). */
@@ -28,6 +30,10 @@ export const buildPublicPostWhere = (now: Date) => ({
     },
   ],
 })
+
+/** Post visibility for by-slug reads. Preview server matches CMS preview_headless (no status filter). */
+export const buildPostVisibilityWhere = (now: Date): Prisma.PostWhereInput =>
+  envVar.isPreviewServer ? {} : buildPublicPostWhere(now)
 
 /** Category/subcategory virtual `relatedPosts` uses published OR archived only (see `packages/cms/lists/category.ts`). */
 export const buildCategoryFeedPostWhere = (subSubcategoryIds: number[]) => ({

--- a/packages/content-api/src/utils/v1-helpers.ts
+++ b/packages/content-api/src/utils/v1-helpers.ts
@@ -32,7 +32,9 @@ export const buildPublicPostWhere = (now: Date) => ({
 })
 
 /** Post visibility for by-slug reads. Preview server matches CMS preview_headless (no status filter). */
-export const buildPostVisibilityWhere = (now: Date): Prisma.PostWhereInput =>
+export const buildPostBySlugVisibilityWhere = (
+  now: Date
+): Prisma.PostWhereInput =>
   envVar.isPreviewServer ? {} : buildPublicPostWhere(now)
 
 /** Category/subcategory virtual `relatedPosts` uses published OR archived only (see `packages/cms/lists/category.ts`). */


### PR DESCRIPTION
## Summary

Introduces a preview-only content-api deployment mode so internal preview frontends can load draft and unpublished posts by slug, while the public content-api keeps the existing published/scheduled visibility rules.

## Changes

- Add `IS_PREVIEW_SERVER` env var (parsed in `environment-variables.ts`; documented in `.env.example` with GCP deployment notes)
- Add `buildPostBySlugWhere()` in `v1-helpers.ts`: returns `{}` (no status filter) when `IS_PREVIEW_SERVER=true`, otherwise delegates to `buildPublicPostWhere()` to match Keystone `preview_headless` behavior
- Switch post by-slug queries (`fetchPostDetailBySlug`, `fetchPostMetaBySlug`, `fetchPostEssayQuestionsBySlug`) from `buildPublicPostWhere` to `buildPostBySlugWhere`
- Add Vitest coverage for preview vs public where-clause behavior

## Additional Notes

- **Scope**: Only by-slug read paths change; list/feed/category visibility is unchanged.

## Screenshot(s)


## Reference(s)