### PR TITLE
fix(docker): exclude yarn.lock from Dockerfile COPY commands to prevent overrides

### DIFF
--- a/packages/api-gateway/Dockerfile
+++ b/packages/api-gateway/Dockerfile
@@ -12,10 +12,10 @@ COPY package.json yarn.lock .yarnrc.yml /build/
 
 RUN yarn install
 
-COPY . /build/
+# Exclude lockfile to prevent lockfile got overridden by the repo root lockfile.
+COPY --exclude=yarn.lock . /build/
 
-# Relink workspace deps after source copy, then build.
-RUN yarn install && yarn build
+RUN yarn build
 
 
 FROM node:${NODE_VERSION}

--- a/packages/content-api/Dockerfile
+++ b/packages/content-api/Dockerfile
@@ -12,10 +12,10 @@ COPY package.json yarn.lock .yarnrc.yml Makefile /build/
 
 RUN SKIP_BUILD_DEPS=true DB_GENERATE_LOCAL=false yarn install
 
-COPY . /build/
+# Exclude lockfile to prevent lockfile got overridden by the repo root lockfile.
+COPY --exclude=yarn.lock . /build/
 
-# Relink workspace deps after source copy, then build.
-RUN SKIP_BUILD_DEPS=true DB_GENERATE_LOCAL=false yarn install && yarn build
+RUN yarn build
 
 FROM node:${NODE_VERSION}
 

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -15,11 +15,10 @@ COPY package.json yarn.lock .yarnrc.yml Makefile /build/
 
 RUN SKIP_BUILD_DEPS=true SKIP_CODEGEN_LOCAL=true yarn install --mode=skip-build
 
-COPY . /build/
+# Exclude lockfile to prevent lockfile got overridden by the repo root lockfile.
+COPY --exclude=yarn.lock . /build/
 
-# Relink workspace deps after source copy, then build (codegen runs in build:cloudbuild).
-RUN SKIP_BUILD_DEPS=true SKIP_CODEGEN_LOCAL=true yarn install --mode=skip-build && DEPLOYMENT_ID=${DEPLOYMENT_ID} NEXT_PUBLIC_USE_CONTENT_API=${USE_CONTENT_API} yarn build:cloudbuild
-
+RUN DEPLOYMENT_ID=${DEPLOYMENT_ID} NEXT_PUBLIC_USE_CONTENT_API=${USE_CONTENT_API} yarn build:cloudbuild
 
 FROM node:${NODE_VERSION}
 


### PR DESCRIPTION
## Summary

Fixes an issue where the `COPY . /build/` step in Dockerfiles would override the previously installed `yarn.lock` with the repo root lockfile, causing dependency resolution issues during the build stage.

## Changes

- **packages/api-gateway/Dockerfile**: Use `COPY --exclude=yarn.lock` to prevent lockfile override; remove redundant `yarn install` before `yarn build`
- **packages/content-api/Dockerfile**: Use `COPY --exclude=yarn.lock` to prevent lockfile override; remove redundant `yarn install` before `yarn build`
- **packages/frontend/Dockerfile**: Use `COPY --exclude=yarn.lock` to prevent lockfile override; remove redundant `yarn install --mode=skip-build` before `yarn build:cloudbuild`

## Additional Notes

Previously, each Dockerfile ran `yarn install` twice — oe to install deps from the copied `package.json` + `yarn.lock`, and again after `COPY . /build/` to relink workspace deps since the source copy would overwrite the lockfile. By excluding `yarn.lock` from the second COPY, the reinstall step is no longer needed, simplifying the build process and reducing image build time.

## Screenshot(s)

## Reference(s)