### PR TITLE
fix(frontend): hide content mask when expand button is hidden

### DIFF
--- a/packages/frontend/src/modules/topic/components/topic-content-with-mask.tsx
+++ b/packages/frontend/src/modules/topic/components/topic-content-with-mask.tsx
@@ -76,7 +76,7 @@ function TopicContentWithMask({ rawContentState }: TopicContentWithMaskProps) {
         <div ref={contentRef}>
           <TopicRenderer rawContentState={rawContentState} />
         </div>
-        {!isExpanded && (
+        {showButton && !isExpanded && (
           <div
             className="pointer-events-none absolute right-0 bottom-0 left-0 z-1 h-40 bg-linear-to-b from-[rgba(255,255,255,0)] to-white"
             aria-hidden


### PR DESCRIPTION
## Summary

Fixes a visual bug on topic pages where a white gradient mask was shown at the bottom of content even when the content was short enough that no expand/collapse button was needed. The mask now only renders when the expand button is visible and the content is collapsed.

## Changes

- Update \`TopicContentWithMask\` to gate the gradient mask on \`showButton && !isExpanded\` instead of only \`!isExpanded\`
- Align mask visibility with the existing \`showButton\` condition used by the expand/collapse button (\`showButton = exceedsMaxHeight\`)

## Additional Notes

**Root cause:** The fade-out overlay was tied only to the collapsed state, so short content that did not exceed the max height still showed a bottom gradient even though no "顯示全文" button appeared.


## Screenshot(sference(s)