### PR TITLE
feat(draft-editor,draft-renderer): add left alignment option for images

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/cms-core",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "",
   "main": "lib/index.js",
   "types": "src/index.ts",
@@ -36,7 +36,7 @@
     "@keystone-ui/button": "^7.0.2",
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",
-    "@kids-reporter/draft-editor": "^1.0.35",
+    "@kids-reporter/draft-editor": "^1.0.36",
     "@twreporter/errors": "^1.1.1",
     "axios": "^0.26.0",
     "draft-convert": "^2.1.12",

--- a/packages/draft-editor/package.json
+++ b/packages/draft-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/draft-editor",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -29,7 +29,7 @@
     "@keystone-ui/button": "^7.0.2",
     "@keystone-ui/fields": "^7.2.0",
     "@keystone-ui/modals": "^6.0.3",
-    "@kids-reporter/draft-renderer": "^1.0.28",
+    "@kids-reporter/draft-renderer": "^1.0.29",
     "@twreporter/errors": "^1.1.2",
     "axios": "^1.12.2",
     "draft-js": "^0.11.7"

--- a/packages/draft-editor/src/buttons/selector/image-selector.tsx
+++ b/packages/draft-editor/src/buttons/selector/image-selector.tsx
@@ -22,6 +22,7 @@ export const ImageAlignOptions = [
     label: '與文章段落等寬',
     isDisabled: false,
   },
+  { value: ImageAlignment.LEFT, label: '靠左', isDisabled: false },
   { value: ImageAlignment.RIGHT, label: '靠右', isDisabled: false },
 ]
 

--- a/packages/draft-renderer/package.json
+++ b/packages/draft-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/draft-renderer",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/draft-renderer/src/block-renderers/image-block.tsx
+++ b/packages/draft-renderer/src/block-renderers/image-block.tsx
@@ -92,6 +92,35 @@ const FigureCaption = styled.figcaption<{ $alignment?: string }>`
             text-align: left;
           }
         `
