### PR TITLE
fix(frontend): tier content API failure logs by HTTP status

### DIFF
--- a/packages/frontend/src/utils/send-content-api.ts
+++ b/packages/frontend/src/utils/send-content-api.ts
@@ -1,5 +1,5 @@
 import { RestErrorBodySchema } from '@kids-reporter/api-types'
-import { emitStructured } from '@kids-reporter/logger'
+import { emitStructured, type LogSeverity } from '@kids-reporter/logger'
 import errors from '@twreporter/errors'
 import axios, { AxiosRequestConfig } from 'axios'
 import { ZodError } from 'zod'
@@ -64,6 +64,37 @@ const buildUrl = (path: string) => {
       : CONTENT_API_ORIGIN
   const normalizedPath = path.startsWith('/') ? path : `/${path}`
   return `${base}${normalizedPath}`
+}
+
+function contentApiFailureLogSeverity(status?: number): LogSeverity {
+  if (status === 404) return 'INFO'
+  if (status !== undefined && status >= 400 && status < 500) return 'WARNING'
+  return 'ERROR'
+}
+
+function contentApiFailureLogMessage({
+  method,
+  path,
+  status,
+  errorMessage,
+  annotatedErr,
+}: {
+  method: ContentApiMethod
+  path: string
+  status?: number
+  errorMessage: string
+  annotatedErr: unknown
+}): string {
+  if (status === 404) {
+    return `content-api 404 ${method} ${path}`
+  }
+  if (status !== undefined && status >= 400 && status < 500) {
+    return `content-api ${status} ${method} ${path}: ${errorMessage}`
+  }
+  return errors.helpers.printAll(annotatedErr, {
+    withStack: true,
+    withPayload: false,
+  })
 }
 
 /**
@@ -137,10 +168,13 @@ export async function sendContentApiRequest<TData = unknown>({
         ? annotatedErr.message
         : String(annotatedErr)
     emitStructured({
-      severity: 'ERROR',
-      message: errors.helpers.printAll(annotatedErr, {
-        withStack: true,
-        withPayload: false,
+      severity: contentApiFailureLogSeverity(status),
+      message: contentApiFailureLogMessage({
+        method,
+        path,
+        status,
+        errorMessage,
+        annotatedErr,
       }),
       context: {
         path,

--- a/packages/frontend/src/utils/send-content-api.ts
+++ b/packages/frontend/src/utils/send-content-api.ts
@@ -66,7 +66,11 @@ const buildUrl = (path: string) => {
   return `${base}${normalizedPath}`
 }
 
-function contentApiFailureLogSeverity(status?: number): LogSeverity {
+function contentApiFailureLogSeverity(
+  status?: number,
+  isCancel?: boolean
+): LogSeverity {
+  if (isCancel) return 'INFO'
   if (status === 404) return 'INFO'
   if (status !== undefined && status >= 400 && status < 500) return 'WARNING'
   return 'ERROR'
@@ -78,13 +82,18 @@ function contentApiFailureLogMessage({
   status,
   errorMessage,
   annotatedErr,
+  isCancel,
 }: {
   method: ContentApiMethod
   path: string
   status?: number
   errorMessage: string
   annotatedErr: unknown
+  isCancel?: boolean
 }): string {
+  if (isCancel) {
+    return `content-api request cancelled: ${method} ${path}`
+  }
   if (status === 404) {
     return `content-api 404 ${method} ${path}`
   }
@@ -167,14 +176,16 @@ export async function sendContentApiRequest<TData = unknown>({
       : annotatedErr instanceof Error
         ? annotatedErr.message
         : String(annotatedErr)
+    const isCancel = axios.isCancel(err)
     emitStructured({
-      severity: contentApiFailureLogSeverity(status),
+      severity: contentApiFailureLogSeverity(status, isCancel),
       message: contentApiFailureLogMessage({
         method,
         path,
         status,
         errorMessage,
         annotatedErr,
+        isCancel,
       }),
       context: {
         path,


### PR DESCRIPTION
## Summary

Adjust structured logging in `sendContentApiRequest` so expected HTTP failures (especially 404s) no longer always emit ERROR-level logs with full stack traces, while server-side and unexpected failures still log at ERROR with full detail.

## Changes

- Add `contentApiFailureLogSeverity()` to map HTTP status to log level: 404 → INFO, other 4xx → WARNING, everything else → ERROR
- Add `contentApiFailureLogMessage()` for concise 404/4xx messages (`content-api 404 GET /path`, etc.) and retain `errors.helpers.printAll` with stack for 5xx/unexpected errors
- Wire both helpers into the existing `emitStructured` call in the `sendContentApiRequest` catch block
- Import `LogSeverity` from `@kids-reporter/logger`

## Additional Notes

- **Behavior unchanged for callers:** fs still throw `ContentApiRequestError` with the same status, code, and details; only logging severity and message format change.
- **Rationale:** 404s and other client errors are often expected (e.g. missing content) and were inflating ERROR noise in monitoring.
- **Watch for:** auth failures (401/403) now log as WARNING instead of ERROR—intentional for 4xx, but confirm alerting rules do not depend on ERROR for those cases.

## Screenshot(s)


## Reference(s)