### PR TITLE
fix(frontend): update related posts count in article page

### DIFF
--- a/packages/frontend/src/app/(content)/article/[slug]/page.tsx
+++ b/packages/frontend/src/app/(content)/article/[slug]/page.tsx
@@ -13,7 +13,7 @@ import {
 import ArticleModule from '@/modules/article'
 import { getServerTraceHeaders } from '@/utils/trace-context'
 
-const topicRelatedPostsNum = 5
+const postRelatedPostsNum = 6
 const postEssayQuestionsTake = 3
 const postChoiceQuestionsTake = 3
 
@@ -90,7 +90,7 @@ export default async function PostPage({
       },
     },
     orderBy: [{ order: 'asc' }],
-    take: topicRelatedPostsNum,
+    take: postRelatedPostsNum,
     postEssayQuestionsTake,
     postChoiceQuestionsTake,
   })


### PR DESCRIPTION
## Summary

Adjusts the default number of related posts displayed on the article page from 5 to 6 and renames the variable for clarity.

## Changes

- Renamed `topicRelatedPostsNum` to `postRelatedPostsNum` in `packages/frontend/src/app/(content)/article/[slug]/page.tsx`
- Updated the default related posts count from `5` to `6`

## Additional Notes

## Screenshot(s)

## Reference(s)