### PR TITLE
refactor(content-api,api-types,frontend): remove redundant 'by-slug' segment from API routes

### DIFF
--- a/packages/api-types/package.json
+++ b/packages/api-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kids-reporter/api-types",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "license": "MIT",
   "files": [

--- a/packages/api-types/src/schemas/content.ts
+++ b/packages/api-types/src/schemas/content.ts
@@ -172,7 +172,7 @@ export const V1AuthorAvatarResponseSchema = z
 
 registry.registerPath({
   method: 'get',
-  path: '/v1/authors/by-slug/{slug}/avatar',
+  path: '/v1/authors/{slug}/avatar',
   tags: ['Taxonomy'],
   description:
     'Author avatar tiny image URL by slug. `tiny` is empty when the author or avatar is missing.',
@@ -498,7 +498,7 @@ export const V1PostBySlugPathParamsSchema = z.object({
   slug: z.string().min(1),
 })
 
-/** Flat query for `GET /v1/posts/by-slug/{slug}` (news-reading order + related-posts filter are fixed server-side). */
+/** Flat query for `GET /v1/posts/{slug}` (news-reading order + related-posts filter are fixed server-side). */
 export const V1PostBySlugQuerySchema = z.object({
   take: z.coerce.number().int().min(1).max(50).optional().default(5),
   postEssayQuestionsTake: z.coerce
@@ -540,7 +540,7 @@ export const V1ProjectBySlugMetaResponseSchema = z.object({
     .nullable(),
 })
 
-/** Hero image payloads returned by `/v1/projects/by-slug/{slug}` match Prisma-mapper targets. */
+/** Hero image payloads returned by `/v1/projects/{slug}` match Prisma-mapper targets. */
 export const V1ProjectDetailPhotoResizedSchema = z.object({
   resized: z.object({
     small: z.string(),
@@ -622,7 +622,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: 'get',
-  path: '/v1/projects/by-slug/{slug}',
+  path: '/v1/projects/{slug}',
   tags: ['Projects'],
   description:
     'Published project detail for topic page (matches GraphQL `GetProject`).',
@@ -647,7 +647,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: 'get',
-  path: '/v1/projects/by-slug/{slug}/meta',
+  path: '/v1/projects/{slug}/meta',
   tags: ['Projects'],
   description:
     'Published project OG metadata (matches GraphQL `GetProjectMeta`).',
@@ -672,7 +672,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: 'get',
-  path: '/v1/projects/by-slug/{slug}/related-posts-count',
+  path: '/v1/projects/{slug}/related-posts-count',
   tags: ['Projects'],
   description:
     'Count of public posts linked to a published project (matches GraphQL `relatedPostsCount` on project).',
@@ -713,7 +713,7 @@ export const V1PostsEssayAnswersWithLikesQuerySchema = z.object({
 
 registry.registerPath({
   method: 'get',
-  path: '/v1/posts/by-slug/{slug}',
+  path: '/v1/posts/{slug}',
   tags: ['Posts'],
   description:
     'Single post article payload (matches GraphQL `GetPost`). Flat query: `take`, `postEssayQuestionsTake`, `postChoiceQuestionsTake` (1–50 each, defaults 5/3/3). News-reading item order and nested related-posts filter are fixed server-side.',
@@ -749,7 +749,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: 'get',
-  path: '/v1/posts/by-slug/{slug}/meta',
+  path: '/v1/posts/{slug}/meta',
   tags: ['Posts'],
   description:
     'Post SEO / Open Graph metadata (matches GraphQL `GetPostMeta`).',
@@ -778,7 +778,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: 'get',
-  path: '/v1/posts/by-slug/{slug}/essay-questions',
+  path: '/v1/posts/{slug}/essay-questions',
   tags: ['Posts'],
   description:
     'Post card plus essay questions (matches GraphQL `GetPostEssayQuestions`).',

--- a/packages/api-types/src/schemas/extra-openapi-paths.ts
+++ b/packages/api-types/src/schemas/extra-openapi-paths.ts
@@ -167,7 +167,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: 'get',
-  path: '/v1/categories/by-slug/{slug}/posts',
+  path: '/v1/categories/{slug}/posts',
   tags: ['Taxonomy'],
   description:
     'Posts for a top-level **category** slug. Aggregates all sub-subcategories under that category. Empty list if slug is unknown (no 404).',
@@ -193,7 +193,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: 'get',
-  path: '/v1/categories/by-slug/{slug}/metadata',
+  path: '/v1/categories/{slug}/metadata',
   tags: ['Taxonomy'],
   description:
     'OG metadata for a category, optionally filtered to one subcategory by `subcategorySlug`.',
@@ -223,7 +223,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: 'get',
-  path: '/v1/categories/by-slug/{slug}/subcategories-theme',
+  path: '/v1/categories/{slug}/subcategories-theme',
   tags: ['Taxonomy'],
   description:
     'Display name, theme color, and subcategory list for a category tab UI.',
@@ -246,7 +246,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: 'get',
-  path: '/v1/subcategories/by-slug/{slug}/posts',
+  path: '/v1/subcategories/{slug}/posts',
   tags: ['Taxonomy'],
   description:
     'Feed posts for a **subcategory** slug (published/archived, sub-subcategory membership).',
@@ -274,7 +274,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: 'get',
-  path: '/v1/sub-subcategories/by-slug/{slug}/posts',
+  path: '/v1/sub-subcategories/{slug}/posts',
   tags: ['Taxonomy'],
   description: 'Public posts for a **sub-subcategory** slug, latest-first.',
   request: {
@@ -303,7 +303,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: 'get',
-  path: '/v1/tags/by-slug/{slug}/meta',
+  path: '/v1/tags/{slug}/meta',
   tags: ['Taxonomy'],
   description: 'OG metadata for a tag page.',
   request: { params: V1FeedSlugPathParamsSchema },
@@ -323,7 +323,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: 'get',
-  path: '/v1/tags/by-slug/{slug}/posts',
+  path: '/v1/tags/{slug}/posts',
   tags: ['Taxonomy'],
   description: 'Public posts for a tag (with count).',
   request: {
@@ -350,7 +350,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: 'get',
-  path: '/v1/authors/by-slug/{slug}/meta',
+  path: '/v1/authors/{slug}/meta',
   tags: ['Taxonomy'],
   description: 'Author bio, name, and small image for a profile/SEO surface.',
   request: { params: V1FeedSlugPathParamsSchema },
@@ -370,7 +370,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: 'get',
-  path: '/v1/authors/by-slug/{slug}/posts',
+  path: '/v1/authors/{slug}/posts',
   tags: ['Taxonomy'],
   description: 'Author posts and profile fields for the list view.',
   request: {
@@ -397,7 +397,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: 'get',
-  path: '/v1/authors/by-slug/{slug}/posts-count',
+  path: '/v1/authors/{slug}/posts-count',
   tags: ['Taxonomy'],
   description:
     'Public post count for an author (matches GraphQL `GetAuthorPostsCount`).',

--- a/packages/content-api/.env.example
+++ b/packages/content-api/.env.example
@@ -16,7 +16,7 @@ DATABASE_URL=postgres://user:password@localhost:5432/kids
 # Optional
 REQUEST_TIMEOUT_MS=10000
 
-# Preview-only content-api (internal Cloud Run). When true, GET /v1/posts/by-slug/*
+# Preview-only content-api (internal Cloud Run). When true, GET /v1/posts/*
 # returns draft/unpublished posts. Do not set on public content-api.
 IS_PREVIEW_SERVER=false
 

--- a/packages/content-api/src/contract.test.ts
+++ b/packages/content-api/src/contract.test.ts
@@ -63,8 +63,8 @@ describe('content-api response contracts', () => {
     expect(res.body?.error?.code).toBe('invalid_request')
   })
 
-  it('GET /v1/posts/by-slug/x rejects decimal take query param', async () => {
-    const res = await request(app).get('/v1/posts/by-slug/x?take=1.5')
+  it('GET /v1/posts/x rejects decimal take query param', async () => {
+    const res = await request(app).get('/v1/posts/x?take=1.5')
     expect(res.status).toBe(400)
     expect(res.body?.error?.code).toBe('invalid_request')
   })
@@ -116,9 +116,9 @@ describe('content-api response contracts', () => {
   })
 
   describeWithDb('metadata query normalization (requires DB)', () => {
-    it('GET /v1/categories/by-slug/x/metadata uses first subcategorySlug when repeated', async () => {
+    it('GET /v1/categories/x/metadata uses first subcategorySlug when repeated', async () => {
       const res = await request(app).get(
-        '/v1/categories/by-slug/x/metadata?subcategorySlug=a&subcategorySlug=b'
+        '/v1/categories/x/metadata?subcategorySlug=a&subcategorySlug=b'
       )
       expect([200, 404]).toContain(res.status)
       if (res.status === 200) {
@@ -213,9 +213,9 @@ describe('content-api response contracts', () => {
       expect(res.body?.error?.code).toBe('not_found')
     })
 
-    it('GET /v1/categories/by-slug/unknown-feed-slug/posts success body matches category posts schema', async () => {
+    it('GET /v1/categories/unknown-feed-slug/posts success body matches category posts schema', async () => {
       await expectRouteMatchesSchema(
-        '/v1/categories/by-slug/unknown-feed-slug/posts',
+        '/v1/categories/unknown-feed-slug/posts',
         V1CategoryBySlugCategoryPostsResponseSchema
       )
     })
@@ -234,49 +234,45 @@ describe('content-api response contracts', () => {
       )
     })
 
-    it('GET /v1/projects/by-slug/unknown-topic-slug-xyz/meta returns 404', async () => {
+    it('GET /v1/projects/unknown-topic-slug-xyz/meta returns 404', async () => {
       const res = await request(app).get(
-        '/v1/projects/by-slug/unknown-topic-slug-xyz/meta'
+        '/v1/projects/unknown-topic-slug-xyz/meta'
       )
       expect(res.status).toBe(404)
       expect(RestErrorBodySchema.safeParse(res.body).success).toBe(true)
     })
 
-    it('GET /v1/projects/by-slug/unknown-topic-slug-xyz/related-posts-count returns 404', async () => {
+    it('GET /v1/projects/unknown-topic-slug-xyz/related-posts-count returns 404', async () => {
       const res = await request(app).get(
-        '/v1/projects/by-slug/unknown-topic-slug-xyz/related-posts-count'
+        '/v1/projects/unknown-topic-slug-xyz/related-posts-count'
       )
       expect(res.status).toBe(404)
       expect(RestErrorBodySchema.safeParse(res.body).success).toBe(true)
     })
 
-    it('GET /v1/authors/by-slug/unknown-author-slug-xyz/posts-count returns 404', async () => {
+    it('GET /v1/authors/unknown-author-slug-xyz/posts-count returns 404', async () => {
       const res = await request(app).get(
-        '/v1/authors/by-slug/unknown-author-slug-xyz/posts-count'
+        '/v1/authors/unknown-author-slug-xyz/posts-count'
       )
       expect(res.status).toBe(404)
       expect(RestErrorBodySchema.safeParse(res.body).success).toBe(true)
     })
 
-    it('GET /v1/posts/by-slug/unknown-post-slug-xyz returns 404', async () => {
-      const res = await request(app).get(
-        '/v1/posts/by-slug/unknown-post-slug-xyz'
-      )
+    it('GET /v1/posts/unknown-post-slug-xyz returns 404', async () => {
+      const res = await request(app).get('/v1/posts/unknown-post-slug-xyz')
       expect(res.status).toBe(404)
       expect(RestErrorBodySchema.safeParse(res.body).success).toBe(true)
     })
 
-    it('GET /v1/posts/by-slug/unknown-post-slug-xyz/meta returns 404', async () => {
-      const res = await request(app).get(
-        '/v1/posts/by-slug/unknown-post-slug-xyz/meta'
-      )
+    it('GET /v1/posts/unknown-post-slug-xyz/meta returns 404', async () => {
+      const res = await request(app).get('/v1/posts/unknown-post-slug-xyz/meta')
       expect(res.status).toBe(404)
       expect(RestErrorBodySchema.safeParse(res.body).success).toBe(true)
     })
 
-    it('GET /v1/posts/by-slug/unknown-post-slug-xyz/essay-questions returns 404', async () => {
+    it('GET /v1/posts/unknown-post-slug-xyz/essay-questions returns 404', async () => {
       const res = await request(app).get(
-        '/v1/posts/by-slug/unknown-post-slug-xyz/essay-questions'
+        '/v1/posts/unknown-post-slug-xyz/essay-questions'
       )
       expect(res.status).toBe(404)
       expect(RestErrorBodySchema.safeParse(res.body).success).toBe(true)

--- a/packages/content-api/src/queries/authors.ts
+++ b/packages/content-api/src/queries/authors.ts
@@ -31,7 +31,7 @@ const PUBLISHED_FEED_ORDER = { publishedDate: 'desc' } as const
 const buildAuthorAvatarTinyUrl = (fileId: string | null | undefined) =>
   fileId ? `${envVar.gcs.origin}/resized/${fileId}-400.webp` : ''
 
-/** `GET /v1/authors/by-slug/:slug/meta` (404 when author missing). */
+/** `GET /v1/authors/:slug/meta` (404 when author missing). */
 export async function fetchAuthorMeta(
   slug: string
 ): Promise<V1AuthorBySlugMetaResponse | null> {
@@ -58,7 +58,7 @@ export async function fetchAuthorMeta(
   return result
 }
 
-/** `GET /v1/authors/by-slug/:slug/posts` (404 when author missing). */
+/** `GET /v1/authors/:slug/posts` (404 when author missing). */
 export async function fetchAuthorFeedPosts(
   slug: string,
   opts: { take: number; skip: number },
@@ -103,7 +103,7 @@ export async function fetchAuthorFeedPosts(
   return result
 }
 
-/** `GET /v1/authors/by-slug/:slug/posts-count` (404 when author missing). */
+/** `GET /v1/authors/:slug/posts-count` (404 when author missing). */
 export async function fetchAuthorPostsCount(
   slug: string,
   now: Date
@@ -125,7 +125,7 @@ export async function fetchAuthorPostsCount(
   return { postsCount }
 }
 
-/** `GET /v1/authors/by-slug/:slug/avatar` (always 200; empty `tiny` for unknown slugs). */
+/** `GET /v1/authors/:slug/avatar` (always 200; empty `tiny` for unknown slugs). */
 export async function fetchAuthorAvatar(
   slug: string
 ): Promise<V1AuthorAvatarResponse> {

--- a/packages/content-api/src/queries/projects.ts
+++ b/packages/content-api/src/queries/projects.ts
@@ -105,7 +105,7 @@ export async function fetchPublishedProjects(
   return result
 }
 
-/** `GET /v1/projects/by-slug/:slug/related-posts-count` returns null when the project is not found. */
+/** `GET /v1/projects/:slug/related-posts-count` returns null when the project is not found. */
 export async function fetchPublishedProjectRelatedPostsCount(
   slug: string,
   now: Date

--- a/packages/content-api/src/queries/tags.ts
+++ b/packages/content-api/src/queries/tags.ts
@@ -17,7 +17,7 @@ type V1TagBySlugPostsResponse = z.infer<typeof V1TagBySlugPostsResponseSchema>
 
 const PUBLISHED_FEED_ORDER = { publishedDate: 'desc' } as const
 
-/** `GET /v1/tags/by-slug/:slug/meta` (404 when tag missing). */
+/** `GET /v1/tags/:slug/meta` (404 when tag missing). */
 export async function fetchTagMeta(
   slug: string
 ): Promise<V1TagBySlugMetaResponse | null> {
@@ -42,7 +42,7 @@ export async function fetchTagMeta(
   return result
 }
 
-/** `GET /v1/tags/by-slug/:slug/posts` (404 when tag missing). */
+/** `GET /v1/tags/:slug/posts` (404 when tag missing). */
 export async function fetchTagFeedPosts(
   slug: string,
   opts: { take: number; skip: number },

--- a/packages/content-api/src/queries/taxonomy.ts
+++ b/packages/content-api/src/queries/taxonomy.ts
@@ -77,7 +77,7 @@ export async function fetchSubcategoriesList(): Promise<V1SubcategoriesResponse>
   return result
 }
 
-/** `GET /v1/categories/by-slug/:slug/metadata` */
+/** `GET /v1/categories/:slug/metadata` */
 export async function fetchCategoryMetadata(
   slug: string,
   subcategorySlug: string | undefined
@@ -112,7 +112,7 @@ export async function fetchCategoryMetadata(
   return result
 }
 
-/** `GET /v1/categories/by-slug/:slug/subcategories-theme` */
+/** `GET /v1/categories/:slug/subcategories-theme` */
 export async function fetchCategorySubcategoriesTheme(
   slug: string
 ): Promise<V1CategoryBySlugSubcategoriesThemeResponse | null> {
@@ -147,7 +147,7 @@ async function collectSubSubcategoryIdsForCategorySlug(
   return rows.map((r) => r.id)
 }
 
-/** `GET /v1/categories/by-slug/:slug/posts` (unknown category → empty feed; not 404). */
+/** `GET /v1/categories/:slug/posts` (unknown category → empty feed; not 404). */
 export async function fetchCategoryFeedPosts(
   slug: string,
   opts: FeedPagination
@@ -174,7 +174,7 @@ export async function fetchCategoryFeedPosts(
   return result
 }
 
-/** `GET /v1/subcategories/by-slug/:slug/posts` (404 when subcategory missing). */
+/** `GET /v1/subcategories/:slug/posts` (404 when subcategory missing). */
 export async function fetchSubcategoryFeedPosts(
   slug: string,
   opts: FeedPagination
@@ -217,7 +217,7 @@ export async function fetchSubcategoryFeedPosts(
   return result
 }
 
-/** `GET /v1/sub-subcategories/by-slug/:slug/posts` (404 when sub-subcategory missing). */
+/** `GET /v1/sub-subcategories/:slug/posts` (404 when sub-subcategory missing). */
 export async function fetchSubSubcategoryFeedPosts(
   slug: string,
   opts: FeedPagination,

--- a/packages/content-api/src/routes/v1/index.ts
+++ b/packages/content-api/src/routes/v1/index.ts
@@ -122,7 +122,7 @@ export function createV1Router() {
   )
 
   router.get(
-    '/posts/by-slug/:slug',
+    '/posts/:slug',
     asyncRoute(async (req, res) => {
       const { slug } = V1PostBySlugPathParamsSchema.parse(req.params)
       const q = V1PostBySlugQuerySchema.parse(req.query)
@@ -137,7 +137,7 @@ export function createV1Router() {
   )
 
   router.get(
-    '/posts/by-slug/:slug/meta',
+    '/posts/:slug/meta',
     asyncRoute(async (req, res) => {
       const { slug } = V1PostBySlugPathParamsSchema.parse(req.params)
       const post = await fetchPostMetaBySlug(slug, new Date())
@@ -147,7 +147,7 @@ export function createV1Router() {
   )
 
   router.get(
-    '/posts/by-slug/:slug/essay-questions',
+    '/posts/:slug/essay-questions',
     asyncRoute(async (req, res) => {
       const { slug } = V1PostBySlugPathParamsSchema.parse(req.params)
       const post = await fetchPostEssayQuestionsBySlug(slug, new Date())
@@ -175,7 +175,7 @@ export function createV1Router() {
   )
 
   router.get(
-    '/projects/by-slug/:slug',
+    '/projects/:slug',
     asyncRoute(async (req, res) => {
       const { slug } = V1PostBySlugPathParamsSchema.parse(req.params)
       const project = await fetchPublishedProjectDetailBySlug(slug, new Date())
@@ -185,7 +185,7 @@ export function createV1Router() {
   )
 
   router.get(
-    '/projects/by-slug/:slug/meta',
+    '/projects/:slug/meta',
     asyncRoute(async (req, res) => {
       const { slug } = V1PostBySlugPathParamsSchema.parse(req.params)
       const meta = await fetchPublishedProjectMetaBySlug(slug)
@@ -195,7 +195,7 @@ export function createV1Router() {
   )
 
   router.get(
-    '/projects/by-slug/:slug/related-posts-count',
+    '/projects/:slug/related-posts-count',
     asyncRoute(async (req, res) => {
       const { slug } = V1PostBySlugPathParamsSchema.parse(req.params)
       const result = await fetchPublishedProjectRelatedPostsCount(
@@ -259,7 +259,7 @@ export function createV1Router() {
   )
 
   router.get(
-    '/categories/by-slug/:slug/posts',
+    '/categories/:slug/posts',
     asyncRoute(async (req, res) => {
       const { slug } = V1FeedSlugPathParamsSchema.parse(req.params)
       const q = V1CategoryPostsQuerySchema.parse(req.query)
@@ -272,7 +272,7 @@ export function createV1Router() {
   )
 
   router.get(
-    '/categories/by-slug/:slug/metadata',
+    '/categories/:slug/metadata',
     asyncRoute(async (req, res) => {
       const { slug } = V1FeedSlugPathParamsSchema.parse(req.params)
       const { subcategorySlug } = V1CategoryBySlugMetadataQuerySchema.parse({
@@ -286,7 +286,7 @@ export function createV1Router() {
   )
 
   router.get(
-    '/categories/by-slug/:slug/subcategories-theme',
+    '/categories/:slug/subcategories-theme',
     asyncRoute(async (req, res) => {
       const { slug } = V1FeedSlugPathParamsSchema.parse(req.params)
       const result = await fetchCategorySubcategoriesTheme(slug)
@@ -296,7 +296,7 @@ export function createV1Router() {
   )
 
   router.get(
-    '/subcategories/by-slug/:slug/posts',
+    '/subcategories/:slug/posts',
     asyncRoute(async (req, res) => {
       const { slug } = V1FeedSlugPathParamsSchema.parse(req.params)
       const q = V1CategoryPostsQuerySchema.parse(req.query)
@@ -310,7 +310,7 @@ export function createV1Router() {
   )
 
   router.get(
-    '/sub-subcategories/by-slug/:slug/posts',
+    '/sub-subcategories/:slug/posts',
     asyncRoute(async (req, res) => {
       const { slug } = V1FeedSlugPathParamsSchema.parse(req.params)
       const q = V1SubSubcategoryBySlugPostsQuerySchema.parse(req.query)
@@ -325,7 +325,7 @@ export function createV1Router() {
   )
 
   router.get(
-    '/tags/by-slug/:slug/meta',
+    '/tags/:slug/meta',
     asyncRoute(async (req, res) => {
       const { slug } = V1FeedSlugPathParamsSchema.parse(req.params)
       const result = await fetchTagMeta(slug)
@@ -335,7 +335,7 @@ export function createV1Router() {
   )
 
   router.get(
-    '/tags/by-slug/:slug/posts',
+    '/tags/:slug/posts',
     asyncRoute(async (req, res) => {
       const { slug } = V1FeedSlugPathParamsSchema.parse(req.params)
       const q = V1SubSubcategoryBySlugPostsQuerySchema.parse(req.query)
@@ -350,7 +350,7 @@ export function createV1Router() {
   )
 
   router.get(
-    '/authors/by-slug/:slug/meta',
+    '/authors/:slug/meta',
     asyncRoute(async (req, res) => {
       const { slug } = V1FeedSlugPathParamsSchema.parse(req.params)
       const result = await fetchAuthorMeta(slug)
@@ -360,7 +360,7 @@ export function createV1Router() {
   )
 
   router.get(
-    '/authors/by-slug/:slug/posts',
+    '/authors/:slug/posts',
     asyncRoute(async (req, res) => {
       const { slug } = V1FeedSlugPathParamsSchema.parse(req.params)
       const q = V1SubSubcategoryBySlugPostsQuerySchema.parse(req.query)
@@ -375,7 +375,7 @@ export function createV1Router() {
   )
 
   router.get(
-    '/authors/by-slug/:slug/posts-count',
+    '/authors/:slug/posts-count',
     asyncRoute(async (req, res) => {
       const { slug } = V1FeedSlugPathParamsSchema.parse(req.params)
       const result = await fetchAuthorPostsCount(slug, new Date())
@@ -415,7 +415,7 @@ export function createV1Router() {
   )
 
   router.get(
-    '/authors/by-slug/:slug/avatar',
+    '/authors/:slug/avatar',
     asyncRoute(async (req, res) => {
       const { slug } = V1AuthorAvatarPathParamsSchema.parse(req.params)
       const result = await fetchAuthorAvatar(slug)

--- a/packages/frontend/src/api/content-api/author-avatar.ts
+++ b/packages/frontend/src/api/content-api/author-avatar.ts
@@ -15,14 +15,14 @@ export async function getAuthorAvatarBySlugContentApi({
 }) {
   const encoded = encodeURIComponent(slug)
   const response = await sendContentApiRequest({
-    path: `/v1/authors/by-slug/${encoded}/avatar`,
+    path: `/v1/authors/${encoded}/avatar`,
     method: 'GET',
     traceHeaders,
   })
   const parsed = V1AuthorAvatarResponseSchema.safeParse(response)
   if (!parsed.success) {
     throw contentApiResponseParseError(
-      'content-api response schema mismatch for /v1/authors/by-slug/:slug/avatar',
+      'content-api response schema mismatch for /v1/authors/:slug/avatar',
       parsed.error
     )
   }

--- a/packages/frontend/src/api/content-api/author-collection.ts
+++ b/packages/frontend/src/api/content-api/author-collection.ts
@@ -23,7 +23,7 @@ export async function getAuthorMetaContentApi({
 }) {
   const enc = encodeURIComponent(slug)
   const response = await sendContentApiRequest({
-    path: `/v1/authors/by-slug/${enc}/meta`,
+    path: `/v1/authors/${enc}/meta`,
     traceHeaders,
   })
   const parsed = V1AuthorBySlugMetaResponseSchema.safeParse(response)
@@ -51,7 +51,7 @@ export async function getAuthorPostsCountContentApi({
   try {
     const enc = encodeURIComponent(slug)
     const response = await sendContentApiRequest({
-      path: `/v1/authors/by-slug/${enc}/posts-count`,
+      path: `/v1/authors/${enc}/posts-count`,
       traceHeaders,
     })
     const parsed = V1AuthorPostsCountResponseSchema.safeParse(response)
@@ -87,7 +87,7 @@ export async function getAuthorPostsContentApi({
 }) {
   const enc = encodeURIComponent(slug)
   const response = await sendContentApiRequest({
-    path: `/v1/authors/by-slug/${enc}/posts`,
+    path: `/v1/authors/${enc}/posts`,
     query: { take, skip, orderBy: orderBy ?? 'publishedDate:desc' },
     traceHeaders,
   })

--- a/packages/frontend/src/api/content-api/category-collection.ts
+++ b/packages/frontend/src/api/content-api/category-collection.ts
@@ -25,7 +25,7 @@ export async function getCategoryPostsContentApi({
 }) {
   const enc = encodeURIComponent(slug)
   const response = await sendContentApiRequest({
-    path: `/v1/categories/by-slug/${enc}/posts`,
+    path: `/v1/categories/${enc}/posts`,
     query: { take, skip },
     traceHeaders,
   })
@@ -54,7 +54,7 @@ export async function getCategoryMetadataContentApi({
 }) {
   const enc = encodeURIComponent(slug)
   const response = await sendContentApiRequest({
-    path: `/v1/categories/by-slug/${enc}/metadata`,
+    path: `/v1/categories/${enc}/metadata`,
     query: subcategorySlug ? { subcategorySlug } : undefined,
     traceHeaders,
   })
@@ -85,7 +85,7 @@ export async function getCategorySubcategoriesThemeContentApi({
 }) {
   const enc = encodeURIComponent(slug)
   const response = await sendContentApiRequest({
-    path: `/v1/categories/by-slug/${enc}/subcategories-theme`,
+    path: `/v1/categories/${enc}/subcategories-theme`,
     traceHeaders,
   })
   const parsed =

--- a/packages/frontend/src/api/content-api/post.ts
+++ b/packages/frontend/src/api/content-api/post.ts
@@ -107,7 +107,7 @@ export async function getPostContentApi({
   const slug = postSlugFromWhere(variables.where)
   try {
     const response = await sendContentApiRequest({
-      path: `/v1/posts/by-slug/${encodeURIComponent(slug)}`,
+      path: `/v1/posts/${encodeURIComponent(slug)}`,
       method: 'GET',
       query: {
         take: variables.take ?? undefined,
@@ -142,7 +142,7 @@ export async function getPostMetaContentApi({
   const slug = postSlugFromMetaWhere(variables.where)
   try {
     const response = await sendContentApiRequest({
-      path: `/v1/posts/by-slug/${encodeURIComponent(slug)}/meta`,
+      path: `/v1/posts/${encodeURIComponent(slug)}/meta`,
       method: 'GET',
       traceHeaders,
     })
@@ -215,7 +215,7 @@ export async function getPostEssayQuestionsByPostSlugContentApi({
 }) {
   try {
     const response = await sendContentApiRequest({
-      path: `/v1/posts/by-slug/${encodeURIComponent(slug)}/essay-questions`,
+      path: `/v1/posts/${encodeURIComponent(slug)}/essay-questions`,
       method: 'GET',
       traceHeaders,
     })

--- a/packages/frontend/src/api/content-api/project-by-slug.ts
+++ b/packages/frontend/src/api/content-api/project-by-slug.ts
@@ -24,7 +24,7 @@ export async function getProjectMetaContentApi({
 }): Promise<GetProjectMetaQuery['project'] | undefined> {
   try {
     const response = await sendContentApiRequest({
-      path: `/v1/projects/by-slug/${encodeURIComponent(slug)}/meta`,
+      path: `/v1/projects/${encodeURIComponent(slug)}/meta`,
       method: 'GET',
       traceHeaders,
     })
@@ -59,7 +59,7 @@ export async function getProjectDetailContentApi({
 }): Promise<GetProjectQuery['project'] | undefined> {
   try {
     const response = await sendContentApiRequest({
-      path: `/v1/projects/by-slug/${encodeURIComponent(slug)}`,
+      path: `/v1/projects/${encodeURIComponent(slug)}`,
       method: 'GET',
       traceHeaders,
     })
@@ -88,7 +88,7 @@ export async function getProjectRelatedPostsCountContentApi({
 }): Promise<GetProjectRelatedPostsCountQuery['project'] | undefined> {
   try {
     const response = await sendContentApiRequest({
-      path: `/v1/projects/by-slug/${encodeURIComponent(slug)}/related-posts-count`,
+      path: `/v1/projects/${encodeURIComponent(slug)}/related-posts-count`,
       method: 'GET',
       traceHeaders,
     })

--- a/packages/frontend/src/api/content-api/sub-subcategory-posts.ts
+++ b/packages/frontend/src/api/content-api/sub-subcategory-posts.ts
@@ -23,7 +23,7 @@ export async function getSubSubcategoryPostsContentApi({
 }) {
   const enc = encodeURIComponent(slug)
   const response = await sendContentApiRequest({
-    path: `/v1/sub-subcategories/by-slug/${enc}/posts`,
+    path: `/v1/sub-subcategories/${enc}/posts`,
     query: { take, skip, orderBy: orderBy ?? 'publishedDate:desc' },
     traceHeaders,
   })

--- a/packages/frontend/src/api/content-api/subcategory-posts.ts
+++ b/packages/frontend/src/api/content-api/subcategory-posts.ts
@@ -21,7 +21,7 @@ export async function getSubcategoryPostsContentApi({
 }) {
   const enc = encodeURIComponent(slug)
   const response = await sendContentApiRequest({
-    path: `/v1/subcategories/by-slug/${enc}/posts`,
+    path: `/v1/subcategories/${enc}/posts`,
     query: { take, skip },
     traceHeaders,
   })

--- a/packages/frontend/src/api/content-api/tag-collection.ts
+++ b/packages/frontend/src/api/content-api/tag-collection.ts
@@ -20,7 +20,7 @@ export async function getTagMetaContentApi({
 }) {
   const enc = encodeURIComponent(slug)
   const response = await sendContentApiRequest({
-    path: `/v1/tags/by-slug/${enc}/meta`,
+    path: `/v1/tags/${enc}/meta`,
     traceHeaders,
   })
   const parsed = V1TagBySlugMetaResponseSchema.safeParse(response)
@@ -54,7 +54,7 @@ export async function getTagPostsContentApi({
 }) {
   const enc = encodeURIComponent(slug)
   const response = await sendContentApiRequest({
-    path: `/v1/tags/by-slug/${enc}/posts`,
+    path: `/v1/tags/${enc}/posts`,
     query: { take, skip, orderBy: orderBy ?? 'publishedDate:desc' },
     traceHeaders,
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5237,7 +5237,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/api-types@npm:^0.0.1, @kids-reporter/api-types@workspace:packages/api-types":
+"@kids-reporter/api-types@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "@kids-reporter/api-types@npm:0.0.1"
+  dependencies:
+    "@asteasolutions/zod-to-openapi": "npm:^8.1.0"
+    "@babel/runtime": "npm:^7.18.5"
+    zod: "npm:^4.1.12"
+  checksum: 10c0/932a6aeda341ba6e767788335b5cab8f6f12f7773773e9dd0d4817e29613b8856297ab1a2f390a389912290d00048720f89669910b4ca01f95dbec42ba5b4ab8
+  languageName: node
+  linkType: hard
+
+"@kids-reporter/api-types@workspace:packages/api-types":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/api-types@workspace:packages/api-types"
   dependencies:


### PR DESCRIPTION
## Summary

Standardize all content-api endpoint paths by removing the redundant `/by-slug/` segment from slug-based routes (e.g. `/v1/posts/by-slug/{slug}` → `/v1/posts/{slug}`). This simplifies the URL structure while preserving the same behavior, and bumps `@kids-reporter/api-types` to `0.0.2` to reflect the breaking path change.

## Changes

- **api-types**: Updated all registered OpenAPI paths and JSDoc comments to drop `/by-slug/` (e.g. `/v1/authors/by-slug/{slug}/avatar` → `/v1/authors/{slug}/avatar`)
- **api-types**: Bumped package version from `0.0.1` → `0.0.2`
- **content-api**: Updated Express route definitions in `routes/v1/index.ts` to match the new paths
- **content-api**: Adjusted Prisma query modules (`authors.ts`, `projects.ts`, `tags.ts`, `taxonomy.ts`) accordingly
- **content-api**: Updated contract tests and `.env.example` comments to reflect the new paths
- **frontend**: Updated all content-api client functions (`post.ts`, `project-by-slug.ts`, `author-avatar.ts`, `author-collection.ts`, `category-collection.ts`, `subcategory-posts.ts`, `sub-subcategory-posts.ts`, `tag-collection.ts`) to call the simplified endpoints
- **yarn.lock**: Updated to reflect the new `api-types` version resolution

## Additional Notes

- The slug is still used as the path parameter; only the URL structure has changed.
- Affected resources: posts, projects, authors, categories, subcategories, sub-subcategories, and tags.

## Screenshot(s)

## Reference(s)