### PR TITLE
fix(cloudbuild): only copy env file if it exists

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -42,9 +42,10 @@ steps:
 
         cd packages/$_TARGET_PACKAGE
 
-        echo "copy $_ENV_FILE to .env.local"
-
-        cp $_ENV_FILE .env.local
+        if [[ -n "$_ENV_FILE" && -f "$_ENV_FILE" ]]; then
+          echo "copy $_ENV_FILE to .env.local"
+          cp "$_ENV_FILE" .env.local
+        fi
 
         docker build -t \
           gcr.io/$PROJECT_ID/$_IMAGE_NAME:${BRANCH_NAME}_${SHORT_SHA} \


### PR DESCRIPTION
## Summary

Cloud Build was failing when `_ENV_FILE` was unset or pointed to a file that does not exist in the build workspace. This change makes the env copy step optional so builds can proceed for packages that do not need a local env file at image build time.

## Changes

- Guard the `.env.local` copy in `cloudbuild.yaml` with `[[ -n "$_ENV_FILE" && -f "$_ENV_FILE" ]]`
- Only log and run `cp` when the substitution is non-empty and the source file exists
- Quote paths in the `cp` command for safer shell handling

## Additional Notes

- **Why:** The unconditional `cp $_ENV_FILE .env.local` failed when `_ENV_FILE` defaulted to empty or when a trigger did not supply an env file (e.g. packages that do not use build-time env).

## Screenshot(s)



## Reference(s)

