### PR TITLE
fix(frontend): adjust news reading max width

### DIFF
--- a/packages/frontend/src/modules/article/components/news-reading.tsx
+++ b/packages/frontend/src/modules/article/components/news-reading.tsx
@@ -57,7 +57,7 @@ function NewsReading({ className, items }: NewsReadingProps) {
     <div className="w-full px-4">
       <div
         className={cn(
-          'mx-auto mt-10 flex max-w-[512px] flex-col rounded-[20px] border border-neutral-200 p-6 tablet:mt-20 tablet:max-w-[584px] tablet:p-9 hd:max-w-[656px]',
+          'mx-auto mt-10 flex max-w-[512px] flex-col rounded-[20px] border border-neutral-200 p-6 tablet:mt-20 tablet:max-w-[584px] tablet:p-9 desktop:max-w-[608px] hd:max-w-[680px]',
           className
         )}
       >


### PR DESCRIPTION
## Summary

Adjust the News Reading container max-width at larger breakpoints to improve readability and layout consistency.

## Changes

- Update `NewsReading` container responsive max-width classes (adds `desktop:max-w-[608px]`, adjusts `hd:max-w-[680px]`) in `packages/frontend/src/modules/article/components/news-reading.tsx`

## Additional Notes

- Low risk change (Tailwind class tweak only); should verify on desktop/HD breakpoints for expected wrapping and spacing.

## Screenshot(s)

## Reference(s)