### PR TITLE
fix(content-api): only apply base path for OpenAPI docs

### DIFF
--- a/packages/content-api/src/app.ts
+++ b/packages/content-api/src/app.ts
@@ -96,7 +96,6 @@ export function createApp({
   }
 
   return createContentApiApp({
-    basePath,
     corsAllowOrigin,
     jsonLimit: '1mb',
     loggerMiddleware: createLoggerMw({


### PR DESCRIPTION
## Summary

When `BASE_PATH` is set (e.g. behind a reverse proxy), passing it into `createContentApiApp` prefixed every mounted route (`/auth`, `/v1`, health) with that path. API clients and the gateway still expect those routes at the root, so prefixed mounts broke real traffic. This change keeps `BASE_PATH` only for OpenAPI/Swagger URL generation.

## Changes

- Stop passing `basePath` into `createContentApiApp()` in `packages/content-api/src/app.ts`
- Continue passing `basePath` to `createOpenApiRouter()` so Swagger UI loads `openapi.json` and the spec `servers` entry use the correct prefixed URLs

## Additional Notes

**Why:** `createContentApiApp` uses `joinBasePath` for all route mounts and the OpenAPI mount. `BASE_PATH` is meant for docs/spec URLs when the service is exposed under a path prefix, not to relocate `/v1` or `/auth`.

**Risks to verify:**
- With `BASE_PATH` set, confirm `/v1/*`, `/auth/*`, and `/` health still respond at unprefixed paths (as deployed today).
- With OpenAPI enabled, confirm `/docs` and `/openapi.json` still work and Swagger points at `${BASE_PATH}/openapi.json`.
- If any environment relied on Express mounting *all* handlers under `BASE_PATH` (not just proxy URL rewriting), that behavior intentionally changes.

## Screenshot(s)



## Reference(s)