### PR TITLE
fix(frontend): correct hash scroll position for embedded code in posts

### DIFF
--- a/packages/frontend/src/modules/article/components/post-renderer.tsx
+++ b/packages/frontend/src/modules/article/components/post-renderer.tsx
@@ -4,7 +4,7 @@ import 'react-loading-skeleton/dist/skeleton.css'
 import { ArticleBodyDraftRenderer } from '@kids-reporter/draft-renderer'
 import { cn } from '@kids-reporter/routing-ui'
 import { RawDraftContentState } from 'draft-js'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import Skeleton from 'react-loading-skeleton'
 
 import { FontSizeLevel, STICKY_HEADER_HEIGHT } from '@/constants'
@@ -22,8 +22,13 @@ type PostProp = {
   shouldMount?: boolean
 }
 
+const HASH_SCROLL_LAYOUT_STABLE_FRAMES = 3
+const HASH_SCROLL_MAX_WAIT_MS = 2000
+const HASH_SCROLL_CORRECTION_MS = 2000
+
 function PostRenderer({ content, shouldMount }: PostProp) {
   const { onImageModalOpen, fontSize } = useArticleContext()
+  const containerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     if (!shouldMount) return
@@ -34,6 +39,13 @@ function PostRenderer({ content, shouldMount }: PostProp) {
       return
     }
 
+    let cancelled = false
+    let rafId: number | undefined
+    let correctionRafId: number | undefined
+    let correctionTimeoutId: ReturnType<typeof setTimeout> | undefined
+    let resizeObserver: ResizeObserver | undefined
+    const isTabletViewport = window.matchMedia('(min-width: 768px)').matches
+
     const scrollToHashTarget = () => {
       let id = ''
       try {
@@ -42,37 +54,111 @@ function PostRenderer({ content, shouldMount }: PostProp) {
         return false
       }
 
+      if (!id) return false
+
       const anchor = document.getElementById(id)
       if (!anchor) return false
 
       const elementPosition = anchor.getBoundingClientRect().top
-      const headerOffset = window.matchMedia('(min-width: 768px)').matches
-        ? STICKY_HEADER_HEIGHT
-        : 0
+      const headerOffset = isTabletViewport ? STICKY_HEADER_HEIGHT : 0
       const offsetPosition = elementPosition + window.scrollY - headerOffset
       window.scrollTo({ top: offsetPosition, behavior: 'auto' })
       return true
     }
 
-    let rafId1: number | undefined
-    let rafId2: number | undefined
+    const startScrollCorrection = () => {
+      const container = containerRef.current
+      if (!container || cancelled) return
 
-    if (!scrollToHashTarget()) {
-      rafId1 = requestAnimationFrame(() => {
-        if (!scrollToHashTarget()) {
-          rafId2 = requestAnimationFrame(scrollToHashTarget)
+      resizeObserver = new ResizeObserver(() => {
+        if (cancelled) return
+
+        if (correctionRafId !== undefined) {
+          cancelAnimationFrame(correctionRafId)
         }
+
+        correctionRafId = requestAnimationFrame(() => {
+          correctionRafId = undefined
+          if (!cancelled) {
+            scrollToHashTarget()
+          }
+        })
       })
+      resizeObserver.observe(container)
+      correctionTimeoutId = setTimeout(() => {
+        resizeObserver?.disconnect()
+      }, HASH_SCROLL_CORRECTION_MS)
     }
 
+    const attemptScrollStartedAt = Date.now()
+
+    const attemptScroll = () => {
+      if (cancelled) return
+
+      if (scrollToHashTarget()) {
+        startScrollCorrection()
+        return
+      }
+
+      if (Date.now() - attemptScrollStartedAt >= HASH_SCROLL_MAX_WAIT_MS) {
+        return
+      }
+
+      rafId = requestAnimationFrame(attemptScroll)
+    }
+
+    const waitForStableLayout = () => {
+      if (cancelled) return
+
+      const container = containerRef.current
+      if (!container) {
+        rafId = requestAnimationFrame(waitForStableLayout)
+        return
+      }
+
+      let lastHeight = container.getBoundingClientRect().height
+      let stableFrames = 0
+      const startedAt = Date.now()
+
+      const checkLayout = () => {
+        if (cancelled) return
+
+        const height = container.getBoundingClientRect().height
+        if (height > 0 && height === lastHeight) {
+          stableFrames += 1
+        } else {
+          stableFrames = 0
+          lastHeight = height
+        }
+
+        const isStable = stableFrames >= HASH_SCROLL_LAYOUT_STABLE_FRAMES
+        const isTimedOut = Date.now() - startedAt >= HASH_SCROLL_MAX_WAIT_MS
+
+        if (isStable || isTimedOut) {
+          attemptScroll()
+          return
+        }
+
+        rafId = requestAnimationFrame(checkLayout)
+      }
+
+      rafId = requestAnimationFrame(checkLayout)
+    }
+
+    waitForStableLayout()
+
     return () => {
-      if (rafId1 !== undefined) cancelAnimationFrame(rafId1)
-      if (rafId2 !== undefined) cancelAnimationFrame(rafId2)
+      cancelled = true
+      if (rafId !== undefined) cancelAnimationFrame(rafId)
+      if (correctionRafId !== undefined) cancelAnimationFrame(correctionRafId)
+      if (correctionTimeoutId !== undefined) clearTimeout(correctionTimeoutId)
+      resizeObserver?.disconnect()
     }
   }, [shouldMount])
 
   return (
     <div
+      ref={containerRef}
       className={cn(
         'mb-10 prose-article text-neutral-900 tablet:mb-15',
         ...ARTICLE_FONT_SIZE_CLASSNAMES,

--- a/packages/frontend/src/modules/article/components/post-renderer.tsx
+++ b/packages/frontend/src/modules/article/components/post-renderer.tsx
@@ -44,7 +44,8 @@ function PostRenderer({ content, shouldMount }: PostProp) {
     let correctionRafId: number | undefined
     let correctionTimeoutId: ReturnType<typeof setTimeout> | undefined
     let resizeObserver: ResizeObserver | undefined
-    const isTabletViewport = window.matchMedia('(min-width: 768px)').matches
+    const tabletMediaQuery = window.matchMedia('(min-width: 768px)')
+    const getIsTabletViewport = () => tabletMediaQuery.matches
 
     const scrollToHashTarget = () => {
       let id = ''
@@ -60,7 +61,7 @@ function PostRenderer({ content, shouldMount }: PostProp) {
       if (!anchor) return false
 
       const elementPosition = anchor.getBoundingClientRect().top
-      const headerOffset = isTabletViewport ? STICKY_HEADER_HEIGHT : 0
+      const headerOffset = getIsTabletViewport() ? STICKY_HEADER_HEIGHT : 0
       const offsetPosition = elementPosition + window.scrollY - headerOffset
       window.scrollTo({ top: offsetPosition, behavior: 'auto' })
       return true


### PR DESCRIPTION
## Summary

Fixes incorrect scroll position when navigating to a hash anchor (e.g. embedded code blocks) on article pages. The previous implementation scrolled immediately after mount with at most two `requestAnimationFrame` retries, which often ran before async content finished rendering—leaving the viewport at the wrong offset.

This PR waits for the article container layout to stabilize, retries scroll attempts up to a 2s timeout, and then uses a `ResizeObserver` to re-correct scroll position as late-loading content (such as embedded code) changes the page height.

## Changes

- **`post-renderer.tsx`**: Replace simple double-RAF hash scroll with a multi-phase approach:
  - Wait for container height to remain stable across 3 consecutive animation frames before attempting scroll
  Retry `scrollToHashTarget()` via RAF until the anchor is found or `HASH_SCROLL_MAX_WAIT_MS` (2000ms) elapses
  - After a successful scroll, attach a `ResizeObserver` on the article container to re-scroll when content height changes (e.g. embedded code hydration)
  - Auto-disconnect the observer after `HASH_SCROLL_CORRECTION_MS` (2000ms)
  - Add `containerRef` on the article wrapper `div` to measure layout stability
  - Cache tablet viewport check (`matchMedia`) once per effect run for sticky header offset
  - Add explicit early return when decoded hash id is empty
  - Improve effect cleanup: cancel RAFs, clear timeout, disconnect observer, and set `cancelled` flag

## Additional Notes

**Why this approach:** Embedded code blocks and other async content can shift layout after the initial paint. Measuring container height stability plus post-scroll resize correction addresses both "anchor not yet in DOM" and "anchor position shifted after scroll" failure modes.

**Potential edge cases to watch:**
- Scroll correction only observes the article container—layout shifts outside that element (e.g. ads, global header changes) won't trigger re-correction
- The 2s timeouts are fixed constants; very slow networks or large embeds may still land slightly off-target
- `behavior: 'auto'` is preserved from the original implementation (no smooth scroll)

## Screenshot(s)


## Reference(s)