### PR TITLE
chore(frontend): serve dev robots.txt on staging

### DIFF
--- a/packages/frontend/src/app/robots.txt/route.ts
+++ b/packages/frontend/src/app/robots.txt/route.ts
@@ -3,8 +3,7 @@ import envVars from '@/environment-variables'
 import { devRobotsTxt, prodRobotsTxt } from '../robots-txt-content'
 
 export function GET() {
-  const body =
-    envVars.isProduction || envVars.isStaging ? prodRobotsTxt : devRobotsTxt
+  const body = envVars.isProduction ? prodRobotsTxt : devRobotsTxt
 
   return new Response(body, {
     headers: {

--- a/packages/frontend/src/environment-variables.ts
+++ b/packages/frontend/src/environment-variables.ts
@@ -9,7 +9,6 @@ const internalContentApiEndpoint =
   process.env.INTERNAL_CONTENT_API_ENDPOINT || contentApiEndpoint
 
 const isProduction = process.env.NEXT_PUBLIC_RELEASE_ENV === 'prod'
-const isStaging = process.env.NEXT_PUBLIC_RELEASE_ENV === 'staging'
 
 const searchAPIKey = process.env.SEARCH_API_KEY || ''
 const searchEngineID = process.env.SEARCH_ENGINE_ID || ''
@@ -41,7 +40,6 @@ const environmentVariables = {
   internalContentApiEndpoint,
   contentApiEndpoint,
   isProduction,
-  isStaging,
   searchAPIKey,
   searchEngineID,
   mockIdToken,


### PR DESCRIPTION
## Summary

The `isStaging` environment flag is removed, and `/robots.txt` now serves production content only when `NEXT_PUBLIC_RELEASE_ENV` is `prod`; staging and other non-production environments use the dev robots file.

## Changes

- Remove `isStaging` from `packages/frontend/src/environment-variables.ts` (no remaining references in the monorepo).
- Update `packages/frontend/src/app/robots.txt/route.ts` so `prodRobotsTxt` is selected only when `envVars.isProduction` is true; staging falls through to `devRobotsTxt`.

## Additional Notes

**Behavior change:** Staging previously served `prodRobotsTxt` (production header, AI crawler disallow rules, and selective allow rules). It now serves `devRobotsTxt` (`User-agent: *` / `Disallow: /`), matching dev and other non-prod environments.

**Risks to verify:**
- Confirm staging should not mirror production crawling policy (branch intent: stop applying prod robots on staging).
- If any tooling or QA assumed staging `robots.txt` matched production, expectations need updating.
- Production behavior is unchanged (`isProduction` still gates `prodRobotsTxt`).

## Screenshot(s)


## Reference(s)