+      case 'left':
+        return `
+          text-align: left;
+          ${mediaQuery.smallOnly} {
+            max-width: 240px;
+            margin-left: 16px;
+          }
+
+          ${mediaQuery.mediumAbove} {
+            margin-left: 0px;
+            margin-right: 0px;
+          }
+
+          ${mediaQuery.desktopAbove} {
+            max-width: 128px;
+            position: absolute;
+            left: 0;
+            top: 100%;
+            margin-left: 0px;
+          }
+
+          ${mediaQuery.largeOnly} {
+            max-width: 240px;
+            position: absolute;
+            left: 0;
+            top: 100%;
+            margin-left: 0px;
+          }
+        `
       case 'right':
         return `
           text-align: left;
@@ -278,6 +307,26 @@ const ArticleBodyContainer = styled.div<{ $alignment?: string }>`
             max-width: 680px;
           }
         `
+      case 'left':
+        return `
+          ${mediaQuery.mediumAbove} {
+            width: 361px;
+            float: left;
+            margin: 0px 24px 20px 32px;
+          }
+
+          ${mediaQuery.desktopAbove} {
+            width: 368px;
+            float: left;
+            margin: 0px 32px 0px 0px;
+          }
+
+          ${mediaQuery.largeOnly} {
+            width: 451px;
+            float: left;
+            margin: 0px 40px 0px 0px;
+          }
+        `
       case 'right':
         return `
           ${mediaQuery.mediumAbove} {
@@ -341,6 +390,13 @@ export const InfoBoxContainer = styled.div<{ $alignment?: string }>`
 
   ${(props) => {
     switch (props.$alignment) {
+      case 'left': {
+        return `
+          width: 200px;
+          float: left;
+          margin: 20px 24px 20px 32px;
+        `
+      }
       case 'right': {
         return `
           width: 200px;

--- a/packages/draft-renderer/src/block-renderers/image-link.tsx
+++ b/packages/draft-renderer/src/block-renderers/image-link.tsx
@@ -103,6 +103,35 @@ const FigureCaption = styled.figcaption<{ $alignment?: string }>`
             text-align: left;
           }
         `
+      case 'left':
+        return `
+          text-align: left;
+          ${mediaQuery.smallOnly} {
+            max-width: 240px;
+            margin-left: 16px;
+          }
+
+          ${mediaQuery.mediumAbove} {
+            margin-left: 0px;
+            margin-right: 0px;
+          }
+
+          ${mediaQuery.desktopAbove} {
+            max-width: 128px;
+            position: absolute;
+            left: 0;
+            top: 100%;
+            margin-left: 0px;
+          }
+
+          ${mediaQuery.largeOnly} {
+            max-width: 240px;
+            position: absolute;
+            left: 0;
+            top: 100%;
+            margin-left: 0px;
+          }
+        `
       case 'right':
         return `
           text-align: left;
@@ -268,6 +297,26 @@ const ArticleBodyContainer = styled.div<{ $alignment?: string }>`
 
           ${mediaQuery.largeOnly} {
             max-width: 680px;
+          }
+        `
+      case 'left':
+        return `
+        ${mediaQuery.mediumAbove} {
+            width: 361px;
+            float: left;
+            margin: 0px 24px 20px 32px;
+          }
+
+          ${mediaQuery.desktopAbove} {
+            width: 368px;
+            float: left;
+            margin: 0px 32px 0px 0px;
+          }
+
+          ${mediaQuery.largeOnly} {
+            width: 451px;
+            float: left;
+            margin: 0px 40px 0px 0px;
           }
         `
       case 'right':

--- a/yarn.lock
+++ b/yarn.lock
@@ -5267,7 +5267,7 @@ __metadata:
     "@keystone-ui/button": "npm:^7.0.2"
     "@keystone-ui/fields": "npm:^7.2.0"
     "@keystone-ui/modals": "npm:^6.0.3"
-    "@kids-reporter/draft-editor": "npm:^1.0.35"
+    "@kids-reporter/draft-editor": "npm:^1.0.36"
     "@twreporter/errors": "npm:^1.1.1"
     axios: "npm:^0.26.0"
     draft-convert: "npm:^2.1.12"
@@ -5383,7 +5383,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/draft-editor@npm:^1.0.35, @kids-reporter/draft-editor@workspace:packages/draft-editor":
+"@kids-reporter/draft-editor@npm:^1.0.36, @kids-reporter/draft-editor@workspace:packages/draft-editor":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/draft-editor@workspace:packages/draft-editor"
   dependencies:
@@ -5396,7 +5396,7 @@ __metadata:
     "@keystone-ui/button": "npm:^7.0.2"
     "@keystone-ui/fields": "npm:^7.2.0"
     "@keystone-ui/modals": "npm:^6.0.3"
-    "@kids-reporter/draft-renderer": "npm:^1.0.28"
+    "@kids-reporter/draft-renderer": "npm:^1.0.29"
     "@twreporter/errors": "npm:^1.1.2"
     axios: "npm:^1.12.2"
     babel-loader: "npm:^8.3.0"
@@ -5415,7 +5415,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/draft-renderer@npm:^1.0.13, @kids-reporter/draft-renderer@npm:^1.0.28, @kids-reporter/draft-renderer@workspace:packages/draft-renderer":
+"@kids-reporter/draft-renderer@npm:^1.0.13, @kids-reporter/draft-renderer@npm:^1.0.29, @kids-reporter/draft-renderer@workspace:packages/draft-renderer":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/draft-renderer@workspace:packages/draft-renderer"
   dependencies:


### PR DESCRIPTION
## Summary

Adds a **靠左 (left)** image alignment option in the CMS draft editor and implements matching layout styles in the draft renderer. Editors can now float images to the left of article text, mirroring the existing right-align behavior. Package versions are bumped for publish (draft-renderer 1.0.29, draft-editor 1.0.36, cms-core 1.0.36).

## Changes

- **draft-editor** (image-selector.tsx): Expose ImageAlignment.LEFT (靠左) in the image alignment dropdown, between paragraph-width and right align options. The enum value already existed but was not selectable in the UI.
- **draft-renderer** (image-block.tsx, image-link.tsx): Add left case styling for FigureCaption, ArticleBodyContainer, and InfoBoxContainer with float-left layout and responsive widths/margins.
- **Version bumpds-reporter/draft-renderer → 1.0.29, @kids-reporter/draft-editor → 1.0.36, @kids-reporter/cms-core → 1.0.36; yarn.lock updated accordingly.

## Additional Notes

- Left-align styles are symmetric to the existing right-align implementation (float direction and margins flipped).

## Screenshot(s)



## Reference(s)


