### PR TITLE
feat(content-api): enhance OpenAPI response with server information

### DIFF
--- a/packages/content-api/src/routes/openapi.ts
+++ b/packages/content-api/src/routes/openapi.ts
@@ -10,9 +10,13 @@ export function createOpenApiRouter({ basePath = '' } = {}) {
     },
   })
 
+  const openApiDoc = {
+    ...getOpenApiDocument(),
+    servers: [{ url: basePath || '/', description: 'Content API' }],
+  }
   router.get('/openapi.json', (_req, res) => {
     res.set('Cache-Control', 'no-store')
-    res.json(getOpenApiDocument())
+    res.json(openApiDoc)
   })
 
   router.use('/docs', swaggerUi.serve, swaggerSetup)


### PR DESCRIPTION
## Summary
Expose the correct request base URL in Swagger UI by injecting a `servers` entry into the served OpenAPI document using the router `basePath`.
## Changes
- Merge `servers: [{ url: basePath || '/', description: 'Content API' }]` into `/openapi.json` response in `packages/content-api/src/routes/openapi.ts`
## Reference(s)