### PR TITLE
chore(docker): update Dockerfiles and build scripts for Yarn v4 compatibility

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -115,3 +115,4 @@ substitutions:
   _ENV_FILE: '' # default value
   _DEPLOYMENT_TYPE: 'service' # default value
   _DOCKERFILE: 'Dockerfile' # default value
+  _USE_CONTENT_API: 'false' # default value

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -47,13 +47,17 @@ steps:
           cp "$_ENV_FILE" .env.local
         fi
 
+        DOCKER_BUILD_ARGS=(
+          --build-arg "DEPLOYMENT_ID=${SHORT_SHA}"
+          --build-arg "USE_CONTENT_API=$_USE_CONTENT_API"
+        )
+
         docker build -t \
-          gcr.io/$PROJECT_ID/$_IMAGE_NAME:${BRANCH_NAME}_${SHORT_SHA} \
-          -t gcr.io/$PROJECT_ID/$_IMAGE_NAME:latest \
+          "gcr.io/$PROJECT_ID/$_IMAGE_NAME:${BRANCH_NAME}_${SHORT_SHA}" \
+          -t "gcr.io/$PROJECT_ID/$_IMAGE_NAME:latest" \
           -f "$_DOCKERFILE" \
-          --build-arg DEPLOYMENT_ID=${SHORT_SHA} \
-          --build-arg USE_CONTENT_API=$_USE_CONTENT_API \
-          --cache-from gcr.io/$PROJECT_ID/$_IMAGE_NAME:latest .
+          "${DOCKER_BUILD_ARGS[@]}" \
+          --cache-from "gcr.io/$PROJECT_ID/$_IMAGE_NAME:latest" .
     entrypoint: bash
 
   # Push container image to registry

--- a/packages/api-gateway/Dockerfile
+++ b/packages/api-gateway/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /build
 # copy from root at build time (in cloudbuild.yaml)
 COPY package.json yarn.lock .yarnrc.yml /build/
 
-RUN yarn install --immutable
+RUN yarn install
 
 COPY . /build/
 

--- a/packages/api-gateway/package.json
+++ b/packages/api-gateway/package.json
@@ -2,6 +2,7 @@
   "name": "@kids-reporter/api-gateway",
   "type": "module",
   "version": "1.0.0",
