### PR TITLE
chore(frontend): remove duplicate Meta user-agents from robots.txt

### DIFF
--- a/packages/frontend/src/app/robots-txt-content.ts
+++ b/packages/frontend/src/app/robots-txt-content.ts
@@ -84,11 +84,9 @@ Disallow: /
 User-agent: magpie-crawler
 Disallow: /
 
-User-agent: Meta-ExternalAgent
 User-agent: meta-externalagent
 Disallow: /
 
-User-agent: Meta-ExternalFetcher
 User-agent: meta-externalfetcher
 Disallow: /
 


### PR DESCRIPTION
## Summary

Removes duplicate `User-agent` lines for Meta crawlers in production `robots.txt` content. Meta documents crawler names in lowercase (e.g. `meta-externalagent`, `meta-externalfetcher`); the PascalCase variants (`Meta-ExternalAgent`, `Meta-ExternalFetcher`) were redundant alongside the canonical entries and did not add coverage.

## Changes

- **`packages/frontend/src/app/robots-txt-content.ts`**: Drop duplicate `User-agent: Meta-ExternalAgent` and `User-agent: Meta-ExternalFetcher` lines; keep `meta-externalagent` and `meta-externalfetcher` with `Disallow: /` unchanged.
- No change to disallow policy for Meta AI/indexing crawlers (`meta-externalagent`, `meta-externalfetcher`, `meta-webindexer` remain blocked).
- `FacebookBot` and other non-Meta crawler rules are unchanged.

## Additional Notes

Per [Meta Web Crawlers](https://developers.facebook.com/docs/sharing/webmasters/web-crawlers/), official UA strings use lowercase forms such as `meta-externalagent/1.1` and `meta-externalfetcher/1.1`. `robots.txt` examples use the same lowercase `User-agent` names.

**Crawler behavior worth knowing (unchanged by this PR):**

- `FacebookExternalHit` (link previews when URLs are shared on Meta apps) is not listed in our AI disallow block; blocking it would affect OG previews.
- `Meta-ExternalFetcher` and `FacebookExternalHit` may bypass `robots.txt` in some cases (user-initiated fetches or security checks), so disallow rules are a preference signal, not a hard guarantee for every fetch type.

**Risk:** Low. Behavior for Meta crawlers should be the same; we only remove redundant directive lines. If a crawler matched only the removed PascalCase token (unlikely given Meta’s documented UA strings), coverage would still apply via the lowercase entries.

## Screenshot(s)


## Reference(s)

- [Me Web Crawlers](https://developers.facebook.com/docs/sharing/webmasters/web-crawlers/)