### PR TITLE
fix(routing-ui): update privacy policy url in footer

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -19,7 +19,7 @@
     "@kids-reporter/api-types": "^0.0.3",
     "@kids-reporter/draft-renderer": "^1.0.13",
     "@kids-reporter/logger": "^0.0.2",
-    "@kids-reporter/routing-ui": "0.1.24",
+    "@kids-reporter/routing-ui": "0.1.25",
     "@next/third-parties": "^14.1.1",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/packages/routing-ui/package.json
+++ b/packages/routing-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kids-reporter/routing-ui",
   "license": "MIT",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "Routing UI for Kids Reporter",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/routing-ui/src/constants/default-values.tsx
+++ b/packages/routing-ui/src/constants/default-values.tsx
@@ -5,7 +5,7 @@ export const SUBSCRIBE_URL =
   'https://twreporter.us14.list-manage.com/subscribe?u=4da5a7d3b98dbc9fdad009e7e&id=2154ac40c3'
 export const DONATE_URL = 'https://support.twreporter.org/'
 export const JOIN_US_URL = 'https://kids.twreporter.org/article/about-join-us'
-export const PRIVACY_POLICY = 'https://www.twreporter.org/a/privacy-policy'
+export const PRIVACY_POLICY = 'https://www.twreporter.org/a/privacy-footer'
 export const SEARCH_PLACEHOLDER = '搜尋更多新聞、議題'
 
 export const MENU_ITEMS: MenuItem[] = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4351,7 +4351,7 @@ __metadata:
     "@kids-reporter/api-types": "npm:^0.0.3"
     "@kids-reporter/draft-renderer": "npm:^1.0.13"
     "@kids-reporter/logger": "npm:^0.0.2"
-    "@kids-reporter/routing-ui": "npm:0.1.24"
+    "@kids-reporter/routing-ui": "npm:0.1.25"
     "@next/bundle-analyzer": "npm:^14.2.33"
     "@next/eslint-plugin-next": "npm:^14.2.33"
     "@next/third-parties": "npm:^14.1.1"
@@ -4428,7 +4428,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kids-reporter/routing-ui@npm:0.1.24, @kids-reporter/routing-ui@workspace:packages/routing-ui":
+"@kids-reporter/routing-ui@npm:0.1.25, @kids-reporter/routing-ui@workspace:packages/routing-ui":
   version: 0.0.0-use.local
   resolution: "@kids-reporter/routing-ui@workspace:packages/routing-ui"
   dependencies:


### PR DESCRIPTION
## Summary

Fixes the footer privacy policy link that pointed to an incorrect URL (`/a/privacy-policy`). Updates the default `PRIVACY_POLICY` constant in `@kids-reporter/routing-ui` to the correct TW Reporter page (`/a/privacy-footer`) and bumps the package version so the frontend picks up the fix.

## Changes

- Update `PRIVACY_POLICY` in `packages/routing-ui/src/constants/default-values.tsx` from `https://www.twreporter.org/a/privacy-policy` to `https://www.twreporter.org/a/privacy-footer`
- Bump `@kids-reporter/routing-ui` version from `0.1.24` to `0.1.25`
- Update `packages/frontend/package.json` to depend on `@kids-reporter/routing-ui@0.1.25`
- Refresh `yarn.lock` for the version bump

## Additional Notes

The footer component in `routing-ui` uses `PRIVACY_POLICY` as the default value for the privacy policy link. This change ensures users clicking the footer privacy policy link land on the correct page.

**Potential follow-up:** `packages/frontend/src/constants/index.tsx` still defines `PRIVACY_POLICY` with the old URL, but it does not appear to be referenced elsewhere in the frontend. Consider aligning or removing it in a follow-up to avoid future confusion.

## Screenshot(s)


## Reference(s)

- [Notion Page](https://www.notion.so/twreporter/defect-footer-3808dbdca932809bb6f3d7253a28e0eb?source=copy_link)