### PR TITLE
fix(content-api): show draft related posts on topic preview

### DIFF
--- a/packages/content-api/src/queries/post-detail.ts
+++ b/packages/content-api/src/queries/post-detail.ts
@@ -225,7 +225,7 @@ export async function fetchPublishedProjectDetailBySlug(
       },
       relatedPostsOrderJson: true,
       relatedPosts: {
-        where: buildPublicPostWhere(now),
+        where: buildPostBySlugVisibilityWhere(now),
         orderBy: [{ publishedDate: 'desc' }],
         select: relatedPostCardSelect,
       },

--- a/packages/content-api/src/queries/projects.ts
+++ b/packages/content-api/src/queries/projects.ts
@@ -7,8 +7,8 @@ import type { z } from 'zod'
 
 import {
   asOrderJson,
+  buildPostBySlugVisibilityWhere,
   buildProjectBySlugVisibilityWhere,
-  buildPublicPostWhere,
   buildResizedMedium,
   buildResizedSmall,
   mapPostCard,
@@ -63,7 +63,7 @@ export async function fetchPublishedProjects(
       ? {
           ...projectListBaseSelect,
           relatedPosts: {
-            where: buildPublicPostWhere(now),
+            where: buildPostBySlugVisibilityWhere(now),
             orderBy: [{ publishedDate: 'desc' }],
             select: postCardSelect,
           },
@@ -120,7 +120,7 @@ export async function fetchPublishedProjectRelatedPostsCount(
   const relatedPostsCount = await prisma.post.count({
     where: {
       AND: [
-        buildPublicPostWhere(now),
+        buildPostBySlugVisibilityWhere(now),
         { projects: { some: { id: project.id } } },
       ],
     },


### PR DESCRIPTION
## Summary

On the preview content-api (`IS_PREVIEW_SERVER=true`), draft topics could load by slug, but their related posts were still filtered with `buildPublicPostWhere`, so draft articles linked to a topic were hidden on `/topic/{slug}`. This change reuses `buildPostBySlugVisibilityWhere` for topic-related post queries so preview mode includes all linked posts; public content-api behavior is unchanged.

## Changes

- **`packages/content-api/src/queries/post-detail.ts`**: In `fetchPublishedProjectDetailBySlug`, filter nested `relatedPosts` with `buildPostBySlugVisibilityWhere(now)` instead of `buildPublicPostWhere(now)`
- **`packages/content-api/src/queries/projects.ts`**: Use `buildPostBySlugVisibilityWhere(now)` for related posts in:
  - `fetchPublishedProjectRelatedPostsCount` (count stays consistent with detail response)
  - `fetchPublishedProjects` when `includeRelatedPosts=true`
- Remove unused `buildPublicPostWhere` import from `projects.ts`

## Additional Notes

- **Preview-only effect:** `buildPostBySlugVisibilityWhere` resolves to `buildPublicPostWhere` when `IS_PREVIEW_SERVER` is not `true`, so published/scheduled-past filtering on the public API is unchanged.
- **Out of scope:** Topic list (`GET /v1/projects`) and post detail nested related posts are unchanged.
- **Potential edge case:** Draft related posts may have null `publishedDate`; frontend already tolerates this via `getPostSummaries`.
- **Depends on:** Prior preview topic visibility work (`buildProjectBySlugVisibilityWhere`) must be deployed on the preview content-api for draft topics themselves to load.

## Screenshot(s)


## Reference(s)