+  "packageManager": "yarn@4.9.4",
   "scripts": {
     "dev": "make dev",
     "build": "make build",

--- a/packages/cms/Dockerfile
+++ b/packages/cms/Dockerfile
@@ -37,12 +37,10 @@ WORKDIR $APP_DIR
 COPY . $APP_DIR
 
 ## Install application dependencies
-RUN SKIP_BUILD_DEPS=true yarn install
+RUN SKIP_BUILD_DEPS=true yarn install && yarn cache clean --all
 
 ## Build application bundles
 RUN yarn build
-
-RUN yarn cache clean --all
 
 ## Ensure the script is executable
 RUN chmod +x run.sh

--- a/packages/cms/Dockerfile
+++ b/packages/cms/Dockerfile
@@ -37,12 +37,12 @@ WORKDIR $APP_DIR
 COPY . $APP_DIR
 
 ## Install application dependencies
-RUN SKIP_BUILD_DEPS=true yarn install --immutable
+RUN SKIP_BUILD_DEPS=true yarn install
 
 ## Build application bundles
 RUN yarn build
 
-RUN yarn cache clean
+RUN yarn cache clean --all
 
 ## Ensure the script is executable
 RUN chmod +x run.sh

--- a/packages/cms/Dockerfile.gql-only
+++ b/packages/cms/Dockerfile.gql-only
@@ -21,12 +21,12 @@ WORKDIR $APP_DIR
 COPY . $APP_DIR
 
 ## Install application dependencies
-RUN SKIP_BUILD_DEPS=true yarn install --immutable
+RUN SKIP_BUILD_DEPS=true yarn install
 
 ## Build application bundles
 RUN yarn build
 
-RUN yarn cache clean
+RUN yarn cache clean --all
 
 EXPOSE 3000
 

--- a/packages/cms/Dockerfile.gql-only
+++ b/packages/cms/Dockerfile.gql-only
@@ -21,12 +21,10 @@ WORKDIR $APP_DIR
 COPY . $APP_DIR
 
 ## Install application dependencies
-RUN SKIP_BUILD_DEPS=true yarn install
+RUN SKIP_BUILD_DEPS=true yarn install && yarn cache clean --all
 
 ## Build application bundles
 RUN yarn build
-
-RUN yarn cache clean --all
 
 EXPOSE 3000
 

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -10,7 +10,7 @@
     "db-migrate": "keystone prisma migrate deploy",
     "build": "keystone build",
     "lint:check": "eslint . --ext .ts,.tsx,.js,.jsx",
-    "postinstall": "bash -c 'SKIP_BUILD_DEPS=\"${SKIP_BUILD_DEPS:-}\" SKIP_PATCH_PACKAGE=\"${SKIP_PATCH_PACKAGE:-}\" make postinstall'",
+    "postinstall": "make postinstall",
     "type-check": "tsc --noEmit"
   },
   "repository": {

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@kids-reporter/cms",
   "version": "1.0.12",
+  "packageManager": "yarn@4.9.4",
   "description": "",
   "scripts": {
     "dev": "dotenv -e .env.local -- keystone dev",

--- a/packages/content-api/Dockerfile
+++ b/packages/content-api/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /build
 # Makefile must exist before install: postinstall runs `make postinstall` (db-generate, etc.).
 COPY package.json yarn.lock .yarnrc.yml Makefile /build/
 
-RUN SKIP_BUILD_DEPS=true DB_GENERATE_LOCAL=false yarn install --immutable
+RUN SKIP_BUILD_DEPS=true DB_GENERATE_LOCAL=false yarn install
 
 COPY . /build/
 
@@ -29,4 +29,3 @@ COPY --from=build /build/dist ./dist
 COPY --from=build /build/package.json ./package.json
 
 CMD ["node", "dist/server.js"]
-

--- a/packages/content-api/Makefile
+++ b/packages/content-api/Makefile
@@ -1,4 +1,5 @@
 P := "\\033[32m[+]\\033[0m"
+DB_GENERATE_LOCAL ?= true
 ENV_FILE ?= .env.local
 DOTENV_FLAGS ?=
 DOTENV := yarn dotenv -e $(ENV_FILE) $(DOTENV_FLAGS) --

--- a/packages/content-api/package.json
+++ b/packages/content-api/package.json
@@ -13,7 +13,7 @@
     "lint:check": "eslint src --ext .ts,.js",
     "type-check": "tsc --noEmit",
     "test": "vitest run",
-    "postinstall": "bash -c 'SKIP_BUILD_DEPS=\"${SKIP_BUILD_DEPS:-}\" DB_GENERATE_LOCAL=\"${DB_GENERATE_LOCAL:-\"true\"}\" make postinstall'"
+    "postinstall": "make postinstall"
   },
   "dependencies": {
     "@kids-reporter/api-types": "^0.0.1",

--- a/packages/content-api/package.json
+++ b/packages/content-api/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "0.0.1",
   "private": true,
+  "packageManager": "yarn@4.9.4",
   "scripts": {
     "dev": "make dev",
     "build": "make build",

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /build
 # copy from root at build time (in cloudbuild.yaml)
 COPY package.json yarn.lock .yarnrc.yml /build/
 
-RUN yarn install --immutable --ignore-scripts
+RUN SKIP_BUILD_DEPS=true SKIP_CODEGEN_LOCAL=true yarn install --mode=skip-build
 
 COPY . /build/
 

--- a/packages/frontend/Makefile
+++ b/packages/frontend/Makefile
@@ -1,0 +1,27 @@
+P := "\\033[32m[+]\\033[0m"
+
+help:
+	@echo "$(P) make postinstall - run after dependencies installation"
+	@echo "$(P) make build-deps - build workspace deps (logger, routing-ui)"
+
+postinstall:
+	@$(MAKE) build-deps codegen-local
+
+build-deps:
+	@if [ "$(SKIP_BUILD_DEPS)" = "true" ]; then \
+		echo "$(P) Build deps skipped"; \
+	else \
+		echo "$(P) build logger and routing-ui"; \
+		cd ../logger && yarn build; \
+		cd ../routing-ui && yarn build; \
+	fi
+
+codegen-local:
+	@if [ "$(SKIP_CODEGEN_LOCAL)" = "true" ]; then \
+		echo "$(P) Codegen skipped"; \
+	else \
+		echo "$(P) graphql codegen (local)"; \
+		yarn codegen:local; \
+	fi
+
+.PHONY: help postinstall build-deps codegen-local

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -14,7 +14,7 @@
     "type-check": "tsc --noEmit",
     "codegen:local": "graphql-codegen --config codegen.local.ts",
     "codegen:cloudbuild": "graphql-codegen --config codegen.cloudbuild.ts",
-    "postinstall": "bash -c 'SKIP_BUILD_DEPS=\"${SKIP_BUILD_DEPS:-}\" SKIP_CODEGEN_LOCAL=\"${SKIP_CODEGEN_LOCAL:-}\" make postinstall'"
+    "postinstall": "make postinstall"
   },
   "dependencies": {
     "@googleapis/customsearch": "^1.0.4",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "@kids-reporter/frontend",
   "version": "1.0.10",
   "private": true,
+  "packageManager": "yarn@4.9.4",
   "scripts": {
     "dev": "concurrently \"yarn codegen:local --watch\" \"next dev --port ${PORT:-3000}\"",
     "build": "yarn build:local",
@@ -13,7 +14,7 @@
     "type-check": "tsc --noEmit",
     "codegen:local": "graphql-codegen --config codegen.local.ts",
     "codegen:cloudbuild": "graphql-codegen --config codegen.cloudbuild.ts",
-    "postinstall": "yarn codegen:local && yarn workspace @kids-reporter/logger build && yarn workspace @kids-reporter/routing-ui build"
+    "postinstall": "bash -c 'SKIP_BUILD_DEPS=\"${SKIP_BUILD_DEPS:-}\" SKIP_CODEGEN_LOCAL=\"${SKIP_CODEGEN_LOCAL:-}\" make postinstall'"
   },
   "dependencies": {
     "@googleapis/customsearch": "^1.0.4",


### PR DESCRIPTION
## Summary

Update Dockerfiles across all packages and Cloud Build configuration to properly support Yarn v4 (Berry) in Docker builds. Remove `--immutable` flag and introduces `Makefile`-based postinstall orchestration for the frontend package.

## Changes

- Replace `yarn install --immutable` with `yarn install` in all Dockerfiles (api-gateway, cms, content-api, frontend)
- Replace `yarn cache clean` with `yarn cache clean --all` (Yarn v4 syntax) in cms Dockerfiles
- Replace `--ignore-scripts` with `--mode=skip-build` and add `SKIP_BUILD_DEPS` / `SKIP_CODEGEN_LOCAL` env vars in frontend Dockerfile
- Add `packageManager: "yarn@4.9.4"` to all application package-level `package.json` files
- Add `packages/frontend/Makefile` with `postinstall`, `build-deps`, and `codegen-local` targets
- Refactor frontend `postinstall` script to delegate to Makefile with environment-variable-based skipping
- Refactor `cloudbuild.yaml` docker build args into a bash array for readability and proper quoting
- Add `packages/*/yarn.lock` to `.gitignore` (generated by registry lockfile script for Docker builds)

## Additional Notes

- The `--immutable` flag is not used because the Docker builds copy a subset of the monorepo; Yarn v4 PnP resolves differently in isolation and requires a fresh install
- The Makefile pattern is consistent with `packages/content-api/Makefile` and `packages/api-gateway/Makefile`

## Screenshot(s)

## Reference(s)
- https://github.com/kids-reporter/kids-reporter-monorepo/issues/1175