### PR TITLE
fix(frontend): rescroll to post hash anchor after content mounts

### DIFF
--- a/packages/frontend/src/modules/article/components/post-renderer.tsx
+++ b/packages/frontend/src/modules/article/components/post-renderer.tsx
@@ -35,23 +35,39 @@ function PostRenderer({ content, shouldMount }: PostProp) {
     }
 
     const scrollToHashTarget = () => {
-      const id = decodeURIComponent(hash.slice(1))
+      let id = ''
+      try {
+        id = decodeURIComponent(hash.slice(1))
+      } catch {
+        return false
+      }
+
       const anchor = document.getElementById(id)
       if (!anchor) return false
 
       const elementPosition = anchor.getBoundingClientRect().top
-      const offsetPosition =
-        elementPosition + window.scrollY - STICKY_HEADER_HEIGHT
+      const headerOffset = window.matchMedia('(min-width: 768px)').matches
+        ? STICKY_HEADER_HEIGHT
+        : 0
+      const offsetPosition = elementPosition + window.scrollY - headerOffset
       window.scrollTo({ top: offsetPosition, behavior: 'auto' })
       return true
     }
 
+    let rafId1: number | undefined
+    let rafId2: number | undefined
+
     if (!scrollToHashTarget()) {
-      requestAnimationFrame(() => {
+      rafId1 = requestAnimationFrame(() => {
         if (!scrollToHashTarget()) {
-          requestAnimationFrame(scrollToHashTarget)
+          rafId2 = requestAnimationFrame(scrollToHashTarget)
         }
       })
+    }
+
+    return () => {
+      if (rafId1 !== undefined) cancelAnimationFrame(rafId1)
+      if (rafId2 !== undefined) cancelAnimationFrame(rafId2)
     }
   }, [shouldMount])
 

--- a/packages/frontend/src/modules/article/components/post-renderer.tsx
+++ b/packages/frontend/src/modules/article/components/post-renderer.tsx
@@ -4,6 +4,7 @@ import 'react-loading-skeleton/dist/skeleton.css'
 import { ArticleBodyDraftRenderer } from '@kids-reporter/draft-renderer'
 import { cn } from '@kids-reporter/routing-ui'
 import { RawDraftContentState } from 'draft-js'
+import { useEffect } from 'react'
 import Skeleton from 'react-loading-skeleton'
 
 import { FontSizeLevel, STICKY_HEADER_HEIGHT } from '@/constants'
@@ -24,6 +25,36 @@ type PostProp = {
 function PostRenderer({ content, shouldMount }: PostProp) {
   const { onImageModalOpen, fontSize } = useArticleContext()
 
+  useEffect(() => {
+    if (!shouldMount) return
+
+    const hash = window.location.hash
+    if (!hash) {
+      window.scrollTo(0, 0)
+      return
+    }
+
+    const scrollToHashTarget = () => {
+      const id = decodeURIComponent(hash.slice(1))
+      const anchor = document.getElementById(id)
+      if (!anchor) return false
+
+      const elementPosition = anchor.getBoundingClientRect().top
+      const offsetPosition =
+        elementPosition + window.scrollY - STICKY_HEADER_HEIGHT
+      window.scrollTo({ top: offsetPosition, behavior: 'auto' })
+      return true
+    }
+
+    if (!scrollToHashTarget()) {
+      requestAnimationFrame(() => {
+        if (!scrollToHashTarget()) {
+          requestAnimationFrame(scrollToHashTarget)
+        }
+      })
+    }
+  }, [shouldMount])
+
   return (
     <div
       className={cn(
@@ -39,9 +70,6 @@ function PostRenderer({ content, shouldMount }: PostProp) {
         <ArticleBodyDraftRenderer
           rawContentState={trimEmptyBlocks(content)}
           onImageModalOpen={onImageModalOpen}
-          initiallyScrollTo={
-            typeof window !== 'undefined' ? window.location.hash : undefined
-          }
           offsetTop={STICKY_HEADER_HEIGHT}
         />
       )}


### PR DESCRIPTION
## Summary

Fixes incorrect or missing scroll position when opening a post with a URL hash (e.g. deep links to headings). Scroll-to-anchor now runs in `PostRenderer` after article body content has mounted, instead of relying on `ArticleBodyDraftRenderer`'s `initiallyScrollTo` on first paint.

## Changes

- Add a `useEffect` in `PostRenderer` that runs when `shouldMount` is true
- If there is no hash, scroll to the top of the page
- If there is a hash, decode the fragment, find the target element by `id`, and scroll with `STICKY_HEADER_HEIGHT` offset (matching sticky header behavior)
- Retry scroll via `requestAnimationFrame` when the anchor is not yet in the DOM (draft content still rendering)
- Remove `initiallyScrollTo` prop from `ArticleBodyDraftRenderer` — scroll is no longer delegated  draft-renderer

## Additional Notes

**Root cause:** `PostRenderer` defers mounting `ArticleBodyDraftRenderer` until `shouldMount` (`isMounted` from the article page) is true. The previous `initiallyScrollTo={window.location.hash}` ran inside draft-renderer on its first mount, which could fire before anchor elements existed or fail to re-run when returning to a hashed URL.

**Potential risks:**
- Hash scroll only retries twice via `requestAnimationFrame`; very slow renders might still miss the anchor (unlikely for typical article load)
- Uses `getElementById` + `getBoundingClientRect` instead of draft-renderer's `querySelector` + `offsetTop`; behavior should be equivalent for valid heading anchors
- `window.scrollTo(0, 0)` on mount when there is no hash may reset scroll on client navigations without a hash — verify this matches intended UX for post page visits

## Screenshot(s)



## Reference(s)