### PR TITLE
fix(docker): relink workspace deps after COPY in Cloud Build images

### DIFF
--- a/packages/api-gateway/.dockerignore
+++ b/packages/api-gateway/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.env*
+*.tsbuildinfo
+coverage

--- a/packages/api-gateway/Dockerfile
+++ b/packages/api-gateway/Dockerfile
@@ -6,14 +6,16 @@ RUN corepack enable
 
 WORKDIR /build
 
-# copy from root at build time (in cloudbuild.yaml)
+# Cloud Build stages this package dir (lockfile copied from repo root; see cloudbuild.yaml).
+# No Makefile in lean COPY: this package has no postinstall hook.
 COPY package.json yarn.lock .yarnrc.yml /build/
 
 RUN yarn install
 
 COPY . /build/
 
-RUN yarn build
+# Relink workspace deps after source copy, then build.
+RUN yarn install && yarn build
 
 
 FROM node:${NODE_VERSION}

--- a/packages/content-api/.dockerignore
+++ b/packages/content-api/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.env*
+*.tsbuildinfo
+coverage

--- a/packages/content-api/Dockerfile
+++ b/packages/content-api/Dockerfile
@@ -6,7 +6,7 @@ RUN corepack enable
 
 WORKDIR /build
 
-# copy from root at build time (in cloudbuild.yaml).
+# Cloud Build stages this package dir (lockfile copied from repo root; see cloudbuild.yaml).
 # Makefile must exist before install: postinstall runs `make postinstall` (db-generate, etc.).
 COPY package.json yarn.lock .yarnrc.yml Makefile /build/
 
@@ -14,7 +14,8 @@ RUN SKIP_BUILD_DEPS=true DB_GENERATE_LOCAL=false yarn install
 
 COPY . /build/
 
-RUN yarn build
+# Relink workspace deps after source copy, then build.
+RUN SKIP_BUILD_DEPS=true DB_GENERATE_LOCAL=false yarn install && yarn build
 
 FROM node:${NODE_VERSION}
 

--- a/packages/frontend/.dockerignore
+++ b/packages/frontend/.dockerignore
@@ -2,6 +2,7 @@ node_modules
 .next
 dist
 .env*
+!.env.local
 *.tsbuildinfo
 coverage
 __generated__

--- a/packages/frontend/.dockerignore
+++ b/packages/frontend/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+dist
+.env*
+*.tsbuildinfo
+coverage
+__generated__

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -9,14 +9,16 @@ RUN corepack enable
 
 WORKDIR /build
 
-# copy from root at build time (in cloudbuild.yaml)
-COPY package.json yarn.lock .yarnrc.yml /build/
+# Cloud Build stages this package dir (lockfile, schema.graphql, graphql docs; see cloudbuild.yaml).
+# Makefile must exist before install: postinstall runs `make postinstall` (codegen, etc.).
+COPY package.json yarn.lock .yarnrc.yml Makefile /build/
 
 RUN SKIP_BUILD_DEPS=true SKIP_CODEGEN_LOCAL=true yarn install --mode=skip-build
 
 COPY . /build/
 
-RUN DEPLOYMENT_ID=${DEPLOYMENT_ID} NEXT_PUBLIC_USE_CONTENT_API=${USE_CONTENT_API} yarn build:cloudbuild
+# Relink workspace deps after source copy, then build (codegen runs in build:cloudbuild).
+RUN SKIP_BUILD_DEPS=true SKIP_CODEGEN_LOCAL=true yarn install --mode=skip-build && DEPLOYMENT_ID=${DEPLOYMENT_ID} NEXT_PUBLIC_USE_CONTENT_API=${USE_CONTENT_API} yarn build:cloudbuild
 
 
 FROM node:${NODE_VERSION}


### PR DESCRIPTION
## Summary

Fixes Docker image builds for `api-gateway`, `content-api`, and `frontend` when Cloud Build uses a per-package build context. A second `yarn install` after copying source relinks workspace dependencies before `yarn build`, and new `.dockerignore` files keep local artifacts (e.g. `node_modules`, `dist`, `.next`) out of the build context.

## Changes

- Add `.dockerignore` for `packages/api-gateway`, `packages/content-api`, and `packages/frontend` (ignore `node_modules`, build outputs, env files, coverage, etc.; frontend also ignores `__generated__`)
- **api-gateway / content-api / frontend Dockerfiles**: run `yarn install` again after `COPY . /build/`, then build, so workspace packages link against copied sources instead of the install-only layer
- **frontend Dockerfile**: copy `Makefile` before install so postinstall (`make postinstall`) can run during the initial install step
- Clarify Dockerfile comments to document Cloud Build staging (lockfile from repo root, package dir as context)

## Additional Notes

- **Why**: Cloud Build stages each package directory as the Docker context. Install-only layers run before full source is present; without a post-`COPY` install, Yarn workspace links can point at incomplete or stale paths and builds fail or use wrong packages.
- **Trade-off**: two `yarn install` passes per image increase build time; install flags (`SKIP_BUILD_DEPS`, `SKIP_CODEGEN_LOCAL`, `--mode=skip-build`) are preserved on both passes where applicable.

## Screenshot(s)


## Reference(s)

