### PR TITLE
fix(content-api): return draft topics by slug on preview server

### DIFF
--- a/packages/content-api/.env.example
+++ b/packages/content-api/.env.example
@@ -17,7 +17,7 @@ DATABASE_URL=postgres://user:password@localhost:5432/kids
 REQUEST_TIMEOUT_MS=10000
 
 # Preview-only content-api (internal Cloud Run). When true, GET /v1/posts/*
-# returns draft/unpublished posts. Do not set on public content-api.
+# and GET /v1/projects/* by slug return draft/unpublished content. Do not set on public content-api.
 IS_PREVIEW_SERVER=false
 
 # Preview deployment (GCP, not local dev):

--- a/packages/content-api/src/queries/post-detail.ts
+++ b/packages/content-api/src/queries/post-detail.ts
@@ -17,6 +17,7 @@ import {
 import {
   asOrderJson,
   buildPostBySlugVisibilityWhere,
+  buildProjectBySlugVisibilityWhere,
   buildPublicPostWhere,
   buildResizedLarge,
   buildResizedMedium,
@@ -181,7 +182,7 @@ export async function fetchPublishedProjectMetaBySlug(
   slug: string
 ): Promise<V1ProjectBySlugMetaResponse | null> {
   const project = await prisma.project.findFirst({
-    where: { slug, status: 'published' },
+    where: { AND: [{ slug }, buildProjectBySlugVisibilityWhere()] },
     select: {
       publishedDate: true,
       ogDescription: true,
@@ -208,7 +209,7 @@ export async function fetchPublishedProjectDetailBySlug(
   now: Date
 ): Promise<V1ProjectBySlugDetailResponse | null> {
   const project = await prisma.project.findFirst({
-    where: { slug, status: 'published' },
+    where: { AND: [{ slug }, buildProjectBySlugVisibilityWhere()] },
     select: {
       title: true,
       titlePosition: true,

--- a/packages/content-api/src/queries/projects.ts
+++ b/packages/content-api/src/queries/projects.ts
@@ -7,6 +7,7 @@ import type { z } from 'zod'
 
 import {
   asOrderJson,
+  buildProjectBySlugVisibilityWhere,
   buildPublicPostWhere,
   buildResizedMedium,
   buildResizedSmall,
@@ -111,7 +112,7 @@ export async function fetchPublishedProjectRelatedPostsCount(
   now: Date
 ): Promise<V1ProjectRelatedPostsCountResponse | null> {
   const project = await prisma.project.findFirst({
-    where: { slug, ...PUBLISHED_PROJECT_WHERE },
+    where: { AND: [{ slug }, buildProjectBySlugVisibilityWhere()] },
     select: { id: true },
   })
   if (!project) return null

--- a/packages/content-api/src/utils/v1-helpers.test.ts
+++ b/packages/content-api/src/utils/v1-helpers.test.ts
@@ -35,3 +35,39 @@ describe('buildPostBySlugVisibilityWhere', () => {
     expect(buildPostBySlugVisibilityWhere(now)).toEqual({})
   })
 })
+
+describe('buildProjectBySlugVisibilityWhere', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllEnvs()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('matches buildPublicProjectWhere when IS_PREVIEW_SERVER is unset', async () => {
+    const { buildProjectBySlugVisibilityWhere, buildPublicProjectWhere } =
+      await import('./v1-helpers.js')
+    expect(buildProjectBySlugVisibilityWhere()).toEqual(
+      buildPublicProjectWhere()
+    )
+  })
+
+  it('matches buildPublicProjectWhere when IS_PREVIEW_SERVER is false', async () => {
+    vi.stubEnv('IS_PREVIEW_SERVER', 'false')
+    const { buildProjectBySlugVisibilityWhere, buildPublicProjectWhere } =
+      await import('./v1-helpers.js')
+    expect(buildProjectBySlugVisibilityWhere()).toEqual(
+      buildPublicProjectWhere()
+    )
+  })
+
+  it('returns no status filter when IS_PREVIEW_SERVER is true', async () => {
+    vi.stubEnv('IS_PREVIEW_SERVER', 'true')
+    const { buildProjectBySlugVisibilityWhere } = await import(
+      './v1-helpers.js'
+    )
+    expect(buildProjectBySlugVisibilityWhere()).toEqual({})
+  })
+})

--- a/packages/content-api/src/utils/v1-helpers.ts
+++ b/packages/content-api/src/utils/v1-helpers.ts
@@ -37,6 +37,16 @@ export const buildPostBySlugVisibilityWhere = (
 ): Prisma.PostWhereInput =>
   envVar.isPreviewServer ? {} : buildPublicPostWhere(now)
 
+/** Match Keystone `Project` access for FrontendHeadlessAccount (published only). */
+export const buildPublicProjectWhere = (): Prisma.ProjectWhereInput => ({
+  status: 'published',
+})
+
+/** Project visibility for by-slug reads. Preview server matches CMS preview_headless (no status filter). */
+export const buildProjectBySlugVisibilityWhere =
+  (): Prisma.ProjectWhereInput =>
+    envVar.isPreviewServer ? {} : buildPublicProjectWhere()
+
 /** Category/subcategory virtual `relatedPosts` uses published OR archived only (see `packages/cms/lists/category.ts`). */
 export const buildCategoryFeedPostWhere = (subSubcategoryIds: number[]) => ({
   OR: [{ status: 'published' }, { status: 'archived' }],


### PR DESCRIPTION
## Summary

When `IS_PREVIEW_SERVER=true`, draft topics (Prisma `Project`) were still filtered to `status: 'published'`, so CMS preview links to `/topic/{slug}` returned 404. This change mirrors the existing post preview behavior: by-slug project endpoints skip the status filter on the preview content-api, while public list and sitemap endpoints remain published-only.

## Changes

- Add `buildPublicProjectWhere()` and `buildProjectBySlugVisibilityWhere()` in `packages/content-api/src/utils/v1-helpers.ts`, matching the post preview helper pattern
- Use `buildProjectBySlugVisibilityWhere()` for by-slug project reads:
  - `fetchPublishedProjectMetaBySlug`
  - `fetchPublishedProjectDetailBySlug`
  - `fetchPublishedProjectRelatedPostsCount` (project lookup only)
- Keep `GET /v1/projects` list and `GET /v1/sitemaps/projects` published-only (unchanged)
- Keep nested related posts on topic detail filtered via `buildPublicPostWhere` (same as post preview)
- Add unit tests for `buildProjectBySlugVisibilityWhere` (`unset`, `false`, `true` for `IS_PREVIEW_SERVER`)
- Update `packages/content-api/.env.example` to document `/v1/projects/*` by-slug preview behavior

## Additional Notes

- **Risk:** `buildProjectBySlugVisibilityWhere()` follows the same module-load `envVar.isPreviewServer` pattern as posts; ensure the preview Cloud Run service sets `IS_PREVIEW_SERVER=true` and the public content-api does not.
- **Intentionally out of scope:** draft topics will not appear in `GET /v1/projects` or sitemap responses on the preview server, consistent with how draft posts are excluded from `GET /v1/posts`.
- **Verification:** `yarn workspace @kids-reporter/content-api test` passes. Manual check: with `IS_PREVIEW_SERVER=true`, `GET /v1/projects/{draft-slug}` and `/meta` should return 200; with `IS_PREVIEW_SERVER=false`, draft slugs should still 404.

## Screenshot(s)


## Reference(s)