### PR TITLE
fix(frontend): preserve whitespace blocks with TOC anchor entities

### DIFF
--- a/packages/frontend/src/modules/article/utils/trim-empty-blocks.ts
+++ b/packages/frontend/src/modules/article/utils/trim-empty-blocks.ts
@@ -4,9 +4,13 @@ function trimEmptyBlocks(raw: RawDraftContentState): RawDraftContentState {
   const { blocks, entityMap } = raw
   if (blocks.length === 0) return raw
 
-  const filtered = blocks.filter(
-    (block) => !(block.type === 'unstyled' && block.text.trim() === '')
-  )
+  const filtered = blocks.filter((block) => {
+    return (
+      block.type !== 'unstyled' ||
+      block.text.trim() !== '' ||
+      block.entityRanges.length !== 0
+    )
+  })
   if (filtered.length === blocks.length) return raw
 
   return { blocks: filtered, entityMap }


### PR DESCRIPTION
## Summary
Whitespace-only Draft.js blocks used as TOC anchors were being removed by `trimEmptyBlocks`, which caused those anchors to disappear from the table of contents. The trim logic now only removes empty `unstyled` blocks that have no entity ranges, so blocks that carry `TOC_ANCHOR` (or other) entities are kept.
## Changes
- Update `trimEmptyBlocks` in `packages/frontend/src/modules/article/utils/trim-empty-blocks.ts` to require `block.entityRanges.length === 0` before filtering an empty `unstyled` block
- Previously, any `unstyled` block with empty trimmed text was removed; now only blocks with no attached entities are removed
## Additional Notes
**Root cause:** CMS editors can mark whitespace as a TOC anchor. Those blocks are `unstyled` with empty `text` but non-empty `entityRanges` pointing at `TOC_ANCHOR` in `entityMap`. `parseTocIndexesFromEntityMap` reads anchors from `entityMap`, but trimming the block removed the anchor from rendered content and broke TOC behavior.
**Behavior after fix:**
- Empty spacer blocks with no entities — still trimmed (unchanged intent)
- Empty blocks with `TOC_ANCHOR` (or any entity) — preserved
## Screenshot(s)
## Reference(